### PR TITLE
force new strict MVar value before calling putTMVar in updateMVar

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -496,6 +496,7 @@ test-suite consensus-test
     Test.Consensus.MiniProtocol.ChainSync.Client
     Test.Consensus.MiniProtocol.LocalStateQuery.Server
     Test.Consensus.ResourceRegistry
+    Test.Consensus.Util.MonadSTM.NormalForm
     Test.Consensus.Util.MonadSTM.RAWLock
     Test.Consensus.Util.Versioned
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/MonadSTM/StrictMVar.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/MonadSTM/StrictMVar.hs
@@ -170,20 +170,24 @@ updateMVar :: (MonadSTM m, HasCallStack) => StrictMVar m a -> (a -> (a, b)) -> m
 updateMVar StrictMVar { tmvar, tvar, invariant } f = do
     -- it's not unreasonable to assume that forcing !(!a', b) inside the
     -- atomically block will force the new value before putting it into the
-    -- MVar, but there's actually an additional closure constructed (with a
-    -- dependency on a') that will only force a' when *it's* evaluated! in
-    -- order to ensure that we're forcing the value inside the MVar before
-    -- calling checkInvariant, we need an additional bang outside the
-    -- atomically block, which will correctly force a' before checkInvariant
-    -- looks to see if it's been evaluated or not. without this change, it's
-    -- possible to put a lazy value inside a StrictMVar (though it's unlikely
-    -- to occur in production environments because this intermediate unforced
-    -- closure is optimized away at -O1 and above)
+    -- MVar, but although the value in the tuple is forced, there's actually
+    -- a thin closure constructed that just points to the forced value which
+    -- is what GHC returns in the constructed tuple (so it is actually a thunk,
+    -- albeit a trivial one!). in order to ensure that we're forcing the value
+    -- inside the MVar before calling checkInvariant, we need an additional
+    -- bang outside the atomically block, which will correctly force a' before
+    -- checkInvariant looks to see if it's been evaluated or not. without this
+    -- change, it's possible to put a lazy value inside a StrictMVar (though
+    -- it's unlikely to occur in production environments because this
+    -- intermediate unforced closure is optimized away at -O1 and above).
     (!a', b) <- atomically $ do
         a <- Lazy.takeTMVar tmvar
         let !(!a', b) = f a
         Lazy.putTMVar tmvar a'
         Lazy.writeTVar tvar a'
+        -- To exactly see what we mean, compile this module with `-ddump-stg-final`
+        -- and look for the definition of the closure that is placed as the first
+        -- item in the tuple returned here
         return (a', b)
     checkInvariant (invariant a') $ return b
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/MonadSTM/StrictMVar.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/MonadSTM/StrictMVar.hs
@@ -168,7 +168,7 @@ isEmptyMVar StrictMVar { tmvar } = atomically $ Lazy.isEmptyTMVar tmvar
 
 updateMVar :: (MonadSTM m, HasCallStack) => StrictMVar m a -> (a -> (a, b)) -> m b
 updateMVar StrictMVar { tmvar, tvar, invariant } f = do
-    (a', b) <- atomically $ do
+    (!a', b) <- atomically $ do
         a <- Lazy.takeTMVar tmvar
         let !(!a', b) = f a
         Lazy.putTMVar tmvar a'

--- a/ouroboros-consensus/test/consensus-test/Main.hs
+++ b/ouroboros-consensus/test/consensus-test/Main.hs
@@ -10,6 +10,7 @@ import qualified Test.Consensus.MiniProtocol.BlockFetch.Client (tests)
 import qualified Test.Consensus.MiniProtocol.ChainSync.Client (tests)
 import qualified Test.Consensus.MiniProtocol.LocalStateQuery.Server (tests)
 import qualified Test.Consensus.ResourceRegistry (tests)
+import qualified Test.Consensus.Util.MonadSTM.NormalForm (tests)
 import qualified Test.Consensus.Util.MonadSTM.RAWLock (tests)
 import qualified Test.Consensus.Util.Versioned (tests)
 import           Test.Tasty
@@ -30,6 +31,7 @@ tests =
   , Test.Consensus.Mempool.Fairness.tests
   , Test.Consensus.ResourceRegistry.tests
   , Test.Consensus.Util.MonadSTM.RAWLock.tests
+  , Test.Consensus.Util.MonadSTM.NormalForm.tests
   , Test.Consensus.Util.Versioned.tests
   , testGroup "HardFork" [
         testGroup "History" [

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Util/MonadSTM/NormalForm.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Util/MonadSTM/NormalForm.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingStrategies #-}
+module Test.Consensus.Util.MonadSTM.NormalForm (tests) where
+
+import Ouroboros.Consensus.Util.MonadSTM.NormalForm (MonadSTM, newMVar, updateMVar)
+import Test.Tasty
+import Test.Tasty.QuickCheck
+import NoThunks.Class
+import Control.Monad.IOSim
+import GHC.Generics
+
+
+-- Note that all of the tests here are only significant with compiler
+-- optimizations turned off!
+tests :: TestTree
+tests = testGroup "Ouroboros.Consensus.Util.MonadSTM.NormalForm"
+  [ testGroup "updateMVar"
+    [ testProperty "IO @Integer @String"
+        (prop_update_mvar_strictness_io @Integer @String)
+    , testProperty "IOSim @Integer @String"
+        (prop_update_mvar_strictness_iosim @Integer @String)
+    , testProperty "IO @StrictnessTestType @String"
+        (prop_update_mvar_strictness_io @StrictnessTestType @String)
+    , testProperty "IOSim @StrictnessTestType @String"
+        (prop_update_mvar_strictness_iosim @StrictnessTestType @String)
+    ]
+  ]
+
+data StrictnessTestType = StrictnessTestType !Int !Bool
+  deriving stock (Show, Generic)
+  deriving anyclass (Function, NoThunks, CoArbitrary)
+
+instance Arbitrary StrictnessTestType where
+  arbitrary = StrictnessTestType <$> arbitrary <*> arbitrary
+  shrink (StrictnessTestType a b) = do
+    StrictnessTestType <$> shrink a <*> shrink b
+
+prop_update_mvar_strictness_io
+  :: forall a b. NoThunks a
+  => Fun a (a, b) -> a -> Property
+prop_update_mvar_strictness_io f a =
+  ioProperty $ updateMVarTest f a
+
+prop_update_mvar_strictness_iosim
+  :: forall a b. NoThunks a
+  => Fun a (a, b) -> a -> Property
+prop_update_mvar_strictness_iosim f a =
+  property $ runSimOrThrow $ updateMVarTest f a
+
+updateMVarTest :: (MonadSTM m, NoThunks a) => Fun a (a, b) -> a -> m ()
+updateMVarTest (Fun _ f) a = do
+  mvar <- newMVar a
+  _ <- updateMVar mvar f
+  pure ()

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Util/MonadSTM/NormalForm.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Util/MonadSTM/NormalForm.hs
@@ -1,16 +1,17 @@
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveAnyClass     #-}
+{-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE RankNTypes         #-}
+{-# LANGUAGE TypeApplications   #-}
 module Test.Consensus.Util.MonadSTM.NormalForm (tests) where
 
-import Ouroboros.Consensus.Util.MonadSTM.NormalForm (MonadSTM, newMVar, updateMVar)
-import Test.Tasty
-import Test.Tasty.QuickCheck
-import NoThunks.Class
-import Control.Monad.IOSim
-import GHC.Generics
+import           Control.Monad.IOSim
+import           GHC.Generics
+import           NoThunks.Class
+import           Ouroboros.Consensus.Util.MonadSTM.NormalForm (MonadSTM,
+                     newMVar, updateMVar)
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
 
 
 -- Note that all of the tests here are only significant with compiler

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Util/MonadSTM/NormalForm.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Util/MonadSTM/NormalForm.hs
@@ -13,20 +13,27 @@ import           Ouroboros.Consensus.Util.MonadSTM.NormalForm (MonadSTM,
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
-
 -- Note that all of the tests here are only significant with compiler
--- optimizations turned off!
+-- optimizations turned off! These tests ensure that the invariants are
+-- maintained when calling `updateMVar` on consensus' `StrictMVar` values
+-- (which are created with a `NoThunks` "this should not contain any unforced
+-- thunks" invariant). Because the existence of thunks (and therefore the
+-- behaviour of `unsafeNoThunks`) is heavily dependent on compiler
+-- optimizations, these tests will *always* pass at -O1 or higher (at least on
+-- GHC 8.10 and GHC 9.2).
 tests :: TestTree
 tests = testGroup "Ouroboros.Consensus.Util.MonadSTM.NormalForm"
   [ testGroup "updateMVar"
-    [ testProperty "IO @Integer @String"
-        (prop_update_mvar_strictness_io @Integer @String)
-    , testProperty "IOSim @Integer @String"
-        (prop_update_mvar_strictness_iosim @Integer @String)
-    , testProperty "IO @StrictnessTestType @String"
-        (prop_update_mvar_strictness_io @StrictnessTestType @String)
-    , testProperty "IOSim @StrictnessTestType @String"
-        (prop_update_mvar_strictness_iosim @StrictnessTestType @String)
+    [ testGroup "updateMVar strictness"
+      [ testProperty "IO @Integer @String"
+          (prop_update_mvar_strictness_io @Integer @String)
+      , testProperty "IOSim @Integer @String"
+          (prop_update_mvar_strictness_iosim @Integer @String)
+      , testProperty "IO @StrictnessTestType @String"
+          (prop_update_mvar_strictness_io @StrictnessTestType @String)
+      , testProperty "IOSim @StrictnessTestType @String"
+          (prop_update_mvar_strictness_iosim @StrictnessTestType @String)
+      ]
     ]
   ]
 


### PR DESCRIPTION
Part of [ouroboros-network#4006](https://github.com/input-output-hk/ouroboros-network/issues/4006)

Adds a strictness annotation in `Ouroboros.Consensus.Util.MonadSTM.StrictMVar.updateMVar` to force the value we're putting into the `StrictMVar` (`'a`) before checking its invariant. This function isn't commonly used in ouroboros-consensus, but was causing `Ouroboros.Consensus.Mock.Node.Praos.praosBlockForging` to violate its NoThunks invariant during tests.