### PR TITLE
CI bits

### DIFF
--- a/.github/workflows/cabal.project.local.Windows
+++ b/.github/workflows/cabal.project.local.Windows
@@ -1,5 +1,6 @@
 benchmarks:     True
-documentation:  True
+-- causes weird out-of-memory errors on 8.10
+documentation:  False
 reorder-goals:  True
 tests:          True
 

--- a/.github/workflows/haskell-build.yml
+++ b/.github/workflows/haskell-build.yml
@@ -31,7 +31,10 @@ jobs:
       fail-fast: false
       matrix:
         # Currently Hydra/Cicero build with 9.2.7
-        ghc: ["9.2.7"]
+
+        # Consider re-enabling documentation in the respective
+        # cabal.project.local.* when bumping to a newer GHC.
+        ghc: ["8.10.7"]
         os: [windows-latest]
 
     env:

--- a/flake.nix
+++ b/flake.nix
@@ -56,7 +56,7 @@
           packages = [ pkgs.nodejs pkgs.yarn ];
         };
       };
-      hydraJobs = import ./nix/ci.nix { inherit pkgs devShell; };
+      hydraJobs = import ./nix/ci.nix { inherit inputs pkgs devShell; };
       legacyPackages = pkgs;
     } // inputs.tullia.fromSimple system (import ./nix/tullia.nix)
   );

--- a/nix/tullia.nix
+++ b/nix/tullia.nix
@@ -1,72 +1,84 @@
 let
   actionCiInputName = "GitHub event";
+  repository = "input-output-hk/ouroboros-consensus";
+
+  taskDefinitions = [
+    { system = "x86_64-linux"; }
+    { system = "x86_64-darwin"; }
+    { system = "aarch64-darwin"; }
+    { system = "x86_64-linux"; attr = "windows"; name = "x86_64-windows"; }
+  ];
+
+  mkTask = { system, attr ? "native", ... }: { config, ... }: {
+    preset = {
+      nix.enable = true;
+
+      github.ci = {
+        # Tullia tasks can run locally or on Cicero.
+        # When no facts are present we know that we are running locally and vice versa.
+        # When running locally, the current directory is already bind-mounted into the container,
+        # so we don't need to fetch the source from GitHub and we don't want to report a GitHub status.
+        enable = config.actionRun.facts != { };
+        inherit repository;
+        remote = config.preset.github.lib.readRepository actionCiInputName null;
+        revision = config.preset.github.lib.readRevision actionCiInputName null;
+      };
+    };
+
+    command.text = ''
+      nix build -L .#hydraJobs.${system}.required.${attr} \
+        --max-silent-time 1800 --keep-going
+    '';
+
+    memory = 1024 * 32;
+
+    nomad = {
+      resources.cpu = 10000;
+
+      driver = "exec";
+    };
+  };
+
+  taskCue = ''
+    // This is a CUE expression that defines what events trigger a new run of this action.
+    // There is no documentation for this yet. Ask SRE if you have trouble changing this.
+
+    let github = {
+      #input: "${actionCiInputName}"
+      #repo: "${repository}"
+    }
+
+    #lib.merge
+    #ios: [
+      {
+        #lib.io.github_push
+        github
+        #default_branch: true
+        #branch: "gh-readonly-queue/.*"
+      },
+      {
+        #lib.io.github_pr
+        github
+      },
+    ]
+  '';
 in
 {
-  tasks = {
-    ci = { config, lib, ... }: {
-      preset = {
-        nix.enable = true;
+  tasks = builtins.listToAttrs (builtins.map
+    (t: {
+      name = "ci/${t.name or t.system}";
+      value = mkTask t;
+    })
+    taskDefinitions);
 
-        github.ci = {
-          # Tullia tasks can run locally or on Cicero.
-          # When no facts are present we know that we are running locally and vice versa.
-          # When running locally, the current directory is already bind-mounted into the container,
-          # so we don't need to fetch the source from GitHub and we don't want to report a GitHub status.
-          enable = config.actionRun.facts != { };
-          repository = "input-output-hk/ouroboros-consensus";
-          remote = config.preset.github.lib.readRepository actionCiInputName null;
-          revision = config.preset.github.lib.readRevision actionCiInputName null;
+  actions = builtins.listToAttrs (builtins.map
+    (t:
+      let name = "ci/${t.name or t.system}"; in {
+        name = "ouroboros-consensus/${name}";
+        value = {
+          task = name;
+          io = taskCue;
         };
-      };
-
-      command.text = config.preset.github.status.lib.reportBulk {
-        bulk.text = ''
-          nix eval .#hydraJobs --apply __attrNames --json |
-          nix-systems -i |
-          jq 'with_entries(select(.value))' # filter out systems that we cannot build for
-        '';
-        each.text =
-          ''nix build -L .#hydraJobs."$1".required --max-silent-time 1800 --keep-going'';
-        skippedDescription =
-          lib.escapeShellArg "No nix builder available for this system";
-      };
-
-      memory = 1024 * 32;
-
-      nomad = {
-        resources.cpu = 10000;
-
-        driver = "exec";
-      };
-    };
-  };
-
-  actions = {
-    "ouroboros-consensus/ci" = {
-      task = "ci";
-      io = ''
-        // This is a CUE expression that defines what events trigger a new run of this action.
-        // There is no documentation for this yet. Ask SRE if you have trouble changing this.
-
-        let github = {
-          #input: "${actionCiInputName}"
-          #repo: "input-output-hk/ouroboros-consensus"
-        }
-
-        #lib.merge
-        #ios: [
-          {
-            #lib.io.github_push
-            github
-            #default_branch: true
-            #branch: "gh-readonly-queue/.*"
-          },
-          {
-            #lib.io.github_pr
-            github
-          },
-        ]
-      '';
-    };
-  };
+      })
+    taskDefinitions);
 }


### PR DESCRIPTION
 - Split up Cicero into independent jobs such that the logs of different platforms are no longer interleaved, easing log inspection
 - We temporarily bumped the GHC on GHA to 9.2 in #46 as it started to randomly fail with weird out-of-memory errors on 8.10. We still have to support compiling for 8.10 for ~one month, so we are reverting that change here.