### PR TITLE
Mempool `addTx` FIFO behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [Ouroboros Consensus](https://input-output-hk.github.io/ouroboros-consensus/)
 
-[![consensus](https://img.shields.io/badge/ouroboros--consensus-0.5.0.0-blue)](https://input-output-hk.github.io/cardano-haskell-packages/package/ouroboros-consensus-consensus-0.5.0.0/)
+[![consensus](https://img.shields.io/badge/ouroboros--consensus-0.5.0.0-blue)](https://input-output-hk.github.io/cardano-haskell-packages/package/ouroboros-consensus-0.5.0.0/)
 [![diffusion](https://img.shields.io/badge/ouroboros--consensus--diffusion-0.5.0.0-blue)](https://input-output-hk.github.io/cardano-haskell-packages/package/ouroboros-consensus-diffusion-0.5.0.0/)
 [![protocol](https://img.shields.io/badge/ouroboros--consensus--protocol-0.5.0.0-blue)](https://input-output-hk.github.io/cardano-haskell-packages/package/ouroboros-consensus-protocol-0.5.0.0/)
 [![cardano](https://img.shields.io/badge/ouroboros--consensus--cardano-0.5.0.0-blue)](https://input-output-hk.github.io/cardano-haskell-packages/package/ouroboros-consensus-cardano-0.5.0.0/)

--- a/cabal.project
+++ b/cabal.project
@@ -14,9 +14,9 @@ repository cardano-haskell-packages
 -- update either of these.
 index-state:
   -- Bump this if you need newer packages from Hackage
-  , hackage.haskell.org 2023-04-27T10:16:58Z
+  , hackage.haskell.org 2023-04-26T22:25:13Z
   -- Bump this if you need newer packages from CHaP
-  , cardano-haskell-packages 2023-04-26T21:43:05Z
+  , cardano-haskell-packages 2023-04-28T08:53:31Z
 
 packages:
   ./ouroboros-consensus
@@ -26,6 +26,20 @@ packages:
 
 tests: True
 benchmarks: True
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/ouroboros-network
+  tag: 43cfbf5d2de7aa943bf56eecfdbb8eabdc84bf1f
+  --sha256: 17yqpicncf4c434n68afdir894pjxwgsv55pa67v323zirqc4j4b
+  subdir:
+    ./network-mux
+    ./ouroboros-network
+    ./ouroboros-network-api
+    ./ouroboros-network-framework
+    ./ouroboros-network-mock
+    ./ouroboros-network-protocols
+    ./ouroboros-network-testing
 
 package cardano-ledger-core
   flags: +asserts
@@ -67,6 +81,9 @@ package ouroboros-network-mock
   flags: +asserts
 
 package ouroboros-network-protocols
+  flags: +asserts
+
+package si-timers
   flags: +asserts
 
 package strict-stm

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1682321185,
-        "narHash": "sha256-2kCTrJo3IvlofRDofyCPKyLHlKgZU3YKCBEwJMStVoo=",
+        "lastModified": 1682675120,
+        "narHash": "sha256-cB2MpIpd7qNbW0nq29fkOHVXoZWoRY/bX4zTCQ5/4dM=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "8fb4cb386d61c86348905ec9de64bf9810c06a74",
+        "rev": "1f8e945597e5368cfd90d71c008622b1bafe4198",
         "type": "github"
       },
       "original": {
@@ -441,11 +441,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1682295860,
-        "narHash": "sha256-sd7R/Goe6ot6ABFIh+izEnIuWRjtvFTOZ20k/KwCcfo=",
+        "lastModified": 1682641452,
+        "narHash": "sha256-hUBB6B7A6UWiYYHtkeu+R+Xwvqd06chBZpwskx7WG28=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "3aacc2f2f14529668b705161966f9c120ad27d48",
+        "rev": "62d9abdf9eb3d0f2857663ecbf5a7f870f7a7b56",
         "type": "github"
       },
       "original": {

--- a/ouroboros-consensus-diffusion/changelog.d/20230427_173647_javier.sagredo_mempool_addtx_fifo.md
+++ b/ouroboros-consensus-diffusion/changelog.d/20230427_173647_javier.sagredo_mempool_addtx_fifo.md
@@ -1,0 +1,23 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->
+
+### Non-Breaking
+
+- Update `io-sim` dependency to 1.1.0.0.
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -109,7 +109,7 @@ library
     , filepath
     , fs-api
     , hashable
-    , io-classes                   ^>=0.3
+    , io-classes                   ^>=1.1
     , mtl                          ^>=2.2
     , ouroboros-consensus          ^>=0.5
     , ouroboros-network            ^>=0.5
@@ -118,6 +118,7 @@ library
     , ouroboros-network-protocols  ^>=0.4
     , random
     , serialise                    ^>=0.2
+    , si-timers                    ^>=1.1
     , text                         >=1.2    && <1.3
     , time
     , typed-protocols
@@ -163,6 +164,7 @@ library diffusion-testlib
     , QuickCheck
     , quiet                                                         >=0.2 && <0.3
     , random
+    , si-timers
     , text
     , typed-protocols
 
@@ -246,7 +248,6 @@ test-suite consensus-test
     , directory
     , fs-api
     , fs-sim
-    , io-classes
     , io-sim
     , mtl
     , nothunks
@@ -257,6 +258,7 @@ test-suite consensus-test
     , QuickCheck
     , quiet
     , serialise
+    , si-timers
     , tasty
     , tasty-hunit
     , tasty-quickcheck

--- a/ouroboros-consensus-diffusion/src/diffusion-testlib/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-diffusion/src/diffusion-testlib/Test/ThreadNet/Network.hs
@@ -40,9 +40,8 @@ import           Codec.CBOR.Read (DeserialiseFailure)
 import qualified Control.Concurrent.Class.MonadSTM as MonadSTM
 import qualified Control.Exception as Exn
 import           Control.Monad
-import           Control.Monad.Class.MonadMVar (MonadMVar)
-import           Control.Monad.Class.MonadTime (MonadTime)
-import           Control.Monad.Class.MonadTimer (MonadTimer)
+import           Control.Monad.Class.MonadTime.SI (MonadTime)
+import           Control.Monad.Class.MonadTimer.SI (MonadTimer)
 import qualified Control.Monad.Except as Exc
 import           Control.Tracer
 import qualified Data.ByteString.Lazy as Lazy
@@ -278,7 +277,6 @@ runThreadNetwork :: forall m blk.
                     ( IOLike m
                     , MonadTime m
                     , MonadTimer m
-                    , MonadMVar m
                     , RunNode blk
                     , TxGen blk
                     , TracingConstraints blk

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -42,9 +42,8 @@ import qualified Codec.CBOR.Decoding as CBOR
 import           Codec.CBOR.Encoding (Encoding)
 import qualified Codec.CBOR.Encoding as CBOR
 import           Codec.CBOR.Read (DeserialiseFailure)
-import           Control.Monad.Class.MonadMVar (MonadMVar)
-import           Control.Monad.Class.MonadTime (MonadTime)
-import           Control.Monad.Class.MonadTimer (MonadTimer)
+import           Control.Monad.Class.MonadTime.SI (MonadTime)
+import           Control.Monad.Class.MonadTimer.SI (MonadTimer)
 import           Control.Tracer
 import           Data.ByteString.Lazy (ByteString)
 import qualified Data.ByteString.Lazy as BSL
@@ -199,7 +198,6 @@ mkHandlers
      ( IOLike m
      , MonadTime m
      , MonadTimer m
-     , MonadMVar m
      , LedgerSupportsMempool blk
      , HasTxId (GenTx blk)
      , LedgerSupportsProtocol blk

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
@@ -54,9 +54,8 @@ module Ouroboros.Consensus.Node (
 import qualified Codec.CBOR.Decoding as CBOR
 import qualified Codec.CBOR.Encoding as CBOR
 import           Codec.Serialise (DeserialiseFailure)
-import           Control.Monad.Class.MonadMVar (MonadMVar)
-import           Control.Monad.Class.MonadTime (MonadTime)
-import           Control.Monad.Class.MonadTimer (MonadTimer)
+import           Control.Monad.Class.MonadTime.SI (MonadTime)
+import           Control.Monad.Class.MonadTimer.SI (MonadTimer)
 import           Control.Tracer (Tracer, contramap, traceWith)
 import           Data.ByteString.Lazy (ByteString)
 import           Data.Hashable (Hashable)
@@ -282,7 +281,7 @@ run args stdArgs = stdLowLevelRunNodeArgsIO args stdArgs >>= runWith args encode
 -- This function runs forever unless an exception is thrown.
 runWith :: forall m addrNTN addrNTC versionDataNTN versionDataNTC blk p2p.
      ( RunNode blk
-     , IOLike m, MonadTime m, MonadTimer m, MonadMVar m
+     , IOLike m, MonadTime m, MonadTimer m
      , Hashable addrNTN, Ord addrNTN, Show addrNTN, Typeable addrNTN
      )
   => RunNodeArgs m addrNTN addrNTC blk p2p

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node/DbLock.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node/DbLock.hs
@@ -12,7 +12,7 @@ module Ouroboros.Consensus.Node.DbLock (
   , withLockDB_
   ) where
 
-import           Control.Monad.Class.MonadTimer
+import           Control.Monad.Class.MonadTimer.SI
 import qualified Data.Time.Clock as Time
 import           Ouroboros.Consensus.Util.FileLock
 import           Ouroboros.Consensus.Util.IOLike

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Node.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Node.hs
@@ -22,7 +22,7 @@
 --
 module Test.Consensus.Node (tests) where
 
-import           Control.Monad.Class.MonadTimer (MonadTimer)
+import           Control.Monad.Class.MonadTimer.SI (MonadTimer)
 import           Control.Monad.IOSim (runSimOrThrow)
 import           Data.Bifunctor (second)
 import           Data.Functor ((<&>))

--- a/ouroboros-consensus/bench/mempool-bench/Bench/Consensus/Mempool.hs
+++ b/ouroboros-consensus/bench/mempool-bench/Bench/Consensus/Mempool.hs
@@ -26,6 +26,7 @@ import           Data.Foldable (traverse_)
 import           GHC.Generics (Generic)
 import qualified Ouroboros.Consensus.Ledger.SupportsMempool as Ledger
 import           Ouroboros.Consensus.Mempool (Mempool (..))
+import           Ouroboros.Consensus.Mempool.API (AddTxOnBehalfOf (..))
 
 {-------------------------------------------------------------------------------
   Commands
@@ -49,14 +50,14 @@ txsAddedInCmds = concatMap txsAdded
 -- TODO: the interpretation of running the command should be defined elsewhere,
 -- and tested by state-mathine tests.
 run ::
-     Applicative m
+     Monad m
   => MempoolWithMockedLedgerItf m blk -> [MempoolCmd blk] -> m ()
 run mempool = traverse_ (runCmd mempool)
 
 runCmd ::
-     Applicative m
+     Monad m
   => MempoolWithMockedLedgerItf m blk -> MempoolCmd blk -> m ()
 runCmd mempoolWithMockedItf = \case
-    TryAdd txs -> void $ tryAddTxs mempool Ledger.DoNotIntervene txs -- TODO: we might want to benchmark the 'Intervene' case
+    TryAdd txs -> void $ mapM (addTx mempool AddTxForRemotePeer) txs -- TODO: we might want to benchmark the 'Intervene' case
   where
     mempool = getMempool mempoolWithMockedItf

--- a/ouroboros-consensus/changelog.d/20230406_131026_dcoutts_mempool-addtx-fifo.md
+++ b/ouroboros-consensus/changelog.d/20230406_131026_dcoutts_mempool-addtx-fifo.md
@@ -1,0 +1,38 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+
+### Breaking
+
+- Remove function `tryAddTxs` from the mempool API. The implementation (Shelly Era)
+  of this function relied on the fairness of 'service-in-random-order', and 
+  endeavoured to maximally fill the mempool. Since the Babbage Era there is an 
+  increased variation in representational size of transactions for a given cost 
+  of processing. This means that, under certain conditions, representationally
+  large transactions could be stalled in progress between mempools.
+  This function was replaced by `addTx`.
+- Add a `addTx` function to the mempool API. This function tries to add a single
+  transaction and blocks if the mempool can not accept the given transaction. 
+  This means that entry to a mempool is now a (per-peer) FIFO. This also ensure
+  that transactions will always progress, irrespective of size.
+  The refactoring introduces two FIFO queues. Remote clients have to queue in both
+  of them, whereas local clients only have to queue in the local clients' queue. 
+  This gives local clients a higher precedence to get into their local mempool under
+  heavy load situations.
+
+

--- a/ouroboros-consensus/changelog.d/20230427_173759_javier.sagredo_mempool_addtx_fifo.md
+++ b/ouroboros-consensus/changelog.d/20230427_173759_javier.sagredo_mempool_addtx_fifo.md
@@ -1,0 +1,22 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->
+### Non-Breaking
+
+- Update `io-sim` dependency to 1.1.0.0.
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -330,21 +330,22 @@ library
     , filelock
     , fs-api
     , hashable
-    , io-classes                   ^>=0.3
+    , io-classes                   ^>=1.1
     , measures
     , mtl                          >=2.2   && <2.3
     , nothunks                     >=0.1.2 && <0.2
     , ouroboros-network-api
     , ouroboros-network-framework
     , ouroboros-network-mock
-    , ouroboros-network-protocols  >=0.2
+    , ouroboros-network-protocols  ^>=0.4
     , psqueues                     >=0.2.3 && <0.3
     , quiet                        >=0.2   && <0.3
     , semialign                    >=1.1
     , serialise                    >=0.2   && <0.3
+    , si-timers                    ^>=1.1
     , sop-core                     >=0.5   && <0.6
     , streaming
-    , strict-stm                   ^>=0.2
+    , strict-stm                   ^>=1.1
     , text                         >=1.2   && <1.3
     , these                        >=1.1   && <1.2
     , time
@@ -405,7 +406,7 @@ library consensus-testlib
     , binary
     , bytestring
     , cardano-crypto-class
-    , cardano-ledger-binary:testlib
+    , cardano-ledger-binary:{cardano-ledger-binary, testlib}
     , cardano-prelude
     , cardano-strict-containers
     , cborg
@@ -558,8 +559,8 @@ test-suite consensus-test
     , quickcheck-state-machine
     , random
     , serialise
+    , si-timers
     , tasty
-    , tasty-expected-failure
     , tasty-hunit
     , tasty-quickcheck
     , time

--- a/ouroboros-consensus/src/consensus-testlib/Test/Util/Orphans/NoThunks.hs
+++ b/ouroboros-consensus/src/consensus-testlib/Test/Util/Orphans/NoThunks.hs
@@ -3,26 +3,16 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Test.Util.Orphans.NoThunks () where
 
+
 import           Control.Monad.IOSim
 import           Control.Monad.ST.Lazy
 import           Control.Monad.ST.Unsafe (unsafeSTToIO)
+import           Data.Proxy
 import           NoThunks.Class (NoThunks (..))
 import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
-
-
--- | Just like the IO instance, we don't actually check anything here
-instance NoThunks (IOSim s a) where
-  showTypeOf _ = "IOSim"
-  wNoThunks _ctxt _act = return Nothing
-
-instance NoThunks a => NoThunks (StrictTVar (IOSim s) a) where
-  showTypeOf _ = "StrictTVar IOSim"
-  wNoThunks ctxt tvar = do
-      a <- unsafeSTToIO $ lazyToStrictST $ execReadTVar (toLazyTVar tvar)
-      noThunks ctxt a
 
 instance NoThunks a => NoThunks (StrictMVar (IOSim s) a) where
   showTypeOf _ = "StrictMVar IOSim"
   wNoThunks ctxt StrictMVar { tvar } = do
-      a <- unsafeSTToIO $ lazyToStrictST $ execReadTVar tvar
+      a <- unsafeSTToIO $ lazyToStrictST $ inspectTVar (Proxy :: Proxy (IOSim s)) tvar
       noThunks ctxt a

--- a/ouroboros-consensus/src/consensus-testlib/Test/Util/Orphans/ToExpr.hs
+++ b/ouroboros-consensus/src/consensus-testlib/Test/Util/Orphans/ToExpr.hs
@@ -1,12 +1,11 @@
 {-# LANGUAGE FlexibleContexts     #-}
-{-# LANGUAGE StandaloneDeriving   #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Test.Util.Orphans.ToExpr () where
 
-import           Data.TreeDiff (ToExpr (..))
+import           Cardano.Ledger.TreeDiff
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/BlockchainTime/WallClock/Default.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/BlockchainTime/WallClock/Default.hs
@@ -1,7 +1,7 @@
 module Ouroboros.Consensus.BlockchainTime.WallClock.Default (defaultSystemTime) where
 
 import           Control.Monad
-import           Control.Monad.Class.MonadTime (MonadTime (..))
+import           Control.Monad.Class.MonadTime.SI (MonadTime (..))
 import           Control.Tracer
 import           Data.Time (UTCTime, diffUTCTime)
 import           Ouroboros.Consensus.BlockchainTime.WallClock.Types

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/SupportsMempool.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/SupportsMempool.hs
@@ -68,6 +68,10 @@ class ( UpdateLedger blk
   txInvariant = const True
 
   -- | Apply an unvalidated transaction
+  --
+  -- The mempool expects that the ledger checks the sanity of the transaction'
+  -- size. The mempool implementation will add any valid transaction as long as
+  -- there is at least one byte free in the mempool.
   applyTx :: LedgerConfig blk
           -> WhetherToIntervene
           -> SlotNo -- ^ Slot number of the block containing the tx

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/API.hs
@@ -15,6 +15,7 @@ module Ouroboros.Consensus.Mempool.API (
     -- * Mempool
     Mempool (..)
     -- * Transaction adding
+  , AddTxOnBehalfOf (..)
   , MempoolAddTxResult (..)
   , addLocalTxs
   , addTxs
@@ -40,9 +41,6 @@ module Ouroboros.Consensus.Mempool.API (
 import           Ouroboros.Consensus.Block (SlotNo)
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsMempool
-import           Ouroboros.Consensus.Mempool.Capacity hiding
-                     (MempoolCapacityBytes, MempoolCapacityBytesOverride,
-                     MempoolSize, computeMempoolCapacity, (<=))
 import qualified Ouroboros.Consensus.Mempool.Capacity as Cap
 import           Ouroboros.Consensus.Mempool.TxSeq (TicketNo, zeroTicketNo)
 import           Ouroboros.Consensus.Util.IOLike
@@ -71,24 +69,40 @@ import           Ouroboros.Network.Protocol.TxSubmission2.Type (TxSizeInBytes)
 -- * It supports wallets that submit dependent transactions (where later
 --   transaction depends on outputs from earlier ones).
 --
--- When only one thread is operating on the mempool, operations that mutate the
--- state based on the input arguments (tryAddTxs and removeTxs) will produce the
--- same result whether they process transactions one by one or all in one go, so
--- this equality holds:
+-- The mempool provides fairness guarantees for the case of multiple threads
+-- performing 'addTx' concurrently. Implementations of this interface must
+-- provide this guarantee, and users of this interface may rely on it.
+-- Specifically, multiple threads that continuously use 'addTx' will, over
+-- time, get a share of the mempool resource (measured by the number of txs
+-- only, not their sizes) roughly proportional to their \"weight\". The weight
+-- depends on the 'AddTxOnBehalfOf': either acting on behalf of remote peers
+-- ('AddTxForRemotePeer') or on behalf of a local client
+-- ('AddTxForLocalClient'). The weighting for threads acting on behalf of
+-- remote peers is the same for all remote peers, so all remote peers will get
+-- a roughly equal share of the resource. The weighting for local clients is
+-- the same for all local clients but /may/ be higher than the weighting for
+-- remote peers. The weighting is not unboundedly higher however, so there is
+-- still (weighted) fairness between remote peers and local clients. Thus
+-- local clients will also get a roughly equal share of the resource, but that
+-- share may be strictly greater than the share for each remote peer.
+-- Furthermore, this implies local clients cannot starve remote peers, despite
+-- their higher weighting.
 --
--- > void (tryAddTxs wti txs) === forM_ txs (tryAddTxs wti . (:[]))
--- > void (trAddTxs wti [x,y]) === tryAddTxs wti x >> void (tryAddTxs wti y)
+-- This fairness specification in terms of weighting is deliberately
+-- non-specific, which allows multiple strategies. The existing default
+-- strategy (for the implementation in "Ouroboros.Consensus.Mempool") is as
+-- follows. The design uses two FIFOs, to give strictly in-order behaviour.
+-- All remote peers get equal weight and all local clients get equal weight.
+-- The relative weight between remote and local is that if there are N remote
+-- peers and M local clients, each local client gets weight 1/(M+1), while all
+-- of the N remote peers together also get total weight 1/(M+1). This means
+-- individual remote peers get weight 1/(N * (M+1)). Intuitively: a single local
+-- client has the same weight as all the remote peers put together.
 --
--- This shows that @'tryAddTxs' wti@ is an homomorphism from '++' and '>>',
--- which informally makes these operations "distributive".
 data Mempool m blk = Mempool {
-      -- | Add a bunch of transactions (oldest to newest)
+      -- | Add a single transaction to the mempool.
       --
-      -- As long as we keep the mempool entirely in-memory this could live in
-      -- @STM m@; we keep it in @m@ instead to leave open the possibility of
-      -- persistence.
-      --
-      -- The new transactions provided will be validated, /in order/, against
+      -- The new transaction provided will be validated, /in order/, against
       -- the ledger state obtained by applying all the transactions already in
       -- the Mempool to it. Transactions which are found to be invalid, with
       -- respect to the ledger state, are dropped, whereas valid transactions
@@ -102,29 +116,28 @@ data Mempool m blk = Mempool {
       -- the mempool via a call to 'syncWithLedger' or by the background
       -- thread that watches the ledger for changes.
       --
-      -- This function will return two lists
+      -- This action returns one of two results
       --
-      -- 1. A list containing the following transactions:
+      --  * A 'MempoolTxAdded' value if the transaction provided was found to
+      --    be valid. This transactions is now in the Mempool.
       --
-      --    * Those transactions provided which were found to be valid, as a
-      --      'MempoolTxAdded' value. These transactions are now in the Mempool.
-      --    * Those transactions provided which were found to be invalid, along
-      --      with their accompanying validation errors, as a
-      --      'MempoolTxRejected' value. These transactions are not in the
-      --      Mempool.
+      --  * A 'MempoolTxRejected' value if the transaction provided was found
+      --    to be invalid, along with its accompanying validation errors. This
+      --    transactions is not in the Mempool.
       --
-      -- 2. A list containing the transactions that have not yet been added, as
-      --    the capacity of the Mempool has been reached. I.e., there is no
-      --    space in the Mempool to add the first transaction in this list. Note
-      --    that we won't try to add smaller transactions after that first
-      --    transaction because they might depend on the first transaction.
+      -- Note that this is a blocking action. It will block until the
+      -- transaction fits into the mempool. This includes transactions that
+      -- turn out to be invalid: the action waits for there to be space for
+      -- the transaction before it gets validated.
+      --
+      -- Note that it is safe to use this from multiple threads concurrently.
       --
       -- POSTCONDITION:
       -- > let prj = \case
       -- >       MempoolTxAdded vtx        -> txForgetValidated vtx
       -- >       MempoolTxRejected tx _err -> tx
-      -- > (processed, toProcess) <- tryAddTxs wti txs
-      -- > map prj processed ++ toProcess == txs
+      -- > processed <- addTx wti txs
+      -- > prj processed == tx
       --
       -- Note that previously valid transaction that are now invalid with
       -- respect to the current ledger state are dropped from the mempool, but
@@ -149,11 +162,13 @@ data Mempool m blk = Mempool {
       -- an index of transaction hashes that have been included on the
       -- blockchain.
       --
-      tryAddTxs      :: WhetherToIntervene
-                     -> [GenTx blk]
-                     -> m ( [MempoolAddTxResult blk]
-                          , [GenTx blk]
-                          )
+      -- As long as we keep the mempool entirely in-memory this could live in
+      -- @STM m@; we keep it in @m@ instead to leave open the possibility of
+      -- persistence.
+      --
+      addTx      :: AddTxOnBehalfOf
+                 -> GenTx blk
+                 -> m (MempoolAddTxResult blk)
 
       -- | Manually remove the given transactions from the mempool.
     , removeTxs      :: [GenTxId blk] -> m ()
@@ -232,63 +247,45 @@ isMempoolTxRejected :: MempoolAddTxResult blk -> Bool
 isMempoolTxRejected MempoolTxRejected{} = True
 isMempoolTxRejected _                   = False
 
--- | Wrapper around 'implTryAddTxs' that blocks until all transaction have
--- either been added to the Mempool or rejected.
+-- | A wrapper around 'addTx' that adds a sequence of transactions on behalf of
+-- a remote peer.
 --
--- This function does not sync the Mempool contents with the ledger state in
--- case the latter changes, it relies on the background thread to do that.
+-- Note that transactions are added one by one, and can interleave with other
+-- concurrent threads using 'addTx'.
 --
--- See the necessary invariants on the Haddock for 'tryAddTxs'.
+-- See 'addTx' for further details.
 addTxs
   :: forall m blk. MonadSTM m
   => Mempool m blk
   -> [GenTx blk]
   -> m [MempoolAddTxResult blk]
-addTxs mempool = addTxsHelper mempool DoNotIntervene
+addTxs mempool = mapM (addTx mempool AddTxForRemotePeer)
 
--- | Variation on 'addTxs' that is more forgiving when possible
+-- | A wrapper around 'addTx' that adds a sequence of transactions on behalf of
+-- a local client. This reports more errors for local clients, see 'Intervene'.
 --
--- See 'Intervene'.
+-- Note that transactions are added one by one, and can interleave with other
+-- concurrent threads using 'addTx'.
+--
+-- See 'addTx' for further details.
 addLocalTxs
   :: forall m blk. MonadSTM m
   => Mempool m blk
   -> [GenTx blk]
   -> m [MempoolAddTxResult blk]
-addLocalTxs mempool = addTxsHelper mempool Intervene
+addLocalTxs mempool = mapM (addTx mempool AddTxForLocalClient)
 
--- | See 'addTxs'
-addTxsHelper
-  :: forall m blk. MonadSTM m
-  => Mempool m blk
-  -> WhetherToIntervene
-  -> [GenTx blk]
-  -> m [MempoolAddTxResult blk]
-addTxsHelper mempool wti = \txs -> do
-    (processed, toAdd) <- tryAddTxs mempool wti txs
-    case toAdd of
-      [] -> return processed
-      _  -> go [processed] toAdd
-  where
-    go
-      :: [[MempoolAddTxResult blk]]
-         -- ^ The outer list is in reverse order, but all the inner lists will
-         -- be in the right order.
-      -> [GenTx blk]
-      -> m [MempoolAddTxResult blk]
-    go acc []         = return (concat (reverse acc))
-    go acc txs@(tx:_) = do
-      let firstTxSize = getTxSize mempool tx
-      -- Wait until there's at least room for the first transaction we're
-      -- trying to add, otherwise there's no point in trying to add it.
-      atomically $ do
-        curSize <- msNumBytes . snapshotMempoolSize <$> getSnapshot mempool
-        Cap.MempoolCapacityBytes capacity <- getCapacity mempool
-        check (curSize + firstTxSize <= capacity)
-      -- It is possible that between the check above and the call below, other
-      -- transactions are added, stealing our spot, but that's fine, we'll
-      -- just recurse again without progress.
-      (added, toAdd) <- tryAddTxs mempool wti txs
-      go (added:acc) toAdd
+-- | Who are we adding a tx on behalf of, a remote peer or a local client?
+--
+-- This affects two things:
+--
+-- 1. how certain errors are treated: we want to be helpful to local clients.
+-- 2. priority of service: local clients are prioritised over remote peers.
+--
+-- See 'Mempool' for a discussion of fairness and priority.
+--
+data AddTxOnBehalfOf = AddTxForRemotePeer | AddTxForLocalClient
+
 
 {-------------------------------------------------------------------------------
   Ledger state considered for forging

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Init.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Init.hs
@@ -107,7 +107,7 @@ mkMempool
      )
   => MempoolEnv m blk -> Mempool m blk
 mkMempool mpEnv = Mempool
-    { tryAddTxs      = implTryAddTxs istate cfg txSize trcr
+    { addTx          = implAddTx istate remoteFifo allFifo cfg txSize trcr
     , removeTxs      = implRemoveTxs mpEnv
     , syncWithLedger = implSyncWithLedger mpEnv
     , getSnapshot    = snapshotFromIS <$> readTVar istate
@@ -116,6 +116,8 @@ mkMempool mpEnv = Mempool
     , getTxSize      = txSize
     }
    where MempoolEnv { mpEnvStateVar = istate
+                    , mpEnvAddTxsRemoteFifo = remoteFifo
+                    , mpEnvAddTxsAllFifo = allFifo
                     , mpEnvLedgerCfg = cfg
                     , mpEnvTxSize = txSize
                     , mpEnvTracer = trcr

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/DiskPolicy.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/DiskPolicy.hs
@@ -13,7 +13,7 @@ module Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy (
   , defaultDiskPolicy
   ) where
 
-import           Control.Monad.Class.MonadTime
+import           Control.Monad.Class.MonadTime.SI
 import           Data.Time.Clock (secondsToDiffTime)
 import           Data.Word
 import           GHC.Generics

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/Condense.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/Condense.hs
@@ -24,7 +24,7 @@ import           Cardano.Crypto.KES (MockKES, NeverKES, SigKES, SignedKES (..),
 import           Cardano.Slotting.Block (BlockNo (..))
 import           Cardano.Slotting.Slot (EpochNo (..), SlotNo (..),
                      WithOrigin (..))
-import           Control.Monad.Class.MonadTime (Time (..))
+import           Control.Monad.Class.MonadTime.SI (Time (..))
 import qualified Data.ByteString as BS.Strict
 import qualified Data.ByteString.Lazy as BS.Lazy
 import           Data.Int

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/EarlyExit.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/EarlyExit.hs
@@ -19,6 +19,7 @@ module Ouroboros.Consensus.Util.EarlyExit (
   ) where
 
 import           Control.Applicative
+import           Control.Concurrent.Class.MonadMVar
 import           Control.Monad
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadEventlog
@@ -26,7 +27,10 @@ import           Control.Monad.Class.MonadFork
 import           Control.Monad.Class.MonadST
 import           Control.Monad.Class.MonadSTM.Internal
 import           Control.Monad.Class.MonadThrow
+import           Control.Monad.Class.MonadTime
+import           Control.Monad.Class.MonadTime.SI
 import           Control.Monad.Class.MonadTimer
+import qualified Control.Monad.Class.MonadTimer.SI as TimerSI
 import           Control.Monad.ST (ST)
 import           Control.Monad.Trans.Class
 import           Control.Monad.Trans.Maybe
@@ -34,8 +38,8 @@ import           Data.Function (on)
 import           Data.Proxy
 import           NoThunks.Class (NoThunks (..))
 import           Ouroboros.Consensus.Util ((.:))
-import           Ouroboros.Consensus.Util.IOLike (IOLike (..),
-                     MonadMonotonicTime (..), StrictMVar, StrictTVar)
+import           Ouroboros.Consensus.Util.IOLike (IOLike (..), StrictMVar,
+                     StrictTVar)
 
 {-------------------------------------------------------------------------------
   Basic definitions
@@ -145,6 +149,22 @@ instance MonadSTM m => MonadSTM (WithEarlyExit m) where
   newTMVarIO      = lift . newTMVarIO
   newEmptyTMVarIO = lift   newEmptyTMVarIO
 
+instance (MonadMVar m, MonadMask m, MonadEvaluate m)
+      => MonadMVar (WithEarlyExit m) where
+  type MVar (WithEarlyExit m) = MVar m
+
+  newEmptyMVar          = lift    newEmptyMVar
+  takeMVar              = lift .  takeMVar
+  putMVar               = lift .: putMVar
+  tryTakeMVar           = lift .  tryTakeMVar
+  tryPutMVar            = lift .: tryPutMVar
+  tryReadMVar           = lift .  tryReadMVar
+  isEmptyMVar           = lift .  isEmptyMVar
+
+  newMVar               = lift .  newMVar
+  readMVar              = lift .  readMVar
+  swapMVar              = lift .: swapMVar
+
 instance MonadCatch m => MonadThrow (WithEarlyExit m) where
   throwIO = lift . throwIO
 
@@ -188,7 +208,6 @@ instance MonadThread m => MonadThread (WithEarlyExit m) where
 
   myThreadId   = lift    myThreadId
   labelThread  = lift .: labelThread
-  threadStatus = lift .  threadStatus
 
 instance (MonadMask m, MonadAsync m, MonadCatch (STM m))
       => MonadAsync (WithEarlyExit m) where
@@ -236,11 +255,19 @@ instance MonadST m => MonadST (WithEarlyExit m) where
       lowerLiftST :: (forall s. Proxy s -> (forall a. ST s a -> m a) -> b) -> b
       lowerLiftST g = withLiftST $ g Proxy
 
+instance MonadMonotonicTimeNSec m => MonadMonotonicTimeNSec (WithEarlyExit m) where
+  getMonotonicTimeNSec = lift getMonotonicTimeNSec
+
+
 instance MonadMonotonicTime m => MonadMonotonicTime (WithEarlyExit m) where
   getMonotonicTime = lift getMonotonicTime
 
 instance MonadDelay m => MonadDelay (WithEarlyExit m) where
   threadDelay = lift . threadDelay
+
+
+instance TimerSI.MonadDelay m => TimerSI.MonadDelay (WithEarlyExit m) where
+  threadDelay = lift . TimerSI.threadDelay
 
 instance (MonadEvaluate m, MonadCatch m) => MonadEvaluate (WithEarlyExit m) where
   evaluate  = lift . evaluate

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/IOLike.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/IOLike.hs
@@ -43,13 +43,15 @@ module Ouroboros.Consensus.Util.IOLike (
 
 import           Cardano.Crypto.KES (KESAlgorithm, SignKeyKES)
 import qualified Cardano.Crypto.KES as KES
+import           Control.Applicative (Alternative)
+import           Control.Concurrent.Class.MonadMVar
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadEventlog
 import           Control.Monad.Class.MonadFork
 import           Control.Monad.Class.MonadST
 import           Control.Monad.Class.MonadThrow
-import           Control.Monad.Class.MonadTime hiding (MonadTime (..))
-import           Control.Monad.Class.MonadTimer
+import           Control.Monad.Class.MonadTime.SI
+import           Control.Monad.Class.MonadTimer.SI
 import           Data.Functor (void)
 import           NoThunks.Class (NoThunks (..))
 import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
@@ -60,6 +62,7 @@ import           Ouroboros.Consensus.Util.Orphans ()
 -------------------------------------------------------------------------------}
 
 class ( MonadAsync              m
+      , MonadMVar               m
       , MonadEventlog           m
       , MonadFork               m
       , MonadST                 m
@@ -70,6 +73,7 @@ class ( MonadAsync              m
       , MonadMask               m
       , MonadMonotonicTime      m
       , MonadEvaluate           m
+      , Alternative        (STM m)
       , MonadThrow         (STM m)
       , forall a. NoThunks (m a)
       , forall a. NoThunks a => NoThunks (StrictTVar m a)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/MonadSTM/NormalForm.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/MonadSTM/NormalForm.hs
@@ -14,9 +14,10 @@ module Ouroboros.Consensus.Util.MonadSTM.NormalForm (
 
 import qualified Control.Concurrent.Class.MonadSTM.Strict as Strict
 import           Control.Concurrent.Class.MonadSTM.Strict.TMVar as StrictSTM hiding
-                     (newTMVar, newTMVarIO)
+                     (newTMVar, newTMVarIO, traceTMVar, traceTMVarIO)
 import           Control.Concurrent.Class.MonadSTM.Strict.TVar as StrictSTM hiding
-                     (newTVar, newTVarIO, newTVarWithInvariantIO)
+                     (newTVar, newTVarIO, newTVarWithInvariantIO, traceTVar,
+                     traceTVarIO)
 import           Control.Concurrent.Class.MonadSTM.TBQueue as LazySTM
 import           Control.Concurrent.Class.MonadSTM.TQueue as LazySTM
 import           Control.Monad.Class.MonadSTM as StrictSTM

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/Orphans.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/Orphans.hs
@@ -17,7 +17,7 @@ import           Cardano.Crypto.DSIGN.Mock (MockDSIGN)
 import           Cardano.Crypto.Hash (Hash)
 import           Codec.CBOR.Decoding (Decoder)
 import           Codec.Serialise (Serialise (..))
-import           Control.Monad.Class.MonadTime (Time (..))
+import           Control.Monad.Class.MonadTime.SI (Time (..))
 import           Control.Tracer (Tracer)
 import           Data.Bimap (Bimap)
 import qualified Data.Bimap as Bimap

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool.hs
@@ -24,6 +24,11 @@
 -- * Transactions cannot be retrieved after they are removed.
 -- * The mempool capacity is not exceeded
 --
+-- NOTE: the test mempool's default capacity is set to a very large value in
+-- module "Ouroboros.Consensus.Mock.Ledger.Block". This is why the generators do
+-- not care about the mempool capacity when generating transactions for a
+-- mempool with the 'NoMempoolCapacityBytesOverride' option set.
+--
 module Test.Consensus.Mempool (tests) where
 
 import           Cardano.Binary (Encoding, toCBOR)
@@ -78,7 +83,8 @@ tests = testGroup "Mempool"
   , testProperty "result of addTxs"                        prop_Mempool_addTxs_result
   , testProperty "Invalid transactions are never added"    prop_Mempool_InvalidTxsNeverAdded
   , testProperty "result of getCapacity"                   prop_Mempool_getCapacity
-  , testProperty "Mempool capacity implementation"         prop_Mempool_Capacity
+  --   , testProperty "Mempool capacity implementation"         prop_Mempool_Capacity
+  -- FIXME: we should add an issue to test this aspect somehow.
   , testProperty "Added valid transactions are traced"     prop_Mempool_TraceValidTxs
   , testProperty "Rejected invalid txs are traced"         prop_Mempool_TraceRejectedTxs
   , testProperty "Removed invalid txs are traced"          prop_Mempool_TraceRemovedTxs
@@ -208,63 +214,6 @@ prop_Mempool_getCapacity mcts =
   where
     MempoolCapacityBytesOverride testCapacity = testMempoolCapOverride testSetup
     MempoolCapTestSetup (TestSetupWithTxs testSetup _txsToAdd) = mcts
-
--- | Test the correctness of 'tryAddTxs' when the Mempool is (or will be) at
--- capacity.
---
--- Ignore the "100% empty Mempool" label in the test output, that is there
--- because we reuse 'withTestMempool' and always start with an empty Mempool
--- and 'LedgerState'.
-prop_Mempool_Capacity :: MempoolCapTestSetup -> Property
-prop_Mempool_Capacity (MempoolCapTestSetup testSetupWithTxs) =
-  withTestMempool testSetup $ \TestMempool { mempool } -> do
-    capacity <- atomically (getCapacity mempool)
-    curSize <- msNumBytes . snapshotMempoolSize <$>
-      atomically (getSnapshot mempool)
-    res@(processed, unprocessed) <- tryAddTxs mempool DoNotIntervene (map fst txsToAdd)
-    return $
-      counterexample ("Initial size: " <> show curSize)    $
-      classify (null processed)   "no transactions added"  $
-      classify (null unprocessed) "all transactions added" $
-      blindErrors res === expectedResult capacity curSize
-  where
-    TestSetupWithTxs testSetup txsToAdd = testSetupWithTxs
-
-    -- | Convert 'MempoolAddTxResult' into a 'Bool':
-    -- isMempoolTxAdded -> True, isMempoolTxRejected -> False.
-    blindErrors
-      :: ([MempoolAddTxResult TestBlock], [GenTx TestBlock])
-      -> ([(GenTx TestBlock, Bool)], [GenTx TestBlock])
-    blindErrors (processed, toAdd) = (processed', toAdd)
-      where
-        processed' = [ case txAddRes of
-                         MempoolTxAdded vtx        -> (txForgetValidated vtx, True)
-                         MempoolTxRejected tx _err -> (tx, False)
-                     | txAddRes <- processed ]
-
-    expectedResult
-      :: MempoolCapacityBytes
-      -> Word32  -- ^ Current mempool size
-      -> ([(GenTx TestBlock, Bool)], [GenTx TestBlock])
-    expectedResult (MempoolCapacityBytes capacity) = \curSize ->
-        go curSize [] txsToAdd
-      where
-        go
-          :: Word32
-          -> [(GenTx TestBlock, Bool)]
-          -> [(GenTx TestBlock, Bool)]
-          -> ([(GenTx TestBlock, Bool)], [GenTx TestBlock])
-        go curSize processed = \case
-          []
-            -> (reverse processed, [])
-          (tx, valid):txsToAdd'
-            | let curSize' = curSize + txSize tx
-            , curSize' <= capacity
-            -> go (if valid then curSize' else curSize)
-                  ((tx, valid):processed)
-                  txsToAdd'
-            | otherwise
-            -> (reverse processed, tx:map fst txsToAdd')
 
 -- | Test that all valid transactions added to a 'Mempool' via 'addTxs' are
 -- appropriately represented in the trace of events.
@@ -738,6 +687,11 @@ data TestMempool m = TestMempool
 
 -- NOTE: at the end of the test, this function also checks whether the Mempool
 -- contents are valid w.r.t. the current ledger.
+--
+-- NOTE: the test mempool's default capacity is set to a very large value in
+-- module "Ouroboros.Consensus.Mock.Ledger.Block". This is why the generators do
+-- not care about the mempool capacity when generating transactions for a
+-- mempool with the 'NoMempoolCapacityBytesOverride' option set.
 withTestMempool
   :: forall prop. Testable prop
   => TestSetup

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/Fairness.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/Fairness.hs
@@ -31,14 +31,12 @@ import           Ouroboros.Consensus.Util.IOLike (STM, atomically, retry)
 import           System.Random (randomIO)
 import           Test.Consensus.Mempool.Fairness.TestBlock
 import           Test.Tasty (TestTree, testGroup)
-import           Test.Tasty.ExpectedFailure (expectFail)
 import           Test.Tasty.HUnit (testCase, (@?), (@?=))
 import           Test.Util.TestBlock (testInitLedgerWithState)
 
 tests :: TestTree
 tests = testGroup "Mempool fairness"
-                  [ expectFail $
-                    testCase "There is no substantial bias in added transaction sizes" $
+                  [ testCase "There is no substantial bias in added transaction sizes" $
                               testTxSizeFairness TestParams { mempoolMaxCapacity =   100
                                                             , smallTxSize        =     1
                                                             , largeTxSize        =    10

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/ResourceRegistry.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/ResourceRegistry.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveFoldable             #-}
-{-# LANGUAGE DeriveFunctor              #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE DeriveTraversable          #-}
 {-# LANGUAGE FlexibleContexts           #-}
@@ -11,7 +9,6 @@
 {-# LANGUAGE RecordWildCards            #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE StandaloneDeriving         #-}
-{-# LANGUAGE TupleSections              #-}
 {-# LANGUAGE TypeApplications           #-}
 -- | Tests for the resource registry
 --
@@ -33,7 +30,7 @@
 --
 module Test.Consensus.ResourceRegistry (tests) where
 
-import           Control.Monad.Class.MonadTimer
+import           Control.Monad.Class.MonadTimer.SI
 import           Control.Monad.Except
 import           Data.Foldable (toList)
 import           Data.Function (on)

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/Unit.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/Unit.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE NamedFieldPuns             #-}
 {-# LANGUAGE RankNTypes                 #-}
 {-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE UndecidableInstances       #-}
 
 module Test.Ouroboros.Storage.ChainDB.Unit (tests) where
 

--- a/scripts/ci/check-changelogs.sh
+++ b/scripts/ci/check-changelogs.sh
@@ -43,7 +43,7 @@ function this_merge_updates_version {
 function this_merge_adds_fragment {
     if [[ -n $CI ]];
     then echo "$(($(ls -A1 $BASE/$1/changelog.d | wc -l) - $(ls -A1 $TARGET/$1/changelog.d | wc -l)))"
-    else git diff $TARGET HEAD --name-only --diff-filter=A | grep $1/changelog.d | wc -l
+    else git diff $TARGET HEAD --name-only --diff-filter=AR | grep $1/changelog.d | wc -l
     fi
 }
 
@@ -59,7 +59,7 @@ function check {
 
     echo "Checking consistency of $pkg"
 
-    if [[ $(files-changed $pkg) ]]; then
+    if [[ $(files-changed $pkg) -gt 0 ]]; then
 
         version=$(cabal_files_version $pkg)
         last_version=$(get_last_version $pkg)
@@ -80,7 +80,7 @@ function check {
             printf "version:       %s\nnew version:   %s\nnew fragments: $adds_fragment\nOK\n\n" $version $updated_versions $last_version
         fi
     else
-        echo "No source files changed in $pkg"
+        printf "No source files changed in %s\n\n" $pkg
     fi
 }
 

--- a/scripts/ci/regen-project-asserts.sh
+++ b/scripts/ci/regen-project-asserts.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-common=$(sed '/package /q' cabal.project | sed '$ d')
+common=$(sed '/^package /q' cabal.project | sed '$ d')
 
 echo "$common" > cabal.project
 
@@ -14,3 +14,5 @@ for pkg in $(grep asserts cabal.project.freeze | awk '{$1=$1};1' | cut -d' ' -f1
 package $pkg
   flags: +asserts" >> cabal.project
 done
+
+rm cabal.project.freeze


### PR DESCRIPTION
# Description

Change the behaviour for multiple concurrent threads using `addTx`/`addTxs`: provide simple fifo behaviour.

The first change also refactors the `addTxs` implementation to simplify it by removing unused features.

Ported from https://github.com/input-output-hk/ouroboros-network/pull/4436