### PR TITLE
Note on Byron EBBs in chain comparison

### DIFF
--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/BlockFetch/ClientInterface.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/BlockFetch/ClientInterface.hs
@@ -295,14 +295,14 @@ mkBlockFetchConsensusInterface
           -- fragment can't be empty.
           (True,  _)     -> error "impossible"
 
-      -- The precondition of 'compareAnchoredFragments' is that either both
-      -- fragments are non-empty or they intersect. We are mostly satisfying
-      -- that precondition, but there is a corner case when considering EBBs
-      -- where we don't. Either our fragment or the candidate fragment could be
-      -- anchored at an EBB that shares the block number with the anchor of the
-      -- other, in which case the two fragments are not guaranteed to intersect.
-      -- This can happen even if one of the two fragments is empty while the
-      -- other is non-empty.
+      -- The precondition of 'compareAnchoredFragments' is that both fragments
+      -- are non-empty or they intersect. We are mostly satisfying that
+      -- precondition, but there is a corner case when considering EBBs where we
+      -- don't. Either our fragment or the candidate fragment could be anchored
+      -- at an EBB that shares the block number with the anchor of the other, in
+      -- which case the two fragments are not guaranteed to intersect. This can
+      -- happen even if one of the two fragments is empty while the other is
+      -- non-empty.
       --
       -- For example, consider an EBB @B@ that shares the block number with its
       -- predecessor @A. Consider two fragments @f1 = B ] C@ and @f2 = A ]@.
@@ -310,6 +310,13 @@ mkBlockFetchConsensusInterface
       -- share the same anchor block number, such that @AF.anchorBlockNo f1 ==
       -- AF.anchorBlockNo f2@. However, these fragments do not intersect, so
       -- @preferAnchoredCandidate _ ours cand@ will fail.
+      --
+      -- For this to be a problem in practice, assertions would have to be
+      -- enabled (which isn't the case for a running node) and the current
+      -- evolving chain would have to be in the Byron era (which is not the
+      -- case). Since violation of the precondition is therefore highly
+      -- unlikely, we chose no to include a case for EBBs here because it would
+      -- complicate the code.
       | otherwise
       = preferAnchoredCandidate bcfg ours cand
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/BlockFetch/ClientInterface.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/BlockFetch/ClientInterface.hs
@@ -295,6 +295,21 @@ mkBlockFetchConsensusInterface
           -- fragment can't be empty.
           (True,  _)     -> error "impossible"
 
+      -- The precondition of 'compareAnchoredFragments' is that either both
+      -- fragments are non-empty or they intersect. We are mostly satisfying
+      -- that precondition, but there is a corner case when considering EBBs
+      -- where we don't. Either our fragment or the candidate fragment could be
+      -- anchored at an EBB that shares the block number with the anchor of the
+      -- other, in which case the two fragments are not guaranteed to intersect.
+      -- This can happen even if one of the two fragments is empty while the
+      -- other is non-empty.
+      --
+      -- For example, consider an EBB @B@ that shares the block number with its
+      -- predecessor @A. Consider two fragments @f1 = B ] C@ and @f2 = A ]@.
+      -- @f1@ is anchored at @B@, @f2@ is anchored at @A@. @f1@ and @f2@ will
+      -- share the same anchor block number, such that @AF.anchorBlockNo f1 ==
+      -- AF.anchorBlockNo f2@. However, these fragments do not intersect, so
+      -- @preferAnchoredCandidate _ ours cand@ will fail.
       | otherwise
       = preferAnchoredCandidate bcfg ours cand
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/AnchoredFragment.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/AnchoredFragment.hs
@@ -120,7 +120,7 @@ compareAnchoredFragments cfg frag1 frag2 =
       = return ()
       | otherwise
       = throwError
-          "precondition violated: fragments both empty or don't intersect"
+          "precondition violated: fragments aren't both non-empty or don't intersect"
 
 -- | Lift 'preferCandidate' to 'AnchoredFragment'
 --

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/AnchoredFragment.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/AnchoredFragment.hs
@@ -120,7 +120,8 @@ compareAnchoredFragments cfg frag1 frag2 =
       = return ()
       | otherwise
       = throwError
-          "precondition violated: fragments aren't both non-empty or don't intersect"
+          "precondition violated: fragments should both be non-empty or they \
+          \should intersect"
 
 -- | Lift 'preferCandidate' to 'AnchoredFragment'
 --


### PR DESCRIPTION
# Description

