### PR TITLE
Use a minimum of 10s reconnection delay

### DIFF
--- a/ouroboros-consensus-diffusion/changelog.d/20230517_140320_karl.fb.knutsson_timeout.md
+++ b/ouroboros-consensus-diffusion/changelog.d/20230517_140320_karl.fb.knutsson_timeout.md
@@ -1,0 +1,3 @@
+### Non-Breaking
+
+* Increase the minimum reconnection delay from 0s to 10s.

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node/ExitPolicy.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node/ExitPolicy.hs
@@ -18,7 +18,7 @@ data NodeToNodeInitiatorResult =
 
 
 returnPolicy :: ReturnPolicy NodeToNodeInitiatorResult
-returnPolicy NoInitiatorResult = ReconnectDelay 0
+returnPolicy NoInitiatorResult = ReconnectDelay 10
 returnPolicy (ChainSyncInitiatorResult result) = case result of
   -- TODO: it would be nice to have additional context to predict when we will
   -- be ready to reconnect.
@@ -28,4 +28,4 @@ returnPolicy (ChainSyncInitiatorResult result) = case result of
                    _ _ourTip _theirTip -> ReconnectDelay 180
   -- the outbound-governor asked for hot to warm demotion; it's up to the
   -- governor to decide to promote the peer to hot.
-  AskedToTerminate                     -> ReconnectDelay 0
+  AskedToTerminate                     -> ReconnectDelay 10


### PR DESCRIPTION
Use a minimum of 10s reconnection delay. Non-p2p nodes will disconnect from a p2p-node when chainsync exits. By waiting 10s to reconnect we are less likely to try and promote the peer to hot while the same peer is asynchronously being demoted to cold.

# Description

Please include a meaningful description of the PR and link the relevant issues
this PR might resolve.
