### PR TITLE
Use TraceLabelPeer for blockfetch and chainsync server

### DIFF
--- a/ouroboros-consensus-diffusion/changelog.d/20230517_112320_karl.fb.knutsson_trace_peer.md
+++ b/ouroboros-consensus-diffusion/changelog.d/20230517_112320_karl.fb.knutsson_trace_peer.md
@@ -1,0 +1,4 @@
+### Breaking
+
+* `chainSyncServerHeaderTracer` field of `Tracers` was changed to use `TraceLabelPeer`.
+* `blockFetchServerTracer` field of `Tracers` was changed to use `TraceLabelPeer`.

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -140,7 +140,8 @@ data Handlers m addr blk = Handlers {
         -- closure include these and not need to be explicit about them here.
 
     , hChainSyncServer
-        :: NodeToNodeVersion
+        :: ConnectionId addr
+        -> NodeToNodeVersion
         -> ChainDB.Follower m blk (ChainDB.WithPoint blk (SerialisedHeader blk))
         -> ChainSyncServer (SerialisedHeader blk) (Point blk) (Tip blk) m ()
 
@@ -152,7 +153,8 @@ data Handlers m addr blk = Handlers {
         -> BlockFetchClient (Header blk) blk m ()
 
     , hBlockFetchServer
-        :: NodeToNodeVersion
+        :: ConnectionId addr
+        -> NodeToNodeVersion
         -> ResourceRegistry m
         -> BlockFetchServer (Serialised blk) (Point blk) m ()
 
@@ -221,15 +223,15 @@ mkHandlers
             (contramap (TraceLabelPeer peer) (Node.chainSyncClientTracer tracers))
             getTopLevelConfig
             (defaultChainDbView getChainDB)
-      , hChainSyncServer = \_version ->
+      , hChainSyncServer = \peer _version ->
           chainSyncHeadersServer
-            (Node.chainSyncServerHeaderTracer tracers)
+            (contramap (TraceLabelPeer peer) (Node.chainSyncServerHeaderTracer tracers))
             getChainDB
       , hBlockFetchClient =
           blockFetchClient
-      , hBlockFetchServer = \version ->
+      , hBlockFetchServer = \peer version ->
           blockFetchServer
-            (Node.blockFetchServerTracer tracers)
+            (contramap (TraceLabelPeer peer) (Node.blockFetchServerTracer tracers))
             getChainDB
             version
       , hTxSubmissionClient = \version controlMessageSTM peer ->
@@ -599,7 +601,7 @@ mkApps kernel Tracers {..} mkCodecs ByteLimits {..} genChainSyncTimeout ReportPe
             (timeLimitsChainSync chainSyncTimeout)
             channel
             $ chainSyncServerPeer
-            $ hChainSyncServer version flr
+            $ hChainSyncServer them version flr
 
     aBlockFetchClient
       :: NodeToNodeVersion
@@ -636,7 +638,7 @@ mkApps kernel Tracers {..} mkCodecs ByteLimits {..} genChainSyncTimeout ReportPe
           timeLimitsBlockFetch
           channel
           $ blockFetchServerPeer
-          $ hBlockFetchServer version registry
+          $ hBlockFetchServer them version registry
 
     aTxSubmission2Client
       :: NodeToNodeVersion

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node/Tracers.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node/Tracers.hs
@@ -48,11 +48,11 @@ import           Ouroboros.Network.TxSubmission.Outbound
 
 data Tracers' remotePeer localPeer blk f = Tracers
   { chainSyncClientTracer         :: f (TraceLabelPeer remotePeer (TraceChainSyncClientEvent blk))
-  , chainSyncServerHeaderTracer   :: f (TraceChainSyncServerEvent blk)
+  , chainSyncServerHeaderTracer   :: f (TraceLabelPeer remotePeer (TraceChainSyncServerEvent blk))
   , chainSyncServerBlockTracer    :: f (TraceChainSyncServerEvent blk)
   , blockFetchDecisionTracer      :: f [TraceLabelPeer remotePeer (FetchDecision [Point (Header blk)])]
   , blockFetchClientTracer        :: f (TraceLabelPeer remotePeer (TraceFetchClientState (Header blk)))
-  , blockFetchServerTracer        :: f (TraceBlockFetchServerEvent blk)
+  , blockFetchServerTracer        :: f (TraceLabelPeer remotePeer (TraceBlockFetchServerEvent blk))
   , txInboundTracer               :: f (TraceLabelPeer remotePeer (TraceTxSubmissionInbound  (GenTxId blk) (GenTx blk)))
   , txOutboundTracer              :: f (TraceLabelPeer remotePeer (TraceTxSubmissionOutbound (GenTxId blk) (GenTx blk)))
   , localTxSubmissionServerTracer :: f (TraceLocalTxSubmissionServerEvent blk)


### PR DESCRIPTION
Tracking which clients downloads blocks is very useful.
