### PR TITLE
Add db-truncater tool, for truncating an ImmutableDB at a specified slot number

### DIFF
--- a/ouroboros-consensus-cardano/app/DBAnalyser/Parsers.hs
+++ b/ouroboros-consensus-cardano/app/DBAnalyser/Parsers.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE ApplicativeDo #-}
 {-# LANGUAGE CPP           #-}
 
-module DBAnalyser.Parsers (parseCmdLine) where
+module DBAnalyser.Parsers (parseCmdLine, blockTypeParser) where
 
 import           Cardano.Crypto (RequiresNetworkMagic (..))
 import           Cardano.Tools.DBAnalyser.Block.Byron

--- a/ouroboros-consensus-cardano/app/DBTruncater/Parsers.hs
+++ b/ouroboros-consensus-cardano/app/DBTruncater/Parsers.hs
@@ -1,11 +1,9 @@
-module DBTruncater.Parsers
-  ( commandLineParser
-  ) where
+module DBTruncater.Parsers (commandLineParser) where
 
-import Ouroboros.Consensus.Block.Abstract
-import Options.Applicative
-import Cardano.Tools.DBTruncater.Types
-import DBAnalyser.Parsers
+import           Cardano.Tools.DBTruncater.Types
+import           DBAnalyser.Parsers
+import           Options.Applicative
+import           Ouroboros.Consensus.Block.Abstract
 
 commandLineParser :: Parser DBTruncaterConfig
 commandLineParser = DBTruncaterConfig
@@ -15,7 +13,7 @@ commandLineParser = DBTruncaterConfig
   <*> parseVerbose
   where
     parseChainDBPath = strOption $
-      mconcat 
+      mconcat
         [ long "db"
         , help "Path of the chain DB"
         , metavar "PATH"
@@ -26,5 +24,5 @@ parseTruncatePoint :: Parser TruncatePoint
 parseTruncatePoint = TruncatePoint <$> slotNoOption
 
 slotNoOption :: Parser SlotNo
-slotNoOption = 
+slotNoOption =
   SlotNo <$> option auto (long "truncate-point" <> metavar "SLOT_NUMBER")

--- a/ouroboros-consensus-cardano/app/DBTruncater/Parsers.hs
+++ b/ouroboros-consensus-cardano/app/DBTruncater/Parsers.hs
@@ -21,10 +21,8 @@ commandLineParser = DBTruncaterConfig
     parseVerbose = switch (long "verbose" <> help "Enable verbose logging")
 
 parseTruncateAfter :: Parser TruncateAfter
-parseTruncateAfter = asum
-  [ TruncateAfterSlot <$> slotNoOption
-  , TruncateAfterBlock <$> blockNoOption
-  ]
+parseTruncateAfter =
+  fmap TruncateAfterSlot slotNoOption <|> fmap TruncateAfterBlock blockNoOption
 
 slotNoOption :: Parser SlotNo
 slotNoOption =

--- a/ouroboros-consensus-cardano/app/DBTruncater/Parsers.hs
+++ b/ouroboros-consensus-cardano/app/DBTruncater/Parsers.hs
@@ -8,7 +8,7 @@ import           Ouroboros.Consensus.Block.Abstract
 commandLineParser :: Parser DBTruncaterConfig
 commandLineParser = DBTruncaterConfig
   <$> parseChainDBPath
-  <*> parseTruncatePoint
+  <*> parseTruncateAfter
   <*> blockTypeParser
   <*> parseVerbose
   where
@@ -20,9 +20,28 @@ commandLineParser = DBTruncaterConfig
         ]
     parseVerbose = switch (long "verbose" <> help "Enable verbose logging")
 
-parseTruncatePoint :: Parser TruncatePoint
-parseTruncatePoint = TruncatePoint <$> slotNoOption
+parseTruncateAfter :: Parser TruncateAfter
+parseTruncateAfter = asum
+  [ TruncateAfterSlot <$> slotNoOption
+  , TruncateAfterBlock <$> blockNoOption
+  ]
 
 slotNoOption :: Parser SlotNo
 slotNoOption =
-  SlotNo <$> option auto (long "truncate-point" <> metavar "SLOT_NUMBER")
+    SlotNo <$> option auto mods
+  where
+    mods = mconcat
+      [ long "truncate-after-slot"
+      , metavar "SLOT_NUMBER"
+      , help "The slot number of the intended new tip of the chain after truncation"
+      ]
+
+blockNoOption :: Parser BlockNo
+blockNoOption =
+    BlockNo <$> option auto mods
+  where
+    mods = mconcat
+      [ long "truncate-after-block"
+      , metavar "BLOCK_NUMBER"
+      , help "The block number of the intended new tip of the chain after truncation"
+      ]

--- a/ouroboros-consensus-cardano/app/DBTruncater/Parsers.hs
+++ b/ouroboros-consensus-cardano/app/DBTruncater/Parsers.hs
@@ -1,0 +1,30 @@
+module DBTruncater.Parsers
+  ( commandLineParser
+  ) where
+
+import Ouroboros.Consensus.Block.Abstract
+import Options.Applicative
+import Cardano.Tools.DBTruncater.Types
+import DBAnalyser.Parsers
+
+commandLineParser :: Parser DBTruncaterConfig
+commandLineParser = DBTruncaterConfig
+  <$> parseChainDBPath
+  <*> parseTruncatePoint
+  <*> blockTypeParser
+  <*> parseVerbose
+  where
+    parseChainDBPath = strOption $
+      mconcat 
+        [ long "db"
+        , help "Path of the chain DB"
+        , metavar "PATH"
+        ]
+    parseVerbose = switch (long "verbose" <> help "Enable verbose logging")
+
+parseTruncatePoint :: Parser TruncatePoint
+parseTruncatePoint = TruncatePoint <$> slotNoOption
+
+slotNoOption :: Parser SlotNo
+slotNoOption = 
+  SlotNo <$> option auto (long "truncate-point" <> metavar "SLOT_NUMBER")

--- a/ouroboros-consensus-cardano/app/db-truncater.hs
+++ b/ouroboros-consensus-cardano/app/db-truncater.hs
@@ -1,0 +1,23 @@
+module Main (main) where
+
+import Prelude hiding (truncate)
+import Cardano.Tools.DBTruncater.Run
+import Cardano.Tools.DBAnalyser.Types (BlockType(..))
+import Cardano.Tools.DBTruncater.Types 
+import qualified DBTruncater.Parsers as DBTruncater
+import Options.Applicative (execParser, info, helper, fullDesc, progDesc, (<**>))
+import Ouroboros.Consensus.Storage.ImmutableDB.Impl ()
+
+main :: IO ()
+main = do
+  config <- getCommandLineConfig
+  case blockType config of
+    CardanoBlock args -> truncate config args
+    ByronBlock args -> truncate config args
+    ShelleyBlock args -> truncate config args
+
+getCommandLineConfig :: IO DBTruncaterConfig
+getCommandLineConfig = execParser opts
+  where
+    opts = info (DBTruncater.commandLineParser <**> helper)
+      (fullDesc <> progDesc "Utility for truncating an ImmutableDB")

--- a/ouroboros-consensus-cardano/app/db-truncater.hs
+++ b/ouroboros-consensus-cardano/app/db-truncater.hs
@@ -1,19 +1,20 @@
 module Main (main) where
 
-import Prelude hiding (truncate)
-import Cardano.Tools.DBTruncater.Run
-import Cardano.Tools.DBAnalyser.Types (BlockType(..))
-import Cardano.Tools.DBTruncater.Types 
+import           Cardano.Tools.DBAnalyser.Types (BlockType (..))
+import           Cardano.Tools.DBTruncater.Run
+import           Cardano.Tools.DBTruncater.Types
 import qualified DBTruncater.Parsers as DBTruncater
-import Options.Applicative (execParser, info, helper, fullDesc, progDesc, (<**>))
-import Ouroboros.Consensus.Storage.ImmutableDB.Impl ()
+import           Options.Applicative (execParser, fullDesc, helper, info,
+                     progDesc, (<**>))
+import           Ouroboros.Consensus.Storage.ImmutableDB.Impl ()
+import           Prelude hiding (truncate)
 
 main :: IO ()
 main = do
   config <- getCommandLineConfig
   case blockType config of
     CardanoBlock args -> truncate config args
-    ByronBlock args -> truncate config args
+    ByronBlock args   -> truncate config args
     ShelleyBlock args -> truncate config args
 
 getCommandLineConfig :: IO DBTruncaterConfig

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -463,6 +463,8 @@ library cardano-tools
     Cardano.Tools.DBSynthesizer.Orphans
     Cardano.Tools.DBSynthesizer.Run
     Cardano.Tools.DBSynthesizer.Types
+    Cardano.Tools.DBTruncater.Run
+    Cardano.Tools.DBTruncater.Types
     Cardano.Tools.ImmDBServer.Diffusion
     Cardano.Tools.ImmDBServer.MiniProtocols
 
@@ -550,6 +552,21 @@ executable db-synthesizer
     , ouroboros-consensus
 
   other-modules:  DBSynthesizer.Parsers
+
+executable db-truncater
+  import:         common-exe
+  hs-source-dirs: app
+  main-is:        db-truncater.hs
+  build-depends:
+    , base
+    , cardano-crypto-wrapper
+    , ouroboros-consensus
+    , optparse-applicative
+    , ouroboros-consensus-cardano:{ouroboros-consensus-cardano, cardano-tools}
+
+  other-modules:
+    DBAnalyser.Parsers,
+    DBTruncater.Parsers,
 
 executable immdb-server
   import:         common-exe

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -560,13 +560,13 @@ executable db-truncater
   build-depends:
     , base
     , cardano-crypto-wrapper
-    , ouroboros-consensus
     , optparse-applicative
+    , ouroboros-consensus
     , ouroboros-consensus-cardano:{ouroboros-consensus-cardano, cardano-tools}
 
   other-modules:
-    DBAnalyser.Parsers,
-    DBTruncater.Parsers,
+    DBAnalyser.Parsers
+    DBTruncater.Parsers
 
 executable immdb-server
   import:         common-exe

--- a/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBTruncater/Run.hs
+++ b/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBTruncater/Run.hs
@@ -29,7 +29,7 @@ import           Prelude hiding (truncate)
 import           System.IO
 
 truncate ::
-     forall block . (Node.RunNode block, HasProtocolInfo block)
+     forall block. (Node.RunNode block, HasProtocolInfo block)
   => DBTruncaterConfig
   -> Args block
   -> IO ()
@@ -62,8 +62,8 @@ truncate DBTruncaterConfig{ dbDir, truncateAfter, verbose } args = do
         Nothing ->
           putStrLn $ mconcat
             [ "Unable to find a truncate point. This is likely because the tip "
-            , "of the ImmutableDB has a slot number less than the intended "
-            , "truncate point"
+            , "of the ImmutableDB has a slot number or block number less than "
+            , "the intended truncate point"
             ]
         Just (header, isEBB) -> do
           let HeaderFields slotNo blockNo hash = getHeaderFields header
@@ -79,7 +79,7 @@ truncate DBTruncaterConfig{ dbDir, truncateAfter, verbose } args = do
 -- | Given a 'TruncateAfter' (either a slot number or a block number), and an
 -- iterator, find the last block whose slot or block number is less than or
 -- equal to the intended new chain tip.
-findNewTip :: forall m blk c .
+findNewTip :: forall m blk c.
               (HasHeader (Header blk), Monad m)
            => TruncateAfter
            -> Iterator m blk (Header blk, c)

--- a/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBTruncater/Run.hs
+++ b/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBTruncater/Run.hs
@@ -1,8 +1,8 @@
+{-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE ViewPatterns        #-}
-{-# LANGUAGE FlexibleContexts    #-}
 
 module Cardano.Tools.DBTruncater.Run (truncate) where
 
@@ -12,8 +12,8 @@ import           Cardano.Tools.DBTruncater.Types
 import           Control.Monad
 import           Control.Tracer
 import           Data.Functor.Identity
-import           Ouroboros.Consensus.Block.Abstract (Header, HasHeader, HeaderFields (..),
-                     getHeaderFields)
+import           Ouroboros.Consensus.Block.Abstract (HasHeader, Header,
+                     HeaderFields (..), getHeaderFields)
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Node as Node
 import           Ouroboros.Consensus.Node.InitStorage as Node
@@ -89,7 +89,7 @@ findNewTip target iter =
   where
     acceptable (getHeaderFields -> HeaderFields slotNo blockNo _, _) = do
       case target of
-        TruncateAfterSlot s -> slotNo <= s
+        TruncateAfterSlot s  -> slotNo <= s
         TruncateAfterBlock b -> blockNo <= b
     go acc =
       ImmutableDB.iteratorNext iter >>= \case

--- a/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBTruncater/Run.hs
+++ b/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBTruncater/Run.hs
@@ -1,0 +1,105 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.Tools.DBTruncater.Run ( truncate ) where
+
+import Control.Monad
+import Cardano.Slotting.Slot (WithOrigin(..), SlotNo)
+import Cardano.Tools.DBAnalyser.HasAnalysis
+import Cardano.Tools.DBTruncater.Types
+import Control.Tracer
+import Data.Functor.Identity
+import Ouroboros.Consensus.Block.Abstract (HeaderFields(..), getBlockHeaderFields)
+import Ouroboros.Consensus.Config
+import Ouroboros.Consensus.Node as Node
+import Ouroboros.Consensus.Node.InitStorage as Node
+import Ouroboros.Consensus.Storage.Common
+import Ouroboros.Consensus.Storage.ImmutableDB (ImmutableDB, Iterator, IteratorResult(..))
+import Ouroboros.Consensus.Storage.ImmutableDB.Impl
+import Ouroboros.Consensus.Util.IOLike
+import Ouroboros.Consensus.Util.ResourceRegistry (withRegistry, runWithTempRegistry)
+import Prelude hiding (truncate)
+import System.IO
+import qualified Ouroboros.Consensus.Storage.ImmutableDB as ImmutableDB
+
+truncate :: forall block .
+            ( Node.RunNode block, HasProtocolInfo block )
+         => DBTruncaterConfig -> Args block -> IO ()
+truncate DBTruncaterConfig{ dbDir, truncatePoint, verbose } args = do
+  withRegistry $ \registry -> do
+    lock <- mkLock
+    immutableDBTracer <- mkTracer lock verbose
+    ProtocolInfo {
+      pInfoConfig = config
+    } <- mkProtocolInfo args
+    let
+      TruncatePoint truncateSlotNo = truncatePoint
+      fs = Node.stdMkChainDbHasFS dbDir (RelativeMountPoint "immutable")
+      chunkInfo = Node.nodeImmutableDbChunkInfo (configStorage config)
+      immutableDBArgs :: ImmutableDbArgs Identity IO block
+      immutableDBArgs =
+        (ImmutableDB.defaultArgs fs)
+          { immTracer = immutableDBTracer
+          , immRegistry = registry
+          , immCheckIntegrity = nodeCheckIntegrity (configStorage config)
+          , immCodecConfig = configCodec config
+          , immChunkInfo = chunkInfo
+          }
+
+    withDB immutableDBArgs $ \(immutableDB, internal) -> do
+      iterator <- ImmutableDB.streamAll immutableDB registry
+        ((,,) <$> GetSlot <*> GetBlock <*> GetIsEBB)
+
+      -- Here we're specifically looking for the *first* "block" (i.e. real
+      -- block or EBB) of the latest slot with number less than the truncate
+      -- point.
+      mTruncatePoint <- findTruncatePoint truncateSlotNo iterator
+      case mTruncatePoint of
+        Nothing ->
+          putStrLn "Unable to find a truncate point. This is likely because the tip of the ImmutableDB has a slot number less than the intended truncate point"
+        Just (slotNo, block, isEBB) -> do
+          let HeaderFields _ blockNo hash = getBlockHeaderFields block
+              newTip = ImmutableDB.Tip slotNo isEBB blockNo hash
+          when verbose $ do
+            putStrLn "Truncating the ImmutableDB using the following block as the new tip:"
+            putStrLn $ "  " <> show newTip
+          deleteAfter internal (At newTip)
+
+findTruncatePoint :: Monad m => SlotNo -> Iterator m blk (SlotNo, b, c) -> m (Maybe (SlotNo, b, c))
+findTruncatePoint target iter = go Nothing
+  where
+    go acc =
+      ImmutableDB.iteratorNext iter >>= \case
+        IteratorExhausted -> do
+          ImmutableDB.iteratorClose iter
+          pure acc
+        IteratorResult new@(slotNo, _, _) -> do
+          if slotNo > target
+            then pure acc
+            else
+              case acc of
+                Just lastBlock@(lastSeenSlotNo, _, _) ->
+                  if slotNo > lastSeenSlotNo then go (Just new) else go (Just lastBlock)
+                Nothing ->
+                  go (Just new)
+
+mkLock :: MonadSTM m => m (StrictMVar m ())
+mkLock = newMVar ()
+
+mkTracer :: (Show a) => StrictMVar IO () -> Bool -> IO (Tracer IO a)
+mkTracer _ False = pure mempty
+mkTracer lock True = do
+  startTime <- getMonotonicTime
+  pure $ Tracer $ \ev -> do
+    bracket_ (takeMVar lock) (putMVar lock ()) $ do
+      traceTime <- getMonotonicTime
+      let diff = diffTime traceTime startTime
+      hPutStrLn stderr $ concat ["[", show diff, "] ", show ev]
+      hFlush stderr
+
+withDB :: ( Node.RunNode block, IOLike m )
+       => ImmutableDbArgs Identity m block
+       -> ((ImmutableDB m block, Internal m block) -> m a)
+       -> m a
+withDB immutableDBArgs = bracket (ImmutableDB.openDBInternal immutableDBArgs runWithTempRegistry) (ImmutableDB.closeDB . fst)

--- a/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBTruncater/Run.hs
+++ b/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBTruncater/Run.hs
@@ -11,7 +11,7 @@ import           Control.Monad
 import           Control.Tracer
 import           Data.Functor.Identity
 import           Ouroboros.Consensus.Block.Abstract (HeaderFields (..),
-                     getBlockHeaderFields)
+                     getHeaderFields)
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Node as Node
 import           Ouroboros.Consensus.Node.InitStorage as Node
@@ -52,7 +52,7 @@ truncate DBTruncaterConfig{ dbDir, truncatePoint, verbose } args = do
 
     withDB immutableDBArgs $ \(immutableDB, internal) -> do
       iterator <- ImmutableDB.streamAll immutableDB registry
-        ((,,) <$> GetSlot <*> GetBlock <*> GetIsEBB)
+        ((,,) <$> GetSlot <*> GetHeader <*> GetIsEBB)
 
       -- Here we're specifically looking for the *first* "block" (i.e. real
       -- block or EBB) of the latest slot with number less than the truncate