Running `cabal run ouroboros-consensus-cardano:byron-test --ghc-options="-fno-ignore-asserts" -- -p '/simple convergence/' --quickcheck-replay=323717` on commit 2d50007d80a871999b0f9a09c6f95565c7312103 shows a test failure for Byron ThreadNet tests.
```
byron
  Byron
    simple convergence: FAIL (39.92s)
      *** Failed! (after 76 tests):
      Exception:
        precondition violated: fragments aren't both non-empty or don't intersect
        CallStack (from HasCallStack):
          error, called at src/ouroboros-consensus/Ouroboros/Consensus/Util/Assert.hs:13:30 in ouroboros-consensus-0.5.0.0-inplace:Ouroboros.Consensus.Util.Assert
          assertWithMsg, called at src/ouroboros-consensus/Ouroboros/Consensus/Util/AnchoredFragment.hs:88:5 in ouroboros-consensus-0.5.0.0-inplace:Ouroboros.Consensus.Util.AnchoredFragment
          compareAnchoredFragments, called at src/ouroboros-consensus/Ouroboros/Consensus/Util/AnchoredFragment.hs:135:5 in ouroboros-consensus-0.5.0.0-inplace:Ouroboros.Consensus.Util.AnchoredFragment
          preferAnchoredCandidate, called at src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/BlockFetch/ClientInterface.hs:305:9 in ouroboros-consensus-0.5.0.0-inplace:Ouroboros.Consensus.MiniProtocol.BlockFetch.ClientInterface
          plausibleCandidateChain, called at src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/BlockFetch/ClientInterface.hs:173:35 in ouroboros-consensus-0.5.0.0-inplace:Ouroboros.Consensus.MiniProtocol.BlockFetch.ClientInterface
          plausibleCandidateChain, called at src/Ouroboros/Network/BlockFetch.hs:204:9 in ouroboros-network-0.5.0.0-f5391f998845aaf34991fdbae42479f49285b923ee25ccb4dd95fc194b95735e:Ouroboros.Network.BlockFetch
          plausibleCandidateChain, called at src/Ouroboros/Network/BlockFetch/Decision.hs:245:7 in ouroboros-network-0.5.0.0-f5391f998845aaf34991fdbae42479f49285b923ee25ccb4dd95fc194b95735e:Ouroboros.Network.BlockFetch.Decision
      TestSetup {setupEBBs = ProduceEBBs, setupK = SecurityParam 1, setupTestConfig = TestConfig {initSeed = Seed 5839900652819622642, nodeTopology = NodeTopology (fromList [(CoreNodeId 0,fromList []),(CoreNodeId 1,fromList [CoreNodeId 0]),(CoreNodeId 2,fromList [CoreNodeId 1])]), numCoreNodes = NumCoreNodes 3, numSlots = NumSlots 18}, setupNodeJoinPlan = NodeJoinPlan (fromList [(CoreNodeId 0,SlotNo 0),(CoreNodeId 1,SlotNo 0),(CoreNodeId 2,SlotNo 9)]), setupNodeRestarts = NodeRestarts (fromList [(SlotNo 15,fromList [(CoreNodeId 0,NodeRestart)]),(SlotNo 17,fromList [(CoreNodeId 2,NodeRestart)])]), setupSlotLength = SlotLength 16.923s, setupVersion = (NodeToNodeV_8,ByronNodeToNodeVersion1)}
      Use --quickcheck-replay=323717 to reproduce.

1 out of 1 tests failed (39.92s)
```

This test failure occurs in the implementation of the `plausibleCandidateChain` field of the `BlockFetchConsensusInterface` interface in Byron.
 
```haskell 
       -- | Given the current chain, is the given chain plausible as a
       -- candidate chain. Classically for Ouroboros this would simply
       -- check if the candidate is strictly longer, but for Ouroboros
       -- with operational key certificates there are also cases where
       -- we would consider a chain of equal length to the current chain.
       --
       plausibleCandidateChain :: HasCallStack
                               => AnchoredFragment header
                               -> AnchoredFragment header -> Bool,
```

In the presence of EBBs, the implementation of `plausibleCandidateChain` might violate a precondition down the line in `compareAnchoredFragments`, which is ultimately caused by the fact that EBBs share the block number of their predecessor. We've added documentation to the code to describe this corner case.

For this to be a problem in practice, assertions would have to be enabled (which isn't the case for a running node) and the current evolving chain would have to be in the Byron era (which is not the case). Since violation of the precondition is therefore highly unlikely, we chose no to include a case for EBBs here because it would complicate the code. In addition, the Big Decontamination plan (https://github.com/input-output-hk/ouroboros-network/issues/2156#issuecomment-656713901) would hopefully fix the problem