### PR TITLE
Expose a method for retrieving UTxO set size from the ChainDB

### DIFF
--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Tables.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Tables.hs
@@ -1,15 +1,17 @@
-{-# LANGUAGE DataKinds                #-}
-{-# LANGUAGE DefaultSignatures        #-}
-{-# LANGUAGE DeriveAnyClass           #-}
-{-# LANGUAGE DeriveGeneric            #-}
-{-# LANGUAGE DerivingStrategies       #-}
-{-# LANGUAGE FlexibleContexts         #-}
-{-# LANGUAGE GADTs                    #-}
-{-# LANGUAGE QuantifiedConstraints    #-}
-{-# LANGUAGE Rank2Types               #-}
-{-# LANGUAGE StandaloneKindSignatures #-}
-{-# LANGUAGE TypeFamilies             #-}
-{-# LANGUAGE UndecidableInstances     #-}
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE DefaultSignatures          #-}
+{-# LANGUAGE DeriveAnyClass             #-}
+{-# LANGUAGE DeriveFunctor              #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
+{-# LANGUAGE QuantifiedConstraints      #-}
+{-# LANGUAGE Rank2Types                 #-}
+{-# LANGUAGE StandaloneKindSignatures   #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE UndecidableInstances       #-}
 
 -- | See @'LedgerTables'@
 module Ouroboros.Consensus.Ledger.Tables (
@@ -26,6 +28,7 @@ module Ouroboros.Consensus.Ledger.Tables (
     -- ** Concrete definitions
   , Canonical (..)
   , CodecMK (..)
+  , ConstMK (..)
   , DiffMK (..)
   , EmptyMK (..)
   , KeysMK (..)
@@ -422,7 +425,7 @@ newtype KeysMK     k v = KeysMK      (Set k)
   deriving stock (Generic, Eq, Show)
   deriving anyclass NoThunks
 
-newtype SeqDiffMK  k v = SeqDiffMK   (DiffSeq k v)
+newtype SeqDiffMK  k v = SeqDiffMK { getSeqDiffMK :: DiffSeq k v }
   deriving stock (Generic, Eq, Show)
   deriving anyclass NoThunks
 
@@ -488,6 +491,12 @@ instance Ord k => Monoid (KeysMK k v) where
 
 instance Functor (DiffMK k) where
   fmap f (DiffMK d) = DiffMK $ fmap f d
+
+newtype ConstMK a k v = ConstMK { getConstMK :: a }
+  deriving stock (Generic, Eq, Show, Functor)
+  deriving newtype (Semigroup, Monoid)
+  deriving anyclass NoThunks
+  deriving anyclass IsMapKind
 
 {-------------------------------------------------------------------------------
   Serialization Codecs

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/BackingStore/Init.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/BackingStore/Init.hs
@@ -16,6 +16,7 @@ import           Control.Tracer
 import           Data.Functor.Contravariant
 import qualified Data.Map.Diff.Strict as Diff
 import qualified Data.Map.Strict as Map
+import           Data.Monoid (Sum (..))
 import qualified Data.Set as Set
 import           GHC.Stack (HasCallStack)
 import           Ouroboros.Consensus.Ledger.Extended
@@ -82,6 +83,7 @@ newBackingStoreInitialiser trcr bss =
             zipLedgerTables (rangeRead_  (rqCount rq)) keys values
       )
       (zipLedgerTables applyDiff_)
+      (getSum . foldLedgerTables count_)
       valuesMKEncoder
       valuesMKDecoder
   where
@@ -118,6 +120,9 @@ newBackingStoreInitialiser trcr bss =
       -> ValuesMK k v
     applyDiff_ (ValuesMK values) (DiffMK diff) =
       ValuesMK (Diff.applyDiff values diff)
+
+    count_ :: ValuesMK k v -> Sum Int
+    count_ (ValuesMK values) = Sum $ Map.size values
 
 -- | The backing store selector
 data BackingStoreSelector m where

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/BackingStore/Trivial.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/BackingStore/Trivial.hs
@@ -25,6 +25,7 @@ trivialBackingStore emptyValues = do
                            (pure ())
                            (\_ -> pure emptyValues)
                            (\_ -> pure emptyValues)
+                           (pure $ Statistics s 0)
               )
               (\s _ -> void
                      $ IOLike.atomically

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/DbChangelog.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/DbChangelog.hs
@@ -185,9 +185,7 @@ instance GetTip l => AS.Anchorable (WithOrigin SlotNo) (l EmptyMK) (l EmptyMK) w
   asAnchor = id
   getAnchorMeasure _ = getTipSlot
 
-instance ( IsLedger l
-         , HeaderHash (K @MapKind (DbChangelog l)) ~ HeaderHash l
-         ) => GetTip (K (DbChangelog l)) where
+instance IsLedger l => GetTip (K (DbChangelog l)) where
   getTip = castPoint
          . getTip
          . either id id
@@ -196,7 +194,18 @@ instance ( IsLedger l
          . anchorlessChangelog
          . unK
 
+instance IsLedger l => GetTip (K (AnchorlessDbChangelog l)) where
+  getTip = castPoint
+         . getTip
+         . either id id
+         . AS.head
+         . adcStates
+         . unK
+
 type instance HeaderHash (K @MapKind (DbChangelog l)) =
+              HeaderHash l
+
+type instance HeaderHash (K @MapKind (AnchorlessDbChangelog l)) =
               HeaderHash l
 
 type DbChangelog' blk = DbChangelog (ExtLedgerState blk)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/Orphans.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/Orphans.hs
@@ -23,6 +23,7 @@ import           Data.Bimap (Bimap)
 import qualified Data.Bimap as Bimap
 import           Data.IntPSQ (IntPSQ)
 import qualified Data.IntPSQ as PSQ
+import           Data.Monoid
 import           Data.SOP.Strict
 import           NoThunks.Class (InspectHeap (..), InspectHeapNamed (..),
                      NoThunks (..), OnlyCheckWhnfNamed (..), allNoThunks,
@@ -109,6 +110,8 @@ deriving newtype instance NoThunks Time
 instance NoThunks a => NoThunks (K a b) where
   showTypeOf _ = showTypeOf (Proxy @a)
   wNoThunks ctxt (K a) = wNoThunks ("K":ctxt) a
+
+instance NoThunks a => NoThunks (Sum a)
 
 {-------------------------------------------------------------------------------
   fs-api

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/HD/BackingStore/Mock.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/HD/BackingStore/Mock.hs
@@ -38,6 +38,7 @@ module Test.Ouroboros.Storage.LedgerDB.HD.BackingStore.Mock (
   , mBSVHClose
   , mBSVHRangeRead
   , mBSVHRead
+  , mBSVHStat
   , mBSValueHandle
   , mBSWrite
   , mGuardBSClosed
@@ -313,3 +314,13 @@ mBSVHRead vh ks = do
 -- | Read the slot number out of a value handle
 mBSVHAtSlot :: Monad m => ValueHandle vs -> m (WithOrigin SlotNo)
 mBSVHAtSlot = pure . seqNo
+
+-- | Retrieve statistics for the backing store value handle.
+mBSVHStat ::
+     (MonadState (Mock vs) m, MonadError Err m, ValuesLength vs)
+  => ValueHandle vs
+  -> m BS.Statistics
+mBSVHStat vh = do
+  mGuardBSClosed
+  mGuardBSVHClosed vh
+  pure $ BS.Statistics (seqNo vh) (valuesLength $ values vh)

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/HD/DiffSeq.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/HD/DiffSeq.hs
@@ -82,6 +82,7 @@ instance (RMFT.SuperMeasured vt vi a, Arbitrary a)
 instance (Ord k, Arbitrary k, Arbitrary v)
       => Arbitrary (RootMeasure k v) where
   arbitrary = RootMeasure <$> arbitrary <*> arbitrary
+                          <*> arbitrary <*> arbitrary
 
 instance Arbitrary (InternalMeasure k v) where
   arbitrary = InternalMeasure <$> arbitrary <*> arbitrary <*> arbitrary


### PR DESCRIPTION
# Description

Resolves #57.

We expose a method of retrieving the UTxO set size. More generally, the method can retrieve the size of any table. 

To achieve this, we do the following.
1. The backing store value handle interface is extended with a `bsvhStat` function, which is intended to provide statistics that are common for each backing store implementation, such as the current sequence number (last written slot number) and the number of entries stored on-disk.  This `bsvhStat` function provides the statistics for a consistent view of the database.
2. The changelog now counts the number of inserts and deletes of all diffs in the diff sequence. These numbers determine how the size of a `Data.Map` should increase if the diffs in the sequence are applied to it. This comes with some caveats relating to redundant inserts/deletes: inserting or deleting a key twice does not increase the size of a `Data.Map`. However, the UTxO access pattern is such that that there are most one insert and delete for each UTxO address, and a delete is always preceded by an insert. As such, we do not suffer from the caveats in our solution.
3. Summing the number of entries stored on-disk (step 1) and the total size effect of the changelog (step 2) gives us the total number of UTxO entries, corresponding to the logical current ledger state. This read-forward pattern is similar to the pattern we use when we retrieve the UTxO entries to use for various operations, like block application.