@@ -61,8 +61,8 @@ truncate DBTruncaterConfig{ dbDir, truncatePoint, verbose } args = do
       case mTruncatePoint of
         Nothing ->
           putStrLn "Unable to find a truncate point. This is likely because the tip of the ImmutableDB has a slot number less than the intended truncate point"
-        Just (slotNo, block, isEBB) -> do
-          let HeaderFields _ blockNo hash = getBlockHeaderFields block
+        Just (slotNo, header, isEBB) -> do
+          let HeaderFields _ blockNo hash = getHeaderFields header
               newTip = ImmutableDB.Tip slotNo isEBB blockNo hash
           when verbose $ do
             putStrLn "Truncating the ImmutableDB using the following block as the new tip:"

--- a/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBTruncater/Run.hs
+++ b/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBTruncater/Run.hs
@@ -1,27 +1,30 @@
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Cardano.Tools.DBTruncater.Run ( truncate ) where
+module Cardano.Tools.DBTruncater.Run (truncate) where
 
-import Control.Monad
-import Cardano.Slotting.Slot (WithOrigin(..), SlotNo)
-import Cardano.Tools.DBAnalyser.HasAnalysis
-import Cardano.Tools.DBTruncater.Types
-import Control.Tracer
-import Data.Functor.Identity
-import Ouroboros.Consensus.Block.Abstract (HeaderFields(..), getBlockHeaderFields)
-import Ouroboros.Consensus.Config
-import Ouroboros.Consensus.Node as Node
-import Ouroboros.Consensus.Node.InitStorage as Node
-import Ouroboros.Consensus.Storage.Common
-import Ouroboros.Consensus.Storage.ImmutableDB (ImmutableDB, Iterator, IteratorResult(..))
-import Ouroboros.Consensus.Storage.ImmutableDB.Impl
-import Ouroboros.Consensus.Util.IOLike
-import Ouroboros.Consensus.Util.ResourceRegistry (withRegistry, runWithTempRegistry)
-import Prelude hiding (truncate)
-import System.IO
+import           Cardano.Slotting.Slot (SlotNo, WithOrigin (..))
+import           Cardano.Tools.DBAnalyser.HasAnalysis
+import           Cardano.Tools.DBTruncater.Types
+import           Control.Monad
+import           Control.Tracer
+import           Data.Functor.Identity
+import           Ouroboros.Consensus.Block.Abstract (HeaderFields (..),
+                     getBlockHeaderFields)
+import           Ouroboros.Consensus.Config
+import           Ouroboros.Consensus.Node as Node
+import           Ouroboros.Consensus.Node.InitStorage as Node
+import           Ouroboros.Consensus.Storage.Common
+import           Ouroboros.Consensus.Storage.ImmutableDB (ImmutableDB, Iterator,
+                     IteratorResult (..))
 import qualified Ouroboros.Consensus.Storage.ImmutableDB as ImmutableDB
