### PR TITLE
Build and publish the Consensus report

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -40,6 +40,8 @@ jobs:
           cache: yarn
           cache-dependency-path: './docs/website/yarn.lock'
 
+      - uses: cachix/install-nix-action@v20
+
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
@@ -89,6 +91,11 @@ jobs:
           cd ../../
           cabal build --dry-run --enable-tests all
           ./scripts/docs/haddocks.sh
+
+      - name: Build PDFs (Consensus report)
+        run: |
+          nix build -L .#consensus-pdfs
+          cp -r --no-preserve=mode,ownership result/ static/pdfs
 
       - name: Build website
         run: yarn build

--- a/docs/website/docs/References.md
+++ b/docs/website/docs/References.md
@@ -23,6 +23,6 @@ The following artifacts influence and/or describe the Consensus implementation.
 [ouroboros-bft]: https://iohk.io/en/research/library/papers/ouroboros-bfta-simple-byzantine-fault-tolerant-consensus-protocol/
 [ouroboros-praos]: https://iohk.io/en/research/library/papers/ouroboros-praosan-adaptively-securesemi-synchronous-proof-of-stake-protocol/
 [ouroboros-genesis]: https://iohk.io/en/research/library/papers/ouroboros-genesiscomposable-proof-of-stake-blockchains-with-dynamic-availability/
-[consensus-report]: https://input-output-hk.github.io/ouroboros-network/pdfs/report/
+[consensus-report]: https://input-output-hk.github.io/ouroboros-consensus/pdfs/report.pdf
 [network-report]: https://input-output-hk.github.io/ouroboros-network/pdfs/network-design/
 [cardano-ledger]: https://github.com/input-output-hk/cardano-ledger/

--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,7 @@
           inputs.iohkNix.overlays.crypto
           (import ./nix/tools.nix inputs)
           (import ./nix/haskell.nix inputs)
+          (import ./nix/pdfs.nix)
         ];
       };
       inherit (pkgs) lib haskell-nix;

--- a/nix/ci.nix
+++ b/nix/ci.nix
@@ -25,6 +25,8 @@ let
       haskell = mkHaskellJobsFor pkgs.hsPkgs;
       formatting = import ./formatting.nix pkgs;
       inherit devShell;
+    } // lib.optionalAttrs (buildSystem == "x86_64-linux") {
+      inherit (pkgs) consensus-pdfs;
     };
   } // lib.optionalAttrs (buildSystem == "x86_64-linux") {
     windows = {

--- a/nix/pdfs.nix
+++ b/nix/pdfs.nix
@@ -1,0 +1,20 @@
+final: prev: {
+  consensus-pdfs = final.stdenvNoCC.mkDerivation {
+    name = "ouroboros-consensus-pdfs";
+    src = ../docs/report;
+    nativeBuildInputs = [
+      (final.texlive.combine {
+        inherit (final.texlive)
+          amsmath cleveref collection-fontsrecommended enumitem latexmk
+          scheme-small siunitx todonotes;
+      })
+    ];
+    buildPhase = ''
+      latexmk -pdf -pdflatex="pdflatex -interaction=nonstopmode" report.tex
+    '';
+    installPhase = ''
+      mkdir -p $out
+      cp *.pdf $out/
+    '';
+  };
+}


### PR DESCRIPTION
The previous URL in ouroboros-network is no longer accessible as they switched to the non-cumulative way of deploying to GitHub Pages.