### PR TITLE
Removed ouroboros-network-framework dependency from ouroboros-consenus

### DIFF
--- a/ouroboros-consensus/changelog.d/20230525_172337_coot_remove_on_framework.md
+++ b/ouroboros-consensus/changelog.d/20230525_172337_coot_remove_on_framework.md
@@ -1,0 +1,4 @@
+### Breaking
+
+* Removed `ConnectionId` `Condense` instance.
+

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -312,7 +312,6 @@ library
     , mtl                          >=2.2      && <2.3
     , nothunks                     >=0.1.2    && <0.2
     , ouroboros-network-api        ^>=0.5
-    , ouroboros-network-framework  ^>=0.6
     , ouroboros-network-mock       ^>=0.1.0.1
     , ouroboros-network-protocols  ^>=0.5
     , psqueues                     >=0.2.3    && <0.3
@@ -522,7 +521,6 @@ test-suite consensus-test
     , ouroboros-consensus
     , ouroboros-network
     , ouroboros-network-api
-    , ouroboros-network-framework
     , ouroboros-network-mock
     , ouroboros-network-protocols:{ouroboros-network-protocols, testlib}
     , QuickCheck
@@ -536,6 +534,7 @@ test-suite consensus-test
     , time
     , tree-diff
     , typed-protocols
+    , typed-protocols-examples
 
 test-suite infra-test
   import:         common-test

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/Condense.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/Condense.hs
@@ -41,7 +41,6 @@ import           Numeric.Natural
 import           Ouroboros.Consensus.Util.HList (All, HList (..))
 import qualified Ouroboros.Consensus.Util.HList as HList
 import           Ouroboros.Network.Block (ChainHash (..), HeaderHash, Tip (..))
-import           Ouroboros.Network.ConnectionId (ConnectionId (..))
 import           Text.Printf (printf)
 
 {-------------------------------------------------------------------------------
@@ -166,9 +165,6 @@ instance Condense (HeaderHash b) => Condense (Tip b) where
 instance Condense a => Condense (WithOrigin a) where
   condense Origin = "origin"
   condense (At a) = condense a
-
-instance Condense addr => Condense (ConnectionId addr) where
-  condense (ConnectionId l r) = condense l <> " " <> condense r
 
 {-------------------------------------------------------------------------------
   Orphans for cardano-crypto-classes

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -35,6 +35,8 @@ import qualified Data.Map.Strict as Map
 import           Data.Maybe (isJust)
 import qualified Data.Set as Set
 import           Data.Typeable
+import           Network.TypedProtocol.Channel
+import           Network.TypedProtocol.Driver.Simple
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config
@@ -59,9 +61,7 @@ import           Ouroboros.Consensus.Util.STM (Fingerprint (..),
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block (getTipPoint)
-import           Ouroboros.Network.Channel
 import           Ouroboros.Network.ControlMessage (ControlMessage (..))
-import           Ouroboros.Network.Driver
 import           Ouroboros.Network.Mock.Chain (Chain (Genesis))
 import qualified Ouroboros.Network.Mock.Chain as Chain
 import           Ouroboros.Network.Mock.ProducerState (chainState,
@@ -371,7 +371,7 @@ runChainSync securityParam (ClientUpdates clientUpdates)
            maxBound $ \varCandidate -> do
              atomically $ modifyTVar varFinalCandidates $
                Map.insert serverId varCandidate
-             (result, _) <-
+             result <-
                runPipelinedPeer protocolTracer codecChainSyncId clientChannel $
                  chainSyncClientPeerPipelined $ client varCandidate
              atomically $ writeTVar varClientResult (Just (Right result))


### PR DESCRIPTION
# Description

Make `ouroboros-consensus` independent of `ouroboros-network-framework`.

* Removed `Condence ConnectionId` instance.
* Use `typed-protocols-examples` in `consensus-tests`.
