### PR TITLE
ImmDB server

### DIFF
--- a/ouroboros-consensus-cardano/README.md
+++ b/ouroboros-consensus-cardano/README.md
@@ -245,3 +245,17 @@ The tool expects the given ChainDB path (`--db` option) to *not* be present. Sho
 #### limiting synthesis
 
 A limit must be specified up to which the tool synthesizes a ChainDB. Possible limits are either the number of slots processed (`-s`), the number of epochs processed (`-e`) or the absolute number of blocks in the resulting ChainDB (`-b`).
+
+## ImmDB Server
+
+A standalone tool that serves a Cardano ImmutableDB via ChainSync and BlockFetch.
+
+This can be useful to locally test syncing without having to run a full node just for serving the chain.
+
+```sh
+cabal run immdb-server -- \
+  --db /path/to/db/immutable/ \
+  --config /path/to/cardano/config.json
+```
+
+The ChainSync miniprotocol will terminate with an exception when it receives a `MsgRequestNext` after the immutable tip.

--- a/ouroboros-consensus-cardano/app/immdb-server.hs
+++ b/ouroboros-consensus-cardano/app/immdb-server.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE ApplicativeDo  #-}
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Main (main) where
+
+import qualified Cardano.Tools.DBAnalyser.Block.Cardano as Cardano
+import           Cardano.Tools.DBAnalyser.HasAnalysis (mkProtocolInfo)
+import qualified Cardano.Tools.ImmDBServer.Diffusion as ImmDBServer
+import           Data.Void
+import qualified Network.Socket as Socket
+import           Options.Applicative
+import           Ouroboros.Consensus.Node.ProtocolInfo (ProtocolInfo (..))
+
+main :: IO ()
+main = do
+    Opts {immDBDir, port, configFile} <- execParser optsParser
+    let sockAddr = Socket.SockAddrInet port hostAddr
+          where
+            -- could also be passed in
+            hostAddr = Socket.tupleToHostAddress (127, 0, 0, 1)
+        args = Cardano.CardanoBlockArgs configFile Nothing
+    ProtocolInfo{pInfoConfig} <- mkProtocolInfo args
+    absurd <$> ImmDBServer.run immDBDir sockAddr pInfoConfig
+
+data Opts = Opts {
+    immDBDir   :: FilePath
+  , port       :: Socket.PortNumber
+  , configFile :: FilePath
+  }
+
+optsParser :: ParserInfo Opts
+optsParser =
+    info (helper <*> parse) $ fullDesc <> progDesc desc
+  where
+    desc = "Serve an ImmutableDB via ChainSync and BlockFetch"
+
+    parse = do
+      immDBDir <- strOption $ mconcat
+        [ long "db"
+        , help "Path to the ImmutableDB"
+        , metavar "PATH"
+        ]
+      port <- option auto $ mconcat
+        [ long "port"
+        , help "Port to serve on"
+        , value 3001
+        ]
+      configFile <- strOption $ mconcat
+        [ long "config"
+        , help "Path to config file, in the same format as for the node or db-analyser"
+        , metavar "PATH"
+        ]
+      pure Opts {immDBDir, port, configFile}

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -463,6 +463,8 @@ library cardano-tools
     Cardano.Tools.DBSynthesizer.Orphans
     Cardano.Tools.DBSynthesizer.Run
     Cardano.Tools.DBSynthesizer.Types
+    Cardano.Tools.ImmDBServer.Diffusion
+    Cardano.Tools.ImmDBServer.MiniProtocols
 
   other-modules:
     Cardano.Api.Key
@@ -508,12 +510,16 @@ library cardano-tools
     , fs-api
     , microlens
     , mtl                            >=2.2   && <2.3
+    , network
     , nothunks
     , ouroboros-consensus            >=0.5   && <0.7
     , ouroboros-consensus-cardano
     , ouroboros-consensus-diffusion  ^>=0.5
     , ouroboros-consensus-protocol   ^>=0.5
+    , ouroboros-network
     , ouroboros-network-api
+    , ouroboros-network-framework
+    , ouroboros-network-protocols
     , serialise                      >=0.2   && <0.3
     , text                           >=1.2   && <1.3
     , text-builder
