### PR TITLE
Update to `diff-containers-1.0.0.0` and `fingertree-rm-1.0.0.0`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -16,7 +16,7 @@ index-state:
   -- Bump this if you need newer packages from Hackage
   , hackage.haskell.org 2023-04-24T00:00:00Z
   -- Bump this if you need newer packages from CHaP
-  , cardano-haskell-packages 2023-04-24T15:31:00Z
+  , cardano-haskell-packages 2023-05-09T09:56:37Z
 
 packages:
   ./ouroboros-consensus

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1682321185,
-        "narHash": "sha256-2kCTrJo3IvlofRDofyCPKyLHlKgZU3YKCBEwJMStVoo=",
+        "lastModified": 1683628047,
+        "narHash": "sha256-p8H6fHmcTlerNB/SxHoWjXR5A0+rFUXJb39jP2jon1g=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "8fb4cb386d61c86348905ec9de64bf9810c06a74",
+        "rev": "94cad9a3163ffc48b8d736ca9a448b4801b697e9",
         "type": "github"
       },
       "original": {

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -134,7 +134,7 @@ library
     , containers                    >=0.5   && <0.7
     , cryptonite                    >=0.25  && <0.31
     , deepseq
-    , diff-containers
+    , diff-containers >= 1.0
     , formatting                    >=6.3   && <7.2
     , measures
     , microlens
@@ -442,7 +442,7 @@ test-suite cardano-test
     , cardano-testlib
     , cborg
     , containers
-    , diff-containers
+    , diff-containers >= 1.0
     , filepath
     , microlens
     , ouroboros-consensus-cardano

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -134,7 +134,7 @@ library
     , containers                    >=0.5   && <0.7
     , cryptonite                    >=0.25  && <0.31
     , deepseq
-    , diff-containers >= 1.0
+    , diff-containers               >=1.0
     , formatting                    >=6.3   && <7.2
     , measures
     , microlens
@@ -442,7 +442,7 @@ test-suite cardano-test
     , cardano-testlib
     , cborg
     , containers
-    , diff-containers >= 1.0
+    , diff-containers                                               >=1.0
     , filepath
     , microlens
     , ouroboros-consensus-cardano

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -147,7 +147,7 @@ library diffusion-testlib
     , cborg
     , containers
     , contra-tracer
-    , diff-containers
+    , diff-containers >= 1.0
     , fgl
     , fs-sim
     , graphviz

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -147,7 +147,7 @@ library diffusion-testlib
     , cborg
     , containers
     , contra-tracer
-    , diff-containers >= 1.0
+    , diff-containers                                               >=1.0
     , fgl
     , fs-sim
     , graphviz

--- a/ouroboros-consensus-diffusion/src/diffusion-testlib/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-diffusion/src/diffusion-testlib/Test/ThreadNet/Network.hs
@@ -51,7 +51,7 @@ import           Data.Either (isRight)
 import           Data.Functor.Identity (Identity)
 import qualified Data.List as List
 import qualified Data.List.NonEmpty as NE
-import           Data.Map.Diff.Strict.Internal (unsafeApplyDiff)
+import           Data.Map.Diff.Strict (applyDiff)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Set (Set)
@@ -619,7 +619,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
                 -- subtraction. When we revisit the range query implementation
                 -- we should remove this workaround.
                 fullUTxO <- unExtLedgerStateTables <$> doRangeQuery (RangeQuery Nothing (maxBound-1))
-                let f (DiffMK d) (ValuesMK m) = ValuesMK $ unsafeApplyDiff m d
+                let f (DiffMK d) (ValuesMK m) = ValuesMK $ applyDiff m d
                 pure $! zipOverLedgerTablesTicked f st fullUTxO
               pure $ isRight $ Exc.runExcept $ applyTx lcfg DoNotIntervene slot tx fullLedgerSt
 

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -354,19 +354,19 @@ library
     , containers                   >=0.5     && <0.7
     , contra-tracer
     , deepseq
-    , diff-containers >= 1.0
+    , diff-containers              >=1.0
     , filelock
-    , fingertree-rm >= 1.0
+    , fingertree-rm                >=1.0
     , fs-api
     , hashable
     , io-classes                   ^>=0.3
     , measures
+    , monoid-subclasses
     , mtl                          >=2.2     && <2.3
     , nothunks                     >=0.1.2   && <0.2
     , ouroboros-network-api
     , ouroboros-network-framework
     , ouroboros-network-mock
-    , monoid-subclasses
     , ouroboros-network-protocols  >=0.2
     , psqueues                     >=0.2.3   && <0.3
     , quiet                        >=0.2     && <0.3
@@ -679,9 +679,9 @@ test-suite storage-test
     , constraints
     , containers
     , contra-tracer
-    , diff-containers >= 1.0
+    , diff-containers                >=1.0
     , directory
-    , fingertree-rm >= 1.0
+    , fingertree-rm                  >=1.0
     , fs-api
     , fs-sim
     , generics-sop
@@ -690,16 +690,16 @@ test-suite storage-test
     , io-sim
     , mtl
     , nonempty-containers
-    , quickcheck-classes
-    , quickcheck-monoid-subclasses
     , nothunks
     , ouroboros-consensus
     , ouroboros-network-api
     , ouroboros-network-mock
     , pretty-show
     , QuickCheck
+    , quickcheck-classes
     , quickcheck-dynamic
     , quickcheck-lockstep
+    , quickcheck-monoid-subclasses
     , quickcheck-state-machine       >=0.7.2
     , random
     , serialise
@@ -736,7 +736,7 @@ benchmark mempool-bench
     , containers
     , contra-tracer
     , deepseq
-    , diff-containers >= 1.0
+    , diff-containers      >=1.0
     , directory
     , fs-api
     , mtl
@@ -764,7 +764,7 @@ benchmark backingstore-bench
     , consensus-testlib
     , containers
     , deepseq
-    , diff-containers >= 1.0
+    , diff-containers      >=1.0
     , directory
     , fs-api
     , io-classes

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -354,11 +354,10 @@ library
     , containers                   >=0.5     && <0.7
     , contra-tracer
     , deepseq
-    , diff-containers
+    , diff-containers >= 1.0
     , filelock
-    , fingertree-rm
+    , fingertree-rm >= 1.0
     , fs-api
-    , groups
     , hashable
     , io-classes                   ^>=0.3
     , measures
@@ -367,6 +366,7 @@ library
     , ouroboros-network-api
     , ouroboros-network-framework
     , ouroboros-network-mock
+    , monoid-subclasses
     , ouroboros-network-protocols  >=0.2
     , psqueues                     >=0.2.3   && <0.3
     , quiet                        >=0.2     && <0.3
@@ -679,9 +679,9 @@ test-suite storage-test
     , constraints
     , containers
     , contra-tracer
-    , diff-containers
+    , diff-containers >= 1.0
     , directory
-    , fingertree-rm
+    , fingertree-rm >= 1.0
     , fs-api
     , fs-sim
     , generics-sop
@@ -690,6 +690,8 @@ test-suite storage-test
     , io-sim
     , mtl
     , nonempty-containers
+    , quickcheck-classes
+    , quickcheck-monoid-subclasses
     , nothunks
     , ouroboros-consensus
     , ouroboros-network-api
@@ -701,7 +703,6 @@ test-suite storage-test
     , quickcheck-state-machine       >=0.7.2
     , random
     , serialise
-    , simple-semigroupoids
     , tasty
     , tasty-hunit
     , tasty-quickcheck
@@ -735,7 +736,7 @@ benchmark mempool-bench
     , containers
     , contra-tracer
     , deepseq
-    , diff-containers
+    , diff-containers >= 1.0
     , directory
     , fs-api
     , mtl
@@ -763,7 +764,7 @@ benchmark backingstore-bench
     , consensus-testlib
     , containers
     , deepseq
-    , diff-containers
+    , diff-containers >= 1.0
     , directory
     , fs-api
     , io-classes

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Tables/Utils.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Tables/Utils.hs
@@ -48,7 +48,6 @@ module Ouroboros.Consensus.Ledger.Tables.Utils (
   ) where
 
 import           Data.Map.Diff.Strict
-import           Data.Map.Diff.Strict.Internal
 import qualified Data.Map.Strict as Map
 import           Ouroboros.Consensus.Ledger.Tables
 import           Ouroboros.Consensus.Ticked
@@ -171,7 +170,7 @@ forgetLedgerTablesDiffsTicked = mapOverLedgerTablesTicked rawForgetDiffs
 -- Prepend diffs
 
 rawPrependDiffs ::
-     (Ord k, Eq v)
+     Ord k
   => DiffMK k v -- ^ Earlier differences
   -> DiffMK k v -- ^ Later differences
   -> DiffMK k v
@@ -193,7 +192,7 @@ rawApplyDiffs ::
   => ValuesMK k v -- ^ Values to which differences are applied
   -> DiffMK   k v -- ^ Differences to apply
   -> ValuesMK k v
-rawApplyDiffs (ValuesMK vals) (DiffMK diffs) = ValuesMK (unsafeApplyDiff vals diffs)
+rawApplyDiffs (ValuesMK vals) (DiffMK diffs) = ValuesMK (applyDiff vals diffs)
 
 applyLedgerTablesDiffs           ::       HasLedgerTables l =>              l ValuesMK ->         l DiffMK ->         l ValuesMK
 applyLedgerTablesDiffsTicked     :: HasTickedLedgerTables l =>              l ValuesMK -> Ticked1 l DiffMK -> Ticked1 l ValuesMK
@@ -225,7 +224,7 @@ rawAttachAndApplyDiffs ::
   => DiffMK     k v
   -> ValuesMK   k v
   -> TrackingMK k v
-rawAttachAndApplyDiffs (DiffMK d) (ValuesMK v) = TrackingMK (unsafeApplyDiff v d) d
+rawAttachAndApplyDiffs (DiffMK d) (ValuesMK v) = TrackingMK (applyDiff v d) d
 
 -- | Replace the tables in the first parameter with the tables of the second
 -- parameter after applying the differences in the first parameter to them
@@ -246,7 +245,7 @@ attachAndApplyDiffsTickedToTables =
     zipOverLedgerTablesTicked rawAttachAndApplyDiffs
 
 rawPrependTrackingDiffs ::
-      (Ord k, Eq v)
+      Ord k
    => TrackingMK k v
    -> TrackingMK k v
    -> TrackingMK k v
@@ -269,7 +268,7 @@ rawReapplyTracking ::
   => TrackingMK k v
   -> ValuesMK   k v
   -> TrackingMK k v
-rawReapplyTracking (TrackingMK _v d) (ValuesMK v) = TrackingMK (unsafeApplyDiff v d) d
+rawReapplyTracking (TrackingMK _v d) (ValuesMK v) = TrackingMK (applyDiff v d) d
 
 -- | Replace the tables in the first parameter with the tables of the second
 -- parameter after applying the differences in the first parameter to them

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/BackingStore/LMDB.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/BackingStore/LMDB.hs
@@ -217,10 +217,8 @@ writeLMDBTable (LMDBMK _ db) codecMK (DiffMK d) =
     lmdbWriteTable = void $ traverseDiffEntryWithKey_ go d
       where
         go k de = case de of
-          Delete _v           -> void $ Bridge.delete codecMK db k
-          Insert v            -> Bridge.put codecMK db k v
-          UnsafeAntiDelete _v -> error "Found anti-delete. See https://github.com/input-output-hk/anti-diffs/blob/main/diff-containers/README.md for an explanation why this should never happen"
-          UnsafeAntiInsert _v -> error "Found anti-insert. See https://github.com/input-output-hk/anti-diffs/blob/main/diff-containers/README.md for an explanation why this should never happen"
+          Delete _v -> void $ Bridge.delete codecMK db k
+          Insert v  -> Bridge.put codecMK db k v
 
 {-------------------------------------------------------------------------------
  Db state

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/DiffSeq.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/DiffSeq.hs
@@ -15,16 +15,17 @@
    the root measure is the total sum of all diffs in the sequence. The internal
    measure is used to keep track of sequence length and maximum slot numbers.
 
-   The diff datatype that we use forms a @'Group'@, which allows for relatively
-   efficient splitting of finger trees with respect to recomputing measures by
-   means of the @'invert'@ operation that the @'Group'@ type class requires.
-   Namely, if either the left or right part of the split is small in comparison
-   with the input sequence, then we can subtract the diffs in the smaller part
-   from the root measure of the input to (quickly) compute the root measure of
-   the /other/ part of the split. This is much faster than computing the root
-   measures from scratch by doing a linear-time pass over the elements of the
-   split parts, or a logarithmic-time pass over intermediate sums of diffs in
-   case we store cumulative diffs in the nodes of the finger tree.
+   The diff datatype that we use forms a cancellative monoid, which allows for
+   relatively efficient splitting of finger trees with respect to recomputing
+   measures by means of subtracting diffs using the 'stripPrefix' and
+   'stripSuffix' functions that cancellative monoids provide. Namely, if either
+   the left or right part of the split is small in comparison with the input
+   sequence, then we can subtract the diffs in the smaller part from the root
+   measure of the input to (quickly) compute the root measure of the /other/
+   part of the split. This is much faster than computing the root measures from
+   scratch by doing a linear-time pass over the elements of the split parts, or
+   a logarithmic-time pass over intermediate sums of diffs in case we store
+   cumulative diffs in the nodes of the finger tree.
 
    === Example of fast splits
 
@@ -55,8 +56,8 @@
    use the total sum of diffs nearly as often as we split or extend the diff
    sequence, this proved to be too costly. The single-instance root measure
    reduces the overhead of this "caching" of intermediate sums of diffs by only
-   using a single total sum of diffs, though augmented with an @'invert'@
-   operation to facilitate computing updated root measures.
+   using a single total sum of diffs, though augmented with 'stripPrefix' and
+   'stripSuffix' operations to facilitate computing updated root measures.
 
 -}
 module Ouroboros.Consensus.Storage.LedgerDB.DiffSeq (
@@ -120,8 +121,8 @@ newtype DiffSeq k v =
   deriving stock (Generic, Show, Eq)
   deriving anyclass (NoThunks)
 
--- The @'SlotNo'@ is not included in the root measure, since it is
--- not a @'Group'@ instance.
+-- The @'SlotNo'@ is not included in the root measure, since it is not a
+-- cancellative monoid.
 data RootMeasure k v = RootMeasure {
     -- | Cumulative length
     rmLength :: {-# UNPACK #-} !Length

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Init.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Init.hs
@@ -28,7 +28,7 @@ import           Codec.Serialise.Decoding (Decoder)
 import           Control.Monad.Except
 import           Control.Tracer
 import           Data.Functor.Contravariant ((>$<))
-import qualified Data.Map.Diff.Strict.Internal as Diff.Internal
+import qualified Data.Map.Diff.Strict as Diff
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import           Data.Word
@@ -392,7 +392,7 @@ newBackingStoreInitialiser tracer bss =
       -> DiffMK   k v
       -> ValuesMK k v
     applyDiff_ (ValuesMK values) (DiffMK diff) =
-      ValuesMK (Diff.Internal.unsafeApplyDiff values diff)
+      ValuesMK (Diff.applyDiff values diff)
 
 -- | The backing store selector
 data BackingStoreSelector m where

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/ReadsKeySets.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/ReadsKeySets.hs
@@ -23,7 +23,7 @@ module Ouroboros.Consensus.Storage.LedgerDB.ReadsKeySets (
   ) where
 
 import           Cardano.Slotting.Slot
-import           Data.Map.Diff.Strict.Internal (unsafeApplyDiffForKeys)
+import           Data.Map.Diff.Strict (applyDiffForKeys)
 import           Ouroboros.Consensus.Block.Abstract
 import           Ouroboros.Consensus.Ledger.Basics (IsLedger)
 import           Ouroboros.Consensus.Ledger.Tables
@@ -192,7 +192,7 @@ forwardTableKeySets' seqNo chdiffs = \(UnforwardedReadSets seqNo' values keys) -
       -> SeqDiffMK k v
       -> ValuesMK  k v
     forward (ValuesMK values) (KeysMK keys) (SeqDiffMK diffs) =
-      ValuesMK $ unsafeApplyDiffForKeys values keys (cumulativeDiff diffs)
+      ValuesMK $ applyDiffForKeys values keys (cumulativeDiff diffs)
 
 forwardTableKeySets ::
      HasLedgerTables l

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool.hs
@@ -754,7 +754,7 @@ withTestMempool setup@TestSetup {..} prop =
                                           origTables
                )
 
-        f :: (Ord k, Eq v) => ValuesMK k v -> TrackingMK k v
+        f :: Ord k => ValuesMK k v -> TrackingMK k v
         f (ValuesMK v) = TrackingMK v mempty
 
         mkErrMsg e =

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/HD/BackingStore.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/HD/BackingStore.hs
@@ -352,8 +352,6 @@ instance QC.Arbitrary v => QC.Arbitrary (Diff.DiffEntry v) where
     constr <- QC.elements [
         Diff.Insert
       , Diff.Delete
-      , Diff.UnsafeAntiInsert
-      , Diff.UnsafeAntiDelete
       ]
     constr <$> QC.arbitrary
 


### PR DESCRIPTION
# Description

Update the UTxO HD branch to use the latest version of the anti-diffs packages.