### PR TITLE
Micro-benchmarking setup for backing store operations

### DIFF
--- a/ouroboros-consensus/bench/backingstore-bench/Bench/Commands.hs
+++ b/ouroboros-consensus/bench/backingstore-bench/Bench/Commands.hs
@@ -54,7 +54,6 @@ data Cmd ks vs d =
 -- | Identifiers for value handles
 type VHID = Int
 
-
 instance NFData (Cmd ks vs d) where rnf = rwhnf
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/bench/backingstore-bench/Bench/Commands.hs
+++ b/ouroboros-consensus/bench/backingstore-bench/Bench/Commands.hs
@@ -1,0 +1,221 @@
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
+{-# LANGUAGE InstanceSigs               #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+
+module Bench.Commands (
+    -- * Command types
+    Cmd (..)
+  , VHID
+    -- * Aux types
+  , BackingStoreInitialiser
+    -- * Running commands in a concrete monad
+  , run
+  ) where
+
+import           Cardano.Slotting.Slot (SlotNo, WithOrigin)
+import           Control.DeepSeq
+import           Control.Monad (void)
+import           Control.Monad.Class.MonadThrow (MonadThrow)
+import           Control.Monad.Reader (MonadReader (ask), MonadTrans (..),
+                     ReaderT (..), asks)
+import           Control.Monad.State.Strict (MonadState, StateT, evalStateT,
+                     gets, modify)
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import           Data.Maybe (fromJust)
+import           Ouroboros.Consensus.Storage.LedgerDB.BackingStore
+                     (BackingStore, BackingStorePath, BackingStoreValueHandle,
+                     InitFrom (..), RangeQuery)
+import qualified Ouroboros.Consensus.Storage.LedgerDB.BackingStore as BS
+import           System.FS.API (SomeHasFS)
+
+{-------------------------------------------------------------------------------
+  Command types
+-------------------------------------------------------------------------------}
+
+data Cmd ks vs d =
+    BSInitFromValues !(WithOrigin SlotNo) !vs
+  | BSInitFromCopy   !BackingStorePath
+  | BSClose
+  | BSCopy           !BackingStorePath
+  | BSValueHandle    !VHID
+  | BSWrite          !SlotNo !d
+  | BSVHClose        !VHID
+  | BSVHRangeRead    !VHID !(RangeQuery ks)
+  | BSVHRead         !VHID !ks
+  | BSRead           !ks
+  deriving Show
+
+-- | Identifiers for value handles
+type VHID = Int
+
+
+instance NFData (Cmd ks vs d) where rnf = rwhnf
+
+{-------------------------------------------------------------------------------
+  Aux types
+-------------------------------------------------------------------------------}
+
+type BackingStoreInitialiser m ks vs d =
+     SomeHasFS m
+  -> InitFrom vs
+  -> m (BackingStore m ks vs d)
+
+{-------------------------------------------------------------------------------
+  Running commands in a concrete monad
+-------------------------------------------------------------------------------}
+
+run ::
+     forall m ks vs d. MonadThrow m
+  => SomeHasFS m
+  -> BackingStoreInitialiser m ks vs d
+  -> [Cmd ks vs d] -> m ()
+run shfs bsi cmds = evalStateT (runReaderT (runM m) initialEnv) initialState
+  where
+    m :: M ks vs d m ()
+    m = runCmds cmds
+
+    initialEnv = Env {
+          envSomeHasFS               = shfs
+        , envBackingStoreInitialiser = bsi
+        }
+
+    initialState = St {
+        stLookUp       = mempty
+      , stBackingStore = Nothing
+      }
+
+-- | Concrete monad 'M' to run commands in.
+--
+-- 'M' is a newtype because 'runCmds' and 'runCmd' require a single transformer
+-- in its type: @t m ()@. Compare this with @'ReaderT' r ('StateT' s m) a@,
+-- which has two transfomers on top of @m@, while @M@ itself is just a single
+-- transformer.
+newtype M ks vs d m a = M {
+    runM :: ReaderT (Env m ks vs d) (StateT (St m ks vs d) m) a
+  }
+  deriving newtype (Functor, Applicative, Monad)
+  deriving newtype (MonadReader (Env m ks vs d), MonadState (St m ks vs d))
+
+instance MonadTrans (M ks vs d) where
+  lift :: Monad m => m a -> M ks vs d m a
+  lift = M . lift . lift
+
+{-------------------------------------------------------------------------------
+  Running commands
+-------------------------------------------------------------------------------}
+
+-- | State to keep track of while running commands.
+data St m ks vs d = St {
+    -- | Backing stores have no built-in notion of value handle management, so
+    -- we have to keep track of them somewhere. Running a command that
+    -- references a value handle by their 'VHID' should use this mapping to look
+    -- up the corresponding value handle.
+    stLookUp       :: !(Map VHID (BackingStoreValueHandle m ks vs))
+    -- | The backing store that is currently in use.
+    --
+    -- This is a 'Maybe', because when starting to run a list of commands, there
+    -- is initially no backing store. After an initialisation command like
+    -- 'BSInitFromValues' and 'BSInitFromCopy', this field should never be
+    -- 'Nothing'.
+  , stBackingStore :: !(Maybe (BackingStore m ks vs d))
+  }
+
+-- | Reader environment to pass around while running commands.
+data Env m ks vs d = Env {
+    -- | Access to the file system (simulated or real) is required for
+    -- initialising backing store, and making copies of a backing store.
+    envSomeHasFS               :: !(SomeHasFS m)
+    -- | A way to initialise a new backing store. A new backing store can be
+    -- initialised even when one already exists.
+  , envBackingStoreInitialiser :: !(BackingStoreInitialiser m ks vs d)
+  }
+
+runCmds ::
+     forall m t ks vs d. (
+       MonadReader (Env m ks vs d) (t m)
+     , MonadState (St m ks vs d) (t m)
+     , MonadTrans t
+     , MonadThrow m
+     )
+  => [Cmd ks vs d]
+  -> t m ()
+runCmds = mapM_ runCmd
+
+runCmd ::
+     ( MonadReader (Env m ks vs d) (t m)
+     , MonadState (St m ks vs d) (t m)
+     , MonadTrans t
+     , MonadThrow m
+     )
+  => Cmd ks vs d
+  -> t m ()
+runCmd = \case
+    BSInitFromValues sl vs -> bsInitFromValues sl vs
+    BSInitFromCopy bsp     -> bsInitFromCopy bsp
+    BSClose                -> bsClose
+    BSCopy bsp             -> bsCopy bsp
+    BSValueHandle i        -> bsValueHandle i
+    BSWrite sl d           -> bsWrite sl d
+    BSVHClose i            -> bsvhClose i
+    BSVHRangeRead i rq     -> bsvhRangeRead i rq
+    BSVHRead i ks          -> bsvhRead i ks
+    BSRead ks              -> bsRead ks
+  where
+    bsInitFromValues sl vs = do
+        Env shfs bsi <- ask
+        bs' <- lift $ bsi shfs (InitFromValues sl vs)
+        modify (\st -> st {
+            stBackingStore = Just bs'
+          })
+
+    bsInitFromCopy bsp = do
+        Env shfs bsi <- ask
+        bs' <- lift $ bsi shfs (InitFromCopy bsp)
+        modify (\st -> st {
+            stBackingStore = Just bs'
+          })
+
+    bsClose = do
+      bs <- fromJust <$> gets stBackingStore
+      lift $ BS.bsClose bs
+
+    bsCopy bsp = do
+        shfs <- asks envSomeHasFS
+        bs <- fromJust <$> gets stBackingStore
+        lift $ BS.bsCopy bs shfs bsp
+
+    bsValueHandle i = do
+        bs <- fromJust <$> gets stBackingStore
+        (_sl, vh) <- lift $ BS.bsValueHandle bs
+        let f vhMay = case vhMay of
+                        Nothing -> Just vh
+                        Just _  -> error "bsValueHandle"
+        modify (\st -> st {
+            stLookUp = Map.alter f i $ stLookUp st
+          })
+
+    bsWrite sl d = do
+        bs <- fromJust <$> gets stBackingStore
+        lift $ BS.bsWrite bs sl d
+
+    bsvhClose i = do
+        vh <- gets (fromJust . Map.lookup i . stLookUp)
+        lift $ BS.bsvhClose vh
+
+    bsvhRangeRead i rq =  do
+        vh <- gets (fromJust . Map.lookup i . stLookUp)
+        void $ lift $ BS.bsvhRangeRead vh rq
+
+    bsvhRead i ks = do
+        vh <- gets (fromJust . Map.lookup i . stLookUp)
+        void $ lift $ BS.bsvhRead vh ks
+
+    bsRead ks = do
+        bs <- fromJust <$> gets stBackingStore
+        void $ lift $ BS.bsRead bs ks

--- a/ouroboros-consensus/bench/backingstore-bench/Main.hs
+++ b/ouroboros-consensus/bench/backingstore-bench/Main.hs
@@ -1,0 +1,163 @@
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE PatternSynonyms    #-}
+{-# LANGUAGE TupleSections      #-}
+
+module Main (main) where
+
+import           Bench.Commands (BackingStoreInitialiser, Cmd (..), run)
+import           Cardano.Slotting.Slot (WithOrigin (..))
+import           Control.DeepSeq (NFData (..), rwhnf)
+import           Data.Map.Diff.Strict (Diff)
+import qualified Data.Map.Diff.Strict as Diff
+import           Data.Set (Set)
+import qualified Data.Set as Set
+import           Data.Word (Word64)
+import           Ouroboros.Consensus.Ledger.Tables (DiffMK (..), KeysMK (..),
+                     ValuesMK)
+import           Ouroboros.Consensus.Ledger.Tables.Utils (emptyLedgerTables)
+import           Ouroboros.Consensus.Storage.LedgerDB.BackingStore
+                     (BackingStorePath (..))
+import           Ouroboros.Consensus.Storage.LedgerDB.BackingStore.LMDB
+                     (LMDBLimits (..))
+import           Ouroboros.Consensus.Storage.LedgerDB.Init
+                     (BackingStoreSelector (..), newBackingStoreInitialiser)
+import qualified System.Directory as Dir
+import           System.FS.API (HasFS (..), SomeHasFS (..))
+import           System.FS.API.Types (MountPoint (..), mkFsPath)
+import           System.FS.IO (ioHasFS)
+import           System.IO.Temp (createTempDirectory,
+                     getCanonicalTemporaryDirectory)
+import           Test.Tasty.Bench (Benchmark, bench, bgroup, defaultMain,
+                     envWithCleanup, nfAppIO)
+import           Test.Util.LedgerStateOnlyTables (OTLedgerTables,
+                     pattern OTLedgerTables)
+
+{-------------------------------------------------------------------------------
+  Main benchmarks
+-------------------------------------------------------------------------------}
+
+main :: IO ()
+main = defaultMain [ benchmarks ]
+
+benchmarks :: Benchmark
+benchmarks = bgroup "BackingStore" [
+      benchCmds "simpleCopy InMemory" bssInMem simpleCopy
+    , benchCmds "simpleCopy LMDB"     bssLMDB  simpleCopy
+    , benchCmds "oneWritePer100Reads InMem 10_000" bssInMem $
+        oneWritePer100Reads 10_000
+    , benchCmds "oneWritePer100Reads LMDB  10_000"  bssLMDB $
+        oneWritePer100Reads 10_000
+    ]
+
+benchCmds :: String -> BackingStoreSelector IO -> [Cmd K V D] -> Benchmark
+benchCmds name bss cmds0 =
+    envWithCleanup ((,cmds0) <$> setup bss) (eCleanup . fst) $
+      \ ~(e, cmds) -> bench name $ nfAppIO (runner e) cmds
+  where
+    runner e cmds = do
+      (shfs, cleanup) <- eMakeNewSomeHasFS e
+      run shfs (eBackingStoreInitialiser e) cmds
+      cleanup
+
+bssInMem :: BackingStoreSelector m
+bssInMem = InMemoryBackingStore
+
+bssLMDB :: BackingStoreSelector IO
+bssLMDB = LMDBBackingStore benchLMDBLimits
+
+benchLMDBLimits :: LMDBLimits
+benchLMDBLimits = LMDBLimits
+  { lmdbMapSize      = 100 * 1_024 * 1_024
+  , lmdbMaxDatabases = 3
+  , lmdbMaxReaders   = 32
+  }
+
+{-------------------------------------------------------------------------------
+  Benchmark scenarios
+-------------------------------------------------------------------------------}
+
+type K = OTLedgerTables Word64 Word64 KeysMK
+type V = OTLedgerTables Word64 Word64 ValuesMK
+type D = OTLedgerTables Word64 Word64 DiffMK
+
+oneWritePer100Reads :: Int -> [Cmd K V D]
+oneWritePer100Reads n = concat [
+      [ini]
+    , workload
+    , [close]
+    ]
+  where
+    ini      = BSInitFromValues Origin emptyLedgerTables
+    close    = BSClose
+
+    workload = flip concatMap dat $ \block -> mkWrite block : mkReads block
+
+    mkWrite block = BSWrite (fst $ last block) $
+        mkDiffs $ Diff.fromListInserts [(x,x) | (_sl, x) <- block]
+
+    mkReads block = [BSRead (mkKey x) | (_sl, x) <- block]
+
+    dat = groupsOfN 100 $ zip [0..] [0 .. fromIntegral n - 1]
+
+simpleCopy :: [Cmd K V D]
+simpleCopy = [
+    BSInitFromValues Origin emptyLedgerTables
+  , BSCopy (BackingStorePath $ mkFsPath ["copies", "somecopy"])
+  , BSClose
+  ]
+
+{-------------------------------------------------------------------------------
+  Benchmark scenarios: helpers
+-------------------------------------------------------------------------------}
+
+mkKey :: k -> OTLedgerTables k v KeysMK
+mkKey = mkKeys . Set.singleton
+
+mkKeys :: Set k -> OTLedgerTables k v KeysMK
+mkKeys = OTLedgerTables . KeysMK
+
+mkDiffs :: Diff k v -> OTLedgerTables k v DiffMK
+mkDiffs = OTLedgerTables . DiffMK
+
+groupsOfN :: Int -> [a] -> [[a]]
+groupsOfN n
+    | n <= 0    = error "groupsOfN: n should be positive"
+    | otherwise = go
+  where
+    go :: [a] -> [[a]]
+    go [] = []
+    go xs = take n xs : groupsOfN n (drop n xs)
+
+{-------------------------------------------------------------------------------
+  Set up benchmark environment
+-------------------------------------------------------------------------------}
+
+data Env m ks vs d = Env {
+    eBackingStoreInitialiser :: !(BackingStoreInitialiser m ks vs d)
+  , eMakeNewSomeHasFS        :: !(m (SomeHasFS m, m ()))
+  , eCleanup                 :: !(m ())
+  }
+
+instance NFData (Env m ks vs d) where rnf = rwhnf
+
+setup :: BackingStoreSelector IO -> IO (Env IO K V D)
+setup bss = do
+  sysTmpDir <- getCanonicalTemporaryDirectory
+  benchTmpDir <- createTempDirectory sysTmpDir "bench_backingstore"
+  let bsi = newBackingStoreInitialiser mempty bss
+
+  let f = do
+        tmpDir <- createTempDirectory benchTmpDir "run"
+        let hfs = ioHasFS (MountPoint tmpDir)
+
+        createDirectory hfs (mkFsPath ["copies"])
+
+        let cleanup = removeDirectoryRecursive hfs (mkFsPath [])
+
+        pure (SomeHasFS hfs, cleanup)
+
+  pure $ Env {
+      eBackingStoreInitialiser = bsi
+    , eMakeNewSomeHasFS        = f
+    , eCleanup                 = Dir.removeDirectoryRecursive benchTmpDir
+    }

--- a/ouroboros-consensus/bench/backingstore-bench/Main.hs
+++ b/ouroboros-consensus/bench/backingstore-bench/Main.hs
@@ -2,11 +2,15 @@
 {-# LANGUAGE PatternSynonyms    #-}
 {-# LANGUAGE TupleSections      #-}
 
-module Main (main) where
+module Main (
+    main
+  , oneWritePer100Reads
+  ) where
 
 import           Bench.Commands (BackingStoreInitialiser, Cmd (..), run)
-import           Cardano.Slotting.Slot (WithOrigin (..))
+import           Cardano.Slotting.Slot (SlotNo, WithOrigin (..))
 import           Control.DeepSeq (NFData (..), rwhnf)
+import           Control.Monad.Class.MonadThrow (MonadThrow)
 import           Data.Map.Diff.Strict (Diff)
 import qualified Data.Map.Diff.Strict as Diff
 import           Data.Set (Set)
@@ -27,8 +31,12 @@ import           System.FS.API.Types (MountPoint (..), mkFsPath)
 import           System.FS.IO (ioHasFS)
 import           System.IO.Temp (createTempDirectory,
                      getCanonicalTemporaryDirectory)
+import qualified Test.QuickCheck.Monadic as QC.Monadic (run)
+import           Test.QuickCheck.Monadic (monadicIO)
+import           Test.Tasty (TestTree, testGroup, withResource)
 import           Test.Tasty.Bench (Benchmark, bench, bgroup, defaultMain,
                      envWithCleanup, nfAppIO)
+import           Test.Tasty.QuickCheck (testProperty)
 import           Test.Util.LedgerStateOnlyTables (OTLedgerTables,
                      pattern OTLedgerTables)
 
@@ -37,15 +45,16 @@ import           Test.Util.LedgerStateOnlyTables (OTLedgerTables,
 -------------------------------------------------------------------------------}
 
 main :: IO ()
-main = defaultMain [ benchmarks ]
+main = defaultMain [bgroup "Bench" [
+      tests
+    , benchmarks
+    ]]
 
 benchmarks :: Benchmark
 benchmarks = bgroup "BackingStore" [
-      benchCmds "simpleCopy InMemory" bssInMem simpleCopy
-    , benchCmds "simpleCopy LMDB"     bssLMDB  simpleCopy
-    , benchCmds "oneWritePer100Reads InMem 10_000" bssInMem $
+      benchCmds "oneWritePer100Reads InMem 10_000" bssInMem $
         oneWritePer100Reads 10_000
-    , benchCmds "oneWritePer100Reads LMDB  10_000"  bssLMDB $
+    , benchCmds "oneWritePer100Reads LMDB  10_000" bssLMDB $
         oneWritePer100Reads 10_000
     ]
 
@@ -53,11 +62,33 @@ benchCmds :: String -> BackingStoreSelector IO -> [Cmd K V D] -> Benchmark
 benchCmds name bss cmds0 =
     envWithCleanup ((,cmds0) <$> setup bss) (eCleanup . fst) $
       \ ~(e, cmds) -> bench name $ nfAppIO (runner e) cmds
-  where
-    runner e cmds = do
-      (shfs, cleanup) <- eMakeNewSomeHasFS e
-      run shfs (eBackingStoreInitialiser e) cmds
-      cleanup
+
+runner :: MonadThrow m => Env m ks vs d -> [Cmd ks vs d] -> m ()
+runner e cmds = do
+  shfs <- eMakeNewSomeHasFS e
+  run shfs (eBackingStoreInitialiser e) cmds
+
+{-------------------------------------------------------------------------------
+  Auxiliary tests
+-------------------------------------------------------------------------------}
+
+tests :: TestTree
+tests = testGroup "Auxiliary tests" [
+      withResource (setup bssInMem) eCleanup $ \eIO -> bgroup "InMem" [
+          testProperty "simpleCopy InMem" $ monadicIO $ do
+          e <- QC.Monadic.run eIO
+          QC.Monadic.run $ runner e simpleCopy
+        ]
+    , withResource (setup bssLMDB) eCleanup $ \eIO -> bgroup "LMDB" [
+          testProperty "simpleCopy LMDB" $ monadicIO $ do
+          e <- QC.Monadic.run eIO
+          QC.Monadic.run $ runner e simpleCopy
+        ]
+    ]
+
+{-------------------------------------------------------------------------------
+  Backing store selectors
+-------------------------------------------------------------------------------}
 
 bssInMem :: BackingStoreSelector m
 bssInMem = InMemoryBackingStore
@@ -76,10 +107,33 @@ benchLMDBLimits = LMDBLimits
   Benchmark scenarios
 -------------------------------------------------------------------------------}
 
+-- Concrete types of keys, values and diffs that we use in the benchmarks.
 type K = OTLedgerTables Word64 Word64 KeysMK
 type V = OTLedgerTables Word64 Word64 ValuesMK
 type D = OTLedgerTables Word64 Word64 DiffMK
 
+-- | Perform one write per 100 reads.
+--
+-- This mimicks the flushing behaviour of the LedgerDB: each applied block
+-- incurs a read, and we aggregate diffs for 100 blocks before we flush/write
+-- them.
+--
+-- @
+--     oneWritePer100Reads 10_000
+--  ==
+--     [ BSInitFromValues Origin []
+--     , BSWrite 99 [Insert 0 at key 0, ..., Insert 99 at key 99]
+--     , BSRead 0
+--     ...
+--     , BSRead 99
+--     , BSWrite 199 [Insert 100 at key 100, ..., Insert 199 at key 199]
+--     , BSRead 100
+--     ...
+--     , BSRead 199
+--     ...
+--     , BSClose
+--     ]
+-- @
 oneWritePer100Reads :: Int -> [Cmd K V D]
 oneWritePer100Reads n = concat [
       [ini]
@@ -92,11 +146,22 @@ oneWritePer100Reads n = concat [
 
     workload = flip concatMap dat $ \block -> mkWrite block : mkReads block
 
+    -- A write aggregates, for a block, the additions to the ledger state. The
+    -- slot number that is used for the write corresponds to the youngest block
+    -- (i.e., highest slot number), which is by construction the last entry in
+    -- the block.
+    mkWrite :: [(SlotNo, Word64)] -> Cmd K V D
     mkWrite block = BSWrite (fst $ last block) $
         mkDiffs $ Diff.fromListInserts [(x,x) | (_sl, x) <- block]
 
+    -- Each value is read once.
+    mkReads :: [(SlotNo, Word64)] -> [Cmd K V D]
     mkReads block = [BSRead (mkKey x) | (_sl, x) <- block]
 
+    -- A list of blocks. Each block maps slot numbers to a value. This mapping
+    -- indicates that this values is added to the ledger tables at the given
+    -- slot number.
+    dat :: [[(SlotNo, Word64)]]
     dat = groupsOfN 100 $ zip [0..] [0 .. fromIntegral n - 1]
 
 simpleCopy :: [Cmd K V D]
@@ -132,32 +197,47 @@ groupsOfN n
   Set up benchmark environment
 -------------------------------------------------------------------------------}
 
+-- | The environment to set up when running benchmarks.
+--
+-- Benchmarked code is run multiple times within the same environment. However,
+-- we don't want (on-disk) state to carry over from one run to the other. For
+-- this reason, each benchmark run should intialise a new backing store, and
+-- each benchmark run should have a clean directory to do filesystem operations
+-- in. 'eBackingStoreInitialiser' provides the former, while 'eMakeNewSomeHasFS'
+-- provides the latter.
 data Env m ks vs d = Env {
+    -- | A method for initialising a backing store.
     eBackingStoreInitialiser :: !(BackingStoreInitialiser m ks vs d)
-  , eMakeNewSomeHasFS        :: !(m (SomeHasFS m, m ()))
+    -- | Creates a fresh directory, and provides an API to interact with it.
+  , eMakeNewSomeHasFS        :: !(m (SomeHasFS m))
+    -- | How to clean up the 'Env'.
   , eCleanup                 :: !(m ())
   }
 
 instance NFData (Env m ks vs d) where rnf = rwhnf
 
+-- | Sets up a root temporary directory, and creates an 'Env' for it.
+--
+-- 'eMakeNewSomeHasFS' creates a new temporary directory under the temporary
+-- root, such that each benchmark run has a fresh directory to work in.
+-- 'eCleanup' will recursively remove the root temporary directory, erasing all
+-- directories created by invocations of 'eMakeNewSomeHasFS'.
 setup :: BackingStoreSelector IO -> IO (Env IO K V D)
 setup bss = do
   sysTmpDir <- getCanonicalTemporaryDirectory
   benchTmpDir <- createTempDirectory sysTmpDir "bench_backingstore"
   let bsi = newBackingStoreInitialiser mempty bss
 
-  let f = do
+  let mkSomeHasFS = do
         tmpDir <- createTempDirectory benchTmpDir "run"
         let hfs = ioHasFS (MountPoint tmpDir)
 
         createDirectory hfs (mkFsPath ["copies"])
 
-        let cleanup = removeDirectoryRecursive hfs (mkFsPath [])
-
-        pure (SomeHasFS hfs, cleanup)
+        pure $ SomeHasFS hfs
 
   pure $ Env {
       eBackingStoreInitialiser = bsi
-    , eMakeNewSomeHasFS        = f
+    , eMakeNewSomeHasFS        = mkSomeHasFS
     , eCleanup                 = Dir.removeDirectoryRecursive benchTmpDir
     }

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -748,3 +748,37 @@ benchmark mempool-bench
   -- https://github.com/Bodigrim/tasty-bench#comparison-against-baseline
   if impl(ghc >=8.6)
     ghc-options: -fproc-alignment=64
+
+benchmark backingstore-bench
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   bench/backingstore-bench
+  main-is:          Main.hs
+  other-modules:    Bench.Commands
+  build-depends:
+    , base
+    , cardano-slotting
+    , consensus-testlib
+    , containers
+    , deepseq
+    , diff-containers
+    , directory
+    , fs-api
+    , io-classes
+    , mtl
+    , ouroboros-consensus
+    , tasty-bench
+    , temporary
+
+  default-language: Haskell2010
+  ghc-options:
+    -Wall -Wcompat -Wincomplete-uni-patterns
+    -Wincomplete-record-updates -Wpartial-fields -Widentities
+    -Wredundant-constraints -Wmissing-export-lists -Wunused-packages
+    -Wno-unticked-promoted-constructors -rtsopts -with-rtsopts=-A32m
+    -threaded
+
+  -- We use this option to avoid skewed results due to changes in cache-line
+  -- alignment. See
+  -- https://github.com/Bodigrim/tasty-bench#comparison-against-baseline
+  if impl(ghc >=8.6)
+    ghc-options: -fproc-alignment=64

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -766,7 +766,10 @@ benchmark backingstore-bench
     , io-classes
     , mtl
     , ouroboros-consensus
+    , tasty
+    , QuickCheck
     , tasty-bench
+    , tasty-quickcheck
     , temporary
 
   default-language: Haskell2010

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -45,6 +45,20 @@ common common-test
   import:      common-lib
   ghc-options: -threaded -rtsopts
 
+common common-bench
+  default-language: Haskell2010
+  ghc-options:
+    -Wall -Wcompat -Wincomplete-uni-patterns
+    -Wincomplete-record-updates -Wpartial-fields -Widentities
+    -Wredundant-constraints -Wmissing-export-lists -Wunused-packages
+    -Wno-unticked-promoted-constructors -rtsopts -with-rtsopts=-A32m
+
+  -- We use this option to avoid skewed results due to changes in cache-line
+  -- alignment. See
+  -- https://github.com/Bodigrim/tasty-bench#comparison-against-baseline
+  if impl(ghc >=8.6)
+    ghc-options: -fproc-alignment=64
+
 library
   import:           common-lib
   hs-source-dirs:   src/ouroboros-consensus
@@ -699,9 +713,10 @@ test-suite storage-test
     , vector
 
 benchmark mempool-bench
-  type:             exitcode-stdio-1.0
-  hs-source-dirs:   bench/mempool-bench
-  main-is:          Main.hs
+  import:         common-bench
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: bench/mempool-bench
+  main-is:        Main.hs
   other-modules:
     Bench.Consensus.Mempool
     Bench.Consensus.Mempool.Params
@@ -736,24 +751,12 @@ benchmark mempool-bench
     , transformers
     , tree-diff
 
-  default-language: Haskell2010
-  ghc-options:
-    -Wall -Wcompat -Wincomplete-uni-patterns
-    -Wincomplete-record-updates -Wpartial-fields -Widentities
-    -Wredundant-constraints -Wmissing-export-lists -Wunused-packages
-    -Wno-unticked-promoted-constructors -rtsopts -with-rtsopts=-A32m
-
-  -- We use this option to avoid skewed results due to changes in cache-line
-  -- alignment. See
-  -- https://github.com/Bodigrim/tasty-bench#comparison-against-baseline
-  if impl(ghc >=8.6)
-    ghc-options: -fproc-alignment=64
-
 benchmark backingstore-bench
-  type:             exitcode-stdio-1.0
-  hs-source-dirs:   bench/backingstore-bench
-  main-is:          Main.hs
-  other-modules:    Bench.Commands
+  import:         common-bench
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: bench/backingstore-bench
+  main-is:        Main.hs
+  other-modules:  Bench.Commands
   build-depends:
     , base
     , cardano-slotting
@@ -766,22 +769,10 @@ benchmark backingstore-bench
     , io-classes
     , mtl
     , ouroboros-consensus
-    , tasty
     , QuickCheck
+    , tasty
     , tasty-bench
     , tasty-quickcheck
     , temporary
 
-  default-language: Haskell2010
-  ghc-options:
-    -Wall -Wcompat -Wincomplete-uni-patterns
-    -Wincomplete-record-updates -Wpartial-fields -Widentities
-    -Wredundant-constraints -Wmissing-export-lists -Wunused-packages
-    -Wno-unticked-promoted-constructors -rtsopts -with-rtsopts=-A32m
-    -threaded
-
-  -- We use this option to avoid skewed results due to changes in cache-line
-  -- alignment. See
-  -- https://github.com/Bodigrim/tasty-bench#comparison-against-baseline
-  if impl(ghc >=8.6)
-    ghc-options: -fproc-alignment=64
+  ghc-options:    -threaded

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/BackingStore.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/BackingStore.hs
@@ -30,12 +30,11 @@ module Ouroboros.Consensus.Storage.LedgerDB.BackingStore (
   ) where
 
 import           Cardano.Slotting.Slot (SlotNo, WithOrigin (..))
+import           Control.Monad.Class.MonadThrow (MonadThrow (..))
 import           GHC.Generics (Generic)
 import           NoThunks.Class (NoThunks, OnlyCheckWhnfNamed (..))
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.Tables
-import           Ouroboros.Consensus.Util.IOLike (IOLike)
-import qualified Ouroboros.Consensus.Util.IOLike as IOLike
 import qualified System.FS.API as FS
 import qualified System.FS.API.Types as FS
 
@@ -120,7 +119,7 @@ deriving via OnlyCheckWhnfNamed "BackingStoreValueHandle" (BackingStoreValueHand
 
 -- | A combination of 'bsValueHandle' and 'bsvhRead'
 bsRead ::
-     IOLike m
+     MonadThrow m
   => BackingStore m keys values diff
   -> keys
   -> m (WithOrigin SlotNo, values)
@@ -130,12 +129,12 @@ bsRead store keys = withBsValueHandle store $ \slot vh -> do
 
 -- | A 'IOLike.bracket'ed 'bsValueHandle'
 withBsValueHandle ::
-     IOLike m
+     MonadThrow m
   => BackingStore m keys values diff
   -> (WithOrigin SlotNo -> BackingStoreValueHandle m keys values -> m a)
   -> m a
 withBsValueHandle store kont =
-    IOLike.bracket
+    bracket
       (bsValueHandle store)
       (bsvhClose . snd)
       (uncurry kont)

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/Fairness.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/Fairness.hs
@@ -19,7 +19,7 @@ import           Control.Monad (forever, void)
 import qualified Control.Tracer as Tracer
 import           Data.Foldable (asum)
 import qualified Data.List as List
-import           Data.List.NonEmpty (singleton)
+import           Data.List.NonEmpty (NonEmpty (..))
 import           Data.Void (Void, vacuous)
 import           Data.Word (Word32)
 import           Ouroboros.Consensus.Config.SecurityParam as Consensus
@@ -209,7 +209,7 @@ remover mempool total = do
         -- transactions.
         threadDelay 1000
         gtx <- atomically $ getATxFromTheMempool
-        Mempool.removeTxs mempool (singleton $ Mempool.txId gtx)
+        Mempool.removeTxs mempool (Mempool.txId gtx :| [])
         loop (unGenTx gtx:txs) (n-1)
       where
         getATxFromTheMempool =

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/HD/BackingStore.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/HD/BackingStore.hs
@@ -322,11 +322,7 @@ monadicSim m = QC.property (runSimGen (QC.monadic' m))
 -------------------------------------------------------------------------------}
 
 deriving newtype instance QC.Arbitrary (mk k v)
-                       => QC.Arbitrary (
-                            LedgerTables
-                              (OTLedgerState k v)
-                              mk
-                            )
+                       => QC.Arbitrary (OTLedgerTables k v mk)
 
 instance (Ord k, QC.Arbitrary k)
       => QC.Arbitrary (KeysMK k v) where

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/HD/BackingStore/Lockstep.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/HD/BackingStore/Lockstep.hs
@@ -176,7 +176,7 @@ instance ( Show ks, Show vs, Show d
     -- Reopen a backing store by intialising from values.
     BSInitFromValues :: WithOrigin SlotNo
                      -> Values vs
-                     ->  BSAct ks vs d ()
+                     -> BSAct ks vs d ()
     -- Reopen a backing store by initialising from a copy.
     BSInitFromCopy   :: BS.BackingStorePath
                      -> BSAct ks vs d ()


### PR DESCRIPTION
# Description

Resolves #44.

This PR introduces a micro-benchmarking setup for backing store operations. This should allows us to catch performance regressions early when we make meaningful changes to any of the backing store implementations.

Benchmark scenarios are defined as lists of commands, which are run in sequence. The commands largely coincide with the operations that the `BackingStore` and `BackingStoreValueHandle` interfaces provide. Two simple scenarios are provided as examples.