@@ -544,6 +550,17 @@ executable db-synthesizer
     , ouroboros-consensus
 
   other-modules:  DBSynthesizer.Parsers
+
+executable immdb-server
+  import:         common-exe
+  hs-source-dirs: app
+  main-is:        immdb-server.hs
+  build-depends:
+    , base
+    , network
+    , optparse-applicative
+    , ouroboros-consensus
+    , ouroboros-consensus-cardano:cardano-tools
 
 test-suite tools-test
   import:         common-test

--- a/ouroboros-consensus-cardano/src/tools/Cardano/Tools/ImmDBServer/Diffusion.hs
+++ b/ouroboros-consensus-cardano/src/tools/Cardano/Tools/ImmDBServer/Diffusion.hs
@@ -1,0 +1,108 @@
+{-# LANGUAGE BlockArguments      #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.Tools.ImmDBServer.Diffusion (run) where
+
+import           Cardano.Tools.ImmDBServer.MiniProtocols (immDBServer)
+import           Control.Tracer
+import qualified Data.ByteString.Lazy as BL
+import           Data.Functor.Contravariant ((>$<))
+import           Data.Void (Void)
+import           Network.Socket (SockAddr (..))
+import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.Config
+import           Ouroboros.Consensus.Config.SupportsNode
+import           Ouroboros.Consensus.Node.InitStorage
+                     (NodeInitStorage (nodeCheckIntegrity, nodeImmutableDbChunkInfo))
+import           Ouroboros.Consensus.Node.NetworkProtocolVersion
+import           Ouroboros.Consensus.Node.Run (SerialiseNodeToNodeConstraints)
+import           Ouroboros.Consensus.Storage.ImmutableDB (ImmutableDbArgs (..))
+import qualified Ouroboros.Consensus.Storage.ImmutableDB as ImmutableDB
+import           Ouroboros.Consensus.Util
+import           Ouroboros.Consensus.Util.IOLike
+import           Ouroboros.Consensus.Util.ResourceRegistry
+import           Ouroboros.Network.ErrorPolicy (nullErrorPolicies)
+import           Ouroboros.Network.IOManager (withIOManager)
+import           Ouroboros.Network.Mux
+import qualified Ouroboros.Network.NodeToNode as N2N
+import           Ouroboros.Network.PeerSelection.PeerSharing
+                     (decodeRemoteAddress, encodeRemoteAddress)
+import qualified Ouroboros.Network.Snocket as Snocket
+import           Ouroboros.Network.Socket (configureSocket)
+import           System.FS.API (SomeHasFS (..))
+import           System.FS.API.Types (MountPoint (MountPoint))
+import           System.FS.IO (ioHasFS)
+
+-- | Glue code for using just the bits from the Diffusion Layer that we need in
+-- this context.
+serve ::
+     SockAddr
+  -> N2N.Versions N2N.NodeToNodeVersion N2N.NodeToNodeVersionData
+       (OuroborosApplication 'ResponderMode SockAddr BL.ByteString IO Void ())
+  -> IO Void
+serve sockAddr application = withIOManager \iocp -> do
+    let sn     = Snocket.socketSnocket iocp
+        family = Snocket.addrFamily sn sockAddr
+    bracket (Snocket.open sn family) (Snocket.close sn) \socket -> do
+      networkMutableState <- N2N.newNetworkMutableState
+      configureSocket socket (Just sockAddr)
+      Snocket.bind sn socket sockAddr
+      Snocket.listen sn socket
+      N2N.withServer
+        sn
+        N2N.nullNetworkServerTracers {
+          N2N.nstHandshakeTracer   = show >$< stdoutTracer
+        , N2N.nstErrorPolicyTracer = show >$< stdoutTracer
+        }
+        networkMutableState
+        acceptedConnectionsLimit
+        socket
+        application
+        nullErrorPolicies
+  where
+    acceptedConnectionsLimit = N2N.AcceptedConnectionsLimit {
+          N2N.acceptedConnectionsHardLimit = maxBound
+        , N2N.acceptedConnectionsSoftLimit = maxBound
+        , N2N.acceptedConnectionsDelay     = 0
+        }
+
+run ::
+     forall blk.
+     ( GetPrevHash blk
+     , ShowProxy blk
+     , SupportedNetworkProtocolVersion blk
+     , SerialiseNodeToNodeConstraints blk
+     , ImmutableDB.ImmutableDbSerialiseConstraints blk
+     , NodeInitStorage blk
+     , ConfigSupportsNode blk
+     )
+  => FilePath
+  -> SockAddr
+  -> TopLevelConfig blk
+  -> IO Void
+run immDBDir sockAddr cfg = withRegistry \registry ->
+    ImmutableDB.withDB
+      (ImmutableDB.openDB (immDBArgs registry) runWithTempRegistry)
+      \immDB -> serve sockAddr $ immDBServer
+        codecCfg
+        encodeRemoteAddress
+        decodeRemoteAddress
+        immDB
+        networkMagic
+  where
+    immDBArgs registry = defaultImmDBArgs {
+          immCheckIntegrity = nodeCheckIntegrity storageCfg
+        , immChunkInfo      = nodeImmutableDbChunkInfo storageCfg
+        , immCodecConfig    = codecCfg
+        , immRegistry       = registry
+        }
+      where
+        defaultImmDBArgs =
+          ImmutableDB.defaultArgs $ SomeHasFS $ ioHasFS $ MountPoint immDBDir
+
+    codecCfg     = configCodec cfg
+    storageCfg   = configStorage cfg
+    networkMagic = getNetworkMagic . configBlock $ cfg

--- a/ouroboros-consensus-cardano/src/tools/Cardano/Tools/ImmDBServer/MiniProtocols.hs
+++ b/ouroboros-consensus-cardano/src/tools/Cardano/Tools/ImmDBServer/MiniProtocols.hs
@@ -1,0 +1,228 @@
+{-# LANGUAGE BlockArguments      #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE DeriveAnyClass      #-}
+{-# LANGUAGE DerivingStrategies  #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE PolyKinds           #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+
+-- | Implement ChainSync and BlockFetch servers on top of just the immutable DB.
+module Cardano.Tools.ImmDBServer.MiniProtocols (immDBServer) where
+
+import qualified Codec.CBOR.Decoding as CBOR
+import qualified Codec.CBOR.Encoding as CBOR
+import           Control.Monad (forever)
+import           Control.Tracer
+import           Data.Bifunctor (bimap)
+import qualified Data.ByteString.Lazy as BL
+import           Data.Functor ((<&>))
+import qualified Data.Map.Strict as Map
+import           Data.Typeable (Typeable)
+import           Data.Void (Void)
+import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.MiniProtocol.BlockFetch.Server
+                     (blockFetchServer')
+import           Ouroboros.Consensus.MiniProtocol.ChainSync.Server
+                     (chainSyncServerForFollower)
+import           Ouroboros.Consensus.Network.NodeToNode (Codecs (..))
+import qualified Ouroboros.Consensus.Network.NodeToNode as Consensus.N2N
+import           Ouroboros.Consensus.Node.NetworkProtocolVersion
+import           Ouroboros.Consensus.Node.Run (SerialiseNodeToNodeConstraints)
+import           Ouroboros.Consensus.Storage.ChainDB.API (Follower (..))
+import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
+import           Ouroboros.Consensus.Storage.Common
+import           Ouroboros.Consensus.Storage.ImmutableDB.API (ImmutableDB)
+import qualified Ouroboros.Consensus.Storage.ImmutableDB.API as ImmutableDB
+import           Ouroboros.Consensus.Util
+import           Ouroboros.Consensus.Util.IOLike
+import           Ouroboros.Consensus.Util.ResourceRegistry
+import           Ouroboros.Network.Block (ChainUpdate (..), Tip (..))
+import           Ouroboros.Network.Driver (runPeer)
+import           Ouroboros.Network.KeepAlive (keepAliveServer)
+import           Ouroboros.Network.Magic (NetworkMagic)
+import           Ouroboros.Network.Mux (MiniProtocol (..), MuxMode (..),
+                     MuxPeer (..), OuroborosApplication (..),
+                     RunMiniProtocol (..))
+import           Ouroboros.Network.NodeToNode (NodeToNodeVersionData (..),
+                     Versions (..))
+import qualified Ouroboros.Network.NodeToNode as N2N
+import           Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing (..))
+import           Ouroboros.Network.Protocol.BlockFetch.Server
+import           Ouroboros.Network.Protocol.ChainSync.Server
+import           Ouroboros.Network.Protocol.Handshake.Version (Version (..))
+import           Ouroboros.Network.Protocol.KeepAlive.Server
+                     (keepAliveServerPeer)
+
+immDBServer ::
+     forall m blk addr.
+     ( IOLike m
+     , HasHeader blk
+     , ShowProxy blk
+     , SerialiseNodeToNodeConstraints blk
+     , SupportedNetworkProtocolVersion blk
+     )
+  => CodecConfig blk
+  -> (addr -> CBOR.Encoding)
+  -> (forall s . CBOR.Decoder s addr)
+  -> ImmutableDB m blk
+  -> NetworkMagic
+  -> Versions NodeToNodeVersion NodeToNodeVersionData
+       (OuroborosApplication 'ResponderMode addr BL.ByteString m Void ())
+immDBServer codecCfg encAddr decAddr immDB networkMagic = do
+    forAllVersions application
+  where
+    forAllVersions ::
+         (NodeToNodeVersion -> BlockNodeToNodeVersion blk -> r)
+      -> Versions NodeToNodeVersion NodeToNodeVersionData r
+    forAllVersions mkR =
+          Versions
+        $ Map.mapWithKey mkVersion
+        $ supportedNodeToNodeVersions (Proxy @blk)
+      where
+        mkVersion version blockVersion = Version {
+            versionApplication = const $ mkR version blockVersion
+          , versionData        = NodeToNodeVersionData {
+                networkMagic
+              , diffusionMode = N2N.InitiatorOnlyDiffusionMode
+              , peerSharing   = NoPeerSharing
+              }
+          }
+
+    application ::
+         NodeToNodeVersion
+      -> BlockNodeToNodeVersion blk
+      -> OuroborosApplication 'ResponderMode addr BL.ByteString m Void ()
+    application version blockVersion =
+        OuroborosApplication \_connId _controlMessageSTM -> miniprotocols
+      where
+        miniprotocols =
+            [ mkMiniProtocol
+                N2N.keepAliveMiniProtocolNum
+                N2N.keepAliveProtocolLimits
+                keepAliveProt
+            , mkMiniProtocol
+                N2N.chainSyncMiniProtocolNum
+                N2N.chainSyncProtocolLimits
+                chainSyncProt
+            , mkMiniProtocol
+                N2N.blockFetchMiniProtocolNum
+                N2N.blockFetchProtocolLimits
+                blockFetchProt
+            , mkMiniProtocol
+                N2N.txSubmissionMiniProtocolNum
+                N2N.txSubmissionProtocolLimits
+                txSubmissionProt
+            ]
+          where
+            Consensus.N2N.Codecs {
+                cKeepAliveCodec
+              , cChainSyncCodecSerialised
+              , cBlockFetchCodecSerialised
+              } =
+              Consensus.N2N.defaultCodecs codecCfg blockVersion encAddr decAddr version
+
+            keepAliveProt  =
+                MuxPeer nullTracer cKeepAliveCodec
+              $ keepAliveServerPeer keepAliveServer
+            chainSyncProt  =
+                MuxPeerRaw \channel ->
+                withRegistry
+              $ runPeer nullTracer cChainSyncCodecSerialised channel
+              . chainSyncServerPeer
+              . chainSyncServer immDB ChainDB.getSerialisedHeaderWithPoint
+            blockFetchProt =
+                MuxPeerRaw \channel ->
+                withRegistry
+              $ runPeer nullTracer cBlockFetchCodecSerialised channel
+              . blockFetchServerPeer
+              . blockFetchServer immDB ChainDB.getSerialisedBlockWithPoint
+            txSubmissionProt =
+                -- never reply, there is no timeout
+                MuxPeerRaw \_channel -> forever $ threadDelay 10
+
+        mkMiniProtocol miniProtocolNum limits proto = MiniProtocol {
+            miniProtocolNum
+          , miniProtocolLimits = limits N2N.defaultMiniProtocolParameters
+          , miniProtocolRun    = ResponderProtocolOnly proto
+          }
+
+chainSyncServer ::
+     forall m blk a. (IOLike m, HasHeader blk)
+  => ImmutableDB m blk
+  -> BlockComponent blk (ChainDB.WithPoint blk a)
+  -> ResourceRegistry m
+  -> ChainSyncServer a (Point blk) (Tip blk) m ()
+chainSyncServer immDB blockComponent registry = ChainSyncServer $ do
+    follower <- newImmutableDBFollower
+    runChainSyncServer $
+      chainSyncServerForFollower nullTracer getImmutableTip follower
+  where
+    newImmutableDBFollower :: m (Follower m blk (ChainDB.WithPoint blk a))
+    newImmutableDBFollower = do
+        varIterator <-
+          newTVarIO =<< ImmutableDB.streamAll immDB registry blockComponent
+
+        let followerInstructionBlocking = do
+              iterator <- readTVarIO varIterator
+              ImmutableDB.iteratorNext iterator >>= \case
+                ImmutableDB.IteratorExhausted -> do
+                  ImmutableDB.iteratorClose iterator
+                  throwIO ReachedImmutableTip
+                ImmutableDB.IteratorResult a  ->
+                  pure $ AddBlock a
+
+            followerClose = ImmutableDB.iteratorClose =<< readTVarIO varIterator
+
+            followerForward []         = pure Nothing
+            followerForward (pt : pts) =
+              ImmutableDB.streamAfterPoint immDB registry blockComponent pt >>= \case
+                Left _         -> followerForward pts
+                Right iterator -> do
+                  followerClose
+                  atomically $ writeTVar varIterator iterator
+                  pure $ Just pt
+
+        pure Follower {
+            followerInstruction = Just <$> followerInstructionBlocking
+          , followerInstructionBlocking
+          , followerForward
+          , followerClose
+          }
+
+    getImmutableTip :: STM m (Tip blk)
+    getImmutableTip = ImmutableDB.getTip immDB <&> \case
+        Origin        -> TipGenesis
+        NotOrigin tip -> Tip tipSlotNo tipHash tipBlockNo
+          where
+            ImmutableDB.Tip tipSlotNo _ tipBlockNo tipHash = tip
+
+blockFetchServer ::
+     forall m blk a. (IOLike m, StandardHash blk, Typeable blk)
+  => ImmutableDB m blk
+  -> BlockComponent blk (ChainDB.WithPoint blk a)
+  -> ResourceRegistry m
+  -> BlockFetchServer a (Point blk) m ()
+blockFetchServer immDB blockComponent registry =
+    blockFetchServer' nullTracer stream
+  where
+    stream from to =
+            bimap convertError convertIterator
+        <$> ImmutableDB.stream immDB registry blockComponent from to
+
+    convertError = ChainDB.MissingBlock . ImmutableDB.missingBlockPoint
+    convertIterator iterator = ChainDB.Iterator {
+          ChainDB.iteratorNext  = ImmutableDB.iteratorNext iterator <&> \case
+            ImmutableDB.IteratorResult b  -> ChainDB.IteratorResult b
+            ImmutableDB.IteratorExhausted -> ChainDB.IteratorExhausted
+        , ChainDB.iteratorClose = ImmutableDB.iteratorClose iterator
+        }
+
+data ImmDBServerException =
+    ReachedImmutableTip
+  | TriedToFetchGenesis
+  deriving stock (Show)
+  deriving anyclass (Exception)


### PR DESCRIPTION
Small tool that serves an existing ImmDB via BlockFetch and ChainSync.

Useful for not running OOM when running syncing experiements on one local machine.

This is a rebased version of https://github.com/input-output-hk/ouroboros-network/pull/4339 with all comments addressed; in particular, we are now reusing the actual miniprotocol server definitions (see the first two commits).