### PR TITLE
place upper bound on cardano-ledger-core

### DIFF
--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -125,7 +125,7 @@ library
     , cardano-ledger-binary
     , cardano-ledger-byron
     , cardano-ledger-conway
-    , cardano-ledger-core
+    , cardano-ledger-core           ^>=1.1
     , cardano-ledger-mary
     , cardano-ledger-shelley
     , cardano-prelude


### PR DESCRIPTION
# Description

In order to release `cardano-ledger-core` 1.2.0 on CHaPs, a revision in `ouroboros-consensus-cardano` was required, placing an upper bound. This commit mirrors the revision exactly.

See https://github.com/input-output-hk/cardano-haskell-packages/pull/254#discussion_r1191769688

We can remove this bound soon if we like, as I will be integrating the latest ledger packages into consensus now.