+import           Ouroboros.Consensus.Storage.ImmutableDB.Impl
+import           Ouroboros.Consensus.Util.IOLike
+import           Ouroboros.Consensus.Util.ResourceRegistry (runWithTempRegistry,
+                     withRegistry)
+import           Prelude hiding (truncate)
+import           System.IO
 
 truncate :: forall block .
             ( Node.RunNode block, HasProtocolInfo block )
@@ -67,7 +70,8 @@ truncate DBTruncaterConfig{ dbDir, truncatePoint, verbose } args = do
           deleteAfter internal (At newTip)
 
 findTruncatePoint :: Monad m => SlotNo -> Iterator m blk (SlotNo, b, c) -> m (Maybe (SlotNo, b, c))
-findTruncatePoint target iter = go Nothing
+findTruncatePoint target iter =
+    go Nothing
   where
     go acc =
       ImmutableDB.iteratorNext iter >>= \case

--- a/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBTruncater/Run.hs
+++ b/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBTruncater/Run.hs
@@ -54,6 +54,10 @@ truncate DBTruncaterConfig{ dbDir, truncateAfter, verbose } args = do
           }
 
     withDB immutableDBArgs $ \(immutableDB, internal) -> do
+
+      -- At the moment, we're just running a linear search with streamAll to
+      -- find the correct block to truncate from, but we could in theory do this
+      -- more quickly by binary searching the chunks of the ImmutableDB.
       iterator <- ImmutableDB.streamAll immutableDB registry
         ((,) <$> GetHeader <*> GetIsEBB)
 

--- a/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBTruncater/Types.hs
+++ b/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBTruncater/Types.hs
@@ -10,6 +10,8 @@ data DBTruncaterConfig = DBTruncaterConfig {
   , verbose       :: Bool
   }
 
+-- | Slot or block number of the block intended to be the new tip of the chain
+-- after the ImmutableDB is truncated.
 data TruncateAfter
   = TruncateAfterSlot SlotNo
   | TruncateAfterBlock BlockNo

--- a/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBTruncater/Types.hs
+++ b/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBTruncater/Types.hs
@@ -1,4 +1,7 @@
-module Cardano.Tools.DBTruncater.Types (module Cardano.Tools.DBTruncater.Types) where
+module Cardano.Tools.DBTruncater.Types (
+    DBTruncaterConfig (..)
+  , TruncateAfter (..)
+  ) where
 
 import           Cardano.Tools.DBAnalyser.Types
 import           Ouroboros.Consensus.Block.Abstract

--- a/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBTruncater/Types.hs
+++ b/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBTruncater/Types.hs
@@ -1,0 +1,16 @@
+module Cardano.Tools.DBTruncater.Types (
+    module Cardano.Tools.DBTruncater.Types
+  ) where
+
+import Cardano.Tools.DBAnalyser.Types
+import Ouroboros.Consensus.Block.Abstract
+
+data DBTruncaterConfig = DBTruncaterConfig {
+    dbDir :: FilePath
+  , truncatePoint :: TruncatePoint
+  , blockType :: BlockType
+  , verbose :: Bool
+  }
+
+newtype TruncatePoint = TruncatePoint SlotNo
+  deriving (Show, Eq)

--- a/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBTruncater/Types.hs
+++ b/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBTruncater/Types.hs
@@ -5,10 +5,12 @@ import           Ouroboros.Consensus.Block.Abstract
 
 data DBTruncaterConfig = DBTruncaterConfig {
     dbDir         :: FilePath
-  , truncatePoint :: TruncatePoint
+  , truncateAfter :: TruncateAfter
   , blockType     :: BlockType
   , verbose       :: Bool
   }
 
-newtype TruncatePoint = TruncatePoint SlotNo
+data TruncateAfter
+  = TruncateAfterSlot SlotNo
+  | TruncateAfterBlock BlockNo
   deriving (Show, Eq)

--- a/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBTruncater/Types.hs
+++ b/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBTruncater/Types.hs
@@ -1,15 +1,13 @@
-module Cardano.Tools.DBTruncater.Types (
-    module Cardano.Tools.DBTruncater.Types
-  ) where
+module Cardano.Tools.DBTruncater.Types (module Cardano.Tools.DBTruncater.Types) where
 
-import Cardano.Tools.DBAnalyser.Types
-import Ouroboros.Consensus.Block.Abstract
+import           Cardano.Tools.DBAnalyser.Types
+import           Ouroboros.Consensus.Block.Abstract
 
 data DBTruncaterConfig = DBTruncaterConfig {
-    dbDir :: FilePath
+    dbDir         :: FilePath
   , truncatePoint :: TruncatePoint
-  , blockType :: BlockType
-  , verbose :: Bool
+  , blockType     :: BlockType
+  , verbose       :: Bool
   }
 
 newtype TruncatePoint = TruncatePoint SlotNo

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ImmutableDB/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ImmutableDB/API.hs
@@ -397,7 +397,8 @@ data MissingBlock blk
     -- | There is no block in the slot of the given point.
   = EmptySlot (RealPoint blk)
     -- | The block and/or EBB in the slot of the given point have a different
-    -- hash.
+    -- hash. We return the 'HeaderHash' for each block we found with the
+    -- corresponding slot number.
   | WrongHash (RealPoint blk) (NonEmpty (HeaderHash blk))
     -- | The requested point is in the future, i.e., its slot is greater than
     -- that of the tip. We record the tip as the second argument.


### PR DESCRIPTION
Fixes https://github.com/input-output-hk/ouroboros-network/issues/4512

# Description

Adds a new tool, `db-truncater`, that truncates the ImmutableDB at a specified point. This code heavily reuses command line parsers and mechanisms designed for `db-analyser`, and performs the truncate using the internal `deleteAfter` ImmutableDB function. In order to find the correct block for truncation without requiring that the user provide the hash of that block, it uses the iterator provided by `streamAll`, and truncates at the first block inhabiting the latest slot whose slot number is less than the target truncate point. 

-----

the code here is mostly complete, so worth reviewing, but I still plan to make some stylistic changes to conform to the style guide

potential improvements, either for now or for later:
- [x] add support for truncating at a specific block number, rather than specifically slot number
- [ ] make it faster by not streaming every single block from the DB