### PR TITLE
Minor CI tweaks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Note: later rules override earlier rules.
 
 # Default
-* @input-output-hk/consensus-team @input-output-hk/consensus-superowners
+* @input-output-hk/ouroboros-consensus @input-output-hk/consensus-superowners

--- a/.github/workflows/haskell-build.yml
+++ b/.github/workflows/haskell-build.yml
@@ -7,6 +7,9 @@ concurrency:
 on:
   pull_request:
   merge_group:
+  push:
+    branches:
+      - main
 
 jobs:
   check-cabal-files:
@@ -31,9 +34,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Currently Hydra/Cicero build with 8.10.7
-        ghc: ["9.2.7"]
-        # This is the only OS that Hydra/Cicero cannot run.
+        # Currently Hydra/Cicero build with 9.2.7
+        ghc: ["8.10.7"]
         os: [windows-latest]
 
     env:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -43,9 +43,6 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
-      - name: Build website
-        run: yarn build
-
       - name: Select build directory
         run: |
           CABAL_BUILDDIR="dist-newstyle"
@@ -97,7 +94,11 @@ jobs:
         run: |
           mkdir ./static/haddocks
           cd ../../
+          cabal build --dry-run all
           ./scripts/docs/haddocks.sh
+
+      - name: Build website
+        run: yarn build
 
       # Popular action to deploy to GitHub Pages:
       # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus


### PR DESCRIPTION
# Description

As Cicero will run with GHC 9.2.7 and we still need to support 8.10.7, this PR makes the CI use that one.

Also some checks, in particular the Haskell build, was not being run for the pushes to master.
