### PR TITLE
Rename `StrictMVar` to `StrictSVar`.

### DIFF
--- a/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBAnalyser/Run.hs
+++ b/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBAnalyser/Run.hs
@@ -52,7 +52,7 @@ analyse ::
   -> IO (Maybe AnalysisResult)
 analyse DBAnalyserConfig{analysis, confLimit, dbDir, selectDB, validation, verbose} args =
     withRegistry $ \registry -> do
-      lock           <- newMVar ()
+      lock           <- newSVar ()
       chainDBTracer  <- mkTracer lock verbose
       analysisTracer <- mkTracer lock True
       ProtocolInfo { pInfoInitLedger = genesisLedger, pInfoConfig = cfg } <-
@@ -128,7 +128,7 @@ analyse DBAnalyserConfig{analysis, confLimit, dbDir, selectDB, validation, verbo
         hPutStrLn stderr $ concat ["[", show diff, "] ", show ev]
         hFlush stderr
       where
-        withLock = bracket_ (takeMVar lock) (putMVar lock ())
+        withLock = bracket_ (takeSVar lock) (putSVar lock ())
 
     immValidationPolicy = case (analysis, validation) of
       (_, Just ValidateAllBlocks)      -> ImmutableDB.ValidateAllChunks

--- a/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBTruncater/Run.hs
+++ b/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBTruncater/Run.hs
@@ -103,15 +103,15 @@ findNewTip target iter =
         IteratorResult item -> do
           if acceptable item then go (Just item) else pure acc
 
-mkLock :: MonadSTM m => m (StrictMVar m ())
-mkLock = newMVar ()
+mkLock :: MonadSTM m => m (StrictSVar m ())
+mkLock = newSVar ()
 
-mkTracer :: Show a => StrictMVar IO () -> Bool -> IO (Tracer IO a)
+mkTracer :: Show a => StrictSVar IO () -> Bool -> IO (Tracer IO a)
 mkTracer _ False = pure mempty
 mkTracer lock True = do
   startTime <- getMonotonicTime
   pure $ Tracer $ \ev -> do
-    bracket_ (takeMVar lock) (putMVar lock ()) $ do
+    bracket_ (takeSVar lock) (putSVar lock ()) $ do
       traceTime <- getMonotonicTime
       let diff = diffTime traceTime startTime
       hPutStrLn stderr $ concat ["[", show diff, "] ", show ev]

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -243,7 +243,7 @@ library
     Ouroboros.Consensus.Util.IOLike
     Ouroboros.Consensus.Util.MonadSTM.NormalForm
     Ouroboros.Consensus.Util.MonadSTM.RAWLock
-    Ouroboros.Consensus.Util.MonadSTM.StrictMVar
+    Ouroboros.Consensus.Util.MonadSTM.StrictSVar
     Ouroboros.Consensus.Util.Orphans
     Ouroboros.Consensus.Util.RedundantConstraints
     Ouroboros.Consensus.Util.ResourceRegistry

--- a/ouroboros-consensus/src/consensus-testlib/Test/Util/Orphans/NoThunks.hs
+++ b/ouroboros-consensus/src/consensus-testlib/Test/Util/Orphans/NoThunks.hs
@@ -11,8 +11,8 @@ import           Data.Proxy
 import           NoThunks.Class (NoThunks (..))
 import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
 
-instance NoThunks a => NoThunks (StrictMVar (IOSim s) a) where
-  showTypeOf _ = "StrictMVar IOSim"
-  wNoThunks ctxt StrictMVar { tvar } = do
+instance NoThunks a => NoThunks (StrictSVar (IOSim s) a) where
+  showTypeOf _ = "StrictSVar IOSim"
+  wNoThunks ctxt StrictSVar { tvar } = do
       a <- unsafeSTToIO $ lazyToStrictST $ inspectTVar (Proxy :: Proxy (IOSim s)) tvar
       noThunks ctxt a

--- a/ouroboros-consensus/src/mock-block/Ouroboros/Consensus/Mock/Node/Praos.hs
+++ b/ouroboros-consensus/src/mock-block/Ouroboros/Consensus/Mock/Node/Praos.hs
@@ -96,16 +96,16 @@ praosBlockForging ::
   -> HotKey PraosMockCrypto
   -> m (BlockForging m MockPraosBlock)
 praosBlockForging cid initHotKey = do
-    varHotKey <- newMVar initHotKey
+    varHotKey <- newSVar initHotKey
     return $ BlockForging {
         forgeLabel       = "praosBlockForging"
       , canBeLeader      = cid
-      , updateForgeState = \_ sno _ -> updateMVar varHotKey $
+      , updateForgeState = \_ sno _ -> updateSVar varHotKey $
                                  second forgeStateUpdateInfoFromUpdateInfo
                                . evolveKey sno
       , checkCanForge    = \_ _ _ _ _ -> return ()
       , forgeBlock       = \cfg bno sno tickedLedgerSt txs isLeader -> do
-                               hotKey <- readMVar varHotKey
+                               hotKey <- readSVar varHotKey
                                return $
                                  forgeSimple
                                    (forgePraosExt hotKey)

--- a/ouroboros-consensus/src/mock-block/Ouroboros/Consensus/Mock/Protocol/Praos.hs
+++ b/ouroboros-consensus/src/mock-block/Ouroboros/Consensus/Mock/Protocol/Praos.hs
@@ -213,7 +213,7 @@ deriving instance PraosCrypto c => Show (HotKey c)
 newtype HotKeyEvolutionError = HotKeyEvolutionError Period
   deriving (Show)
 
--- | To be used in conjunction with, e.g., 'updateMVar'.
+-- | To be used in conjunction with, e.g., 'updateSVar'.
 --
 -- NOTE: when the key's period is after the target period, we shouldn't use
 -- it, but we currently do. In real TPraos we check this in

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Impl/Common.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Impl/Common.hs
@@ -56,7 +56,8 @@ import qualified Ouroboros.Consensus.Mempool.TxSeq as TxSeq
 import           Ouroboros.Consensus.Storage.ChainDB (ChainDB)
 import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
 import           Ouroboros.Consensus.Util (repeatedly)
-import           Ouroboros.Consensus.Util.IOLike hiding (newEmptyMVar, newMVar)
+import           Ouroboros.Consensus.Util.IOLike
+
 {-------------------------------------------------------------------------------
   Internal State
 -------------------------------------------------------------------------------}

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
@@ -170,7 +170,7 @@ openDBInternal args launchBgTasks = runWithTempRegistry $ do
       varFollowers       <- newTVarIO Map.empty
       varNextIteratorKey <- newTVarIO (IteratorKey 0)
       varNextFollowerKey <- newTVarIO (FollowerKey   0)
-      varCopyLock        <- newMVar  ()
+      varCopyLock        <- newSVar  ()
       varKillBgThreads   <- newTVarIO $ return ()
       blocksToAdd        <- newBlocksToAdd (Args.cdbBlocksToAddSize args)
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
@@ -197,8 +197,8 @@ copyToImmutableDB CDB{..} = withCopyLock $ do
 
     withCopyLock :: forall a. HasCallStack => m a -> m a
     withCopyLock = bracket_
-      (fmap mustBeUnlocked $ tryTakeMVar cdbCopyLock)
-      (putMVar  cdbCopyLock ())
+      (fmap mustBeUnlocked $ tryTakeSVar cdbCopyLock)
+      (putSVar  cdbCopyLock ())
 
     mustBeUnlocked :: forall b. HasCallStack => Maybe b -> b
     mustBeUnlocked = fromMaybe

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
@@ -225,7 +225,7 @@ data ChainDbEnv m blk = CDB
     -- not when hashes are garbage-collected from the map.
   , cdbNextIteratorKey :: !(StrictTVar m IteratorKey)
   , cdbNextFollowerKey :: !(StrictTVar m FollowerKey)
-  , cdbCopyLock        :: !(StrictMVar m ())
+  , cdbCopyLock        :: !(StrictSVar m ())
     -- ^ Lock used to ensure that 'copyToImmutableDB' is not executed more than
     -- once concurrently.
     --

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ImmutableDB/Impl.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ImmutableDB/Impl.hs
@@ -257,7 +257,7 @@ openDBInternal ImmutableDbArgs { immHasFS = SomeHasFS hasFS, .. } cont = cont $ 
           }
     ost <- validateAndReopen validateEnv immRegistry immValidationPolicy
 
-    stVar <- lift $ newMVar (DbOpen ost)
+    stVar <- lift $ newSVar (DbOpen ost)
 
     let dbEnv = ImmutableDBEnv {
             hasFS            = hasFS
@@ -286,16 +286,16 @@ closeDBImpl ::
   => ImmutableDBEnv m blk
   -> m ()
 closeDBImpl ImmutableDBEnv { hasFS, tracer, varInternalState } = do
-    internalState <- takeMVar varInternalState
+    internalState <- takeSVar varInternalState
     case internalState of
       -- Already closed
       DbClosed -> do
-        putMVar varInternalState internalState
+        putSVar varInternalState internalState
         traceWith tracer $ DBAlreadyClosed
       DbOpen openState -> do
         -- Close the database before doing the file-system operations so that
         -- in case these fail, we don't leave the database open.
-        putMVar varInternalState DbClosed
+        putSVar varInternalState DbClosed
         cleanUp hasFS openState
         traceWith tracer DBClosed
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index/Cache.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index/Cache.hs
@@ -74,7 +74,7 @@ import           Ouroboros.Consensus.Storage.ImmutableDB.Impl.Util
 import           Ouroboros.Consensus.Util (takeUntil, whenJust)
 import           Ouroboros.Consensus.Util.CallStack
 import           Ouroboros.Consensus.Util.IOLike
-import qualified Ouroboros.Consensus.Util.MonadSTM.StrictMVar as Strict
+import qualified Ouroboros.Consensus.Util.MonadSTM.StrictSVar as Strict
 import           Ouroboros.Consensus.Util.ResourceRegistry
 import           System.FS.API (HasFS (..), withFile)
 import           System.FS.API.Types (AllowExisting (..), Handle,

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/EarlyExit.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/EarlyExit.hs
@@ -38,7 +38,7 @@ import           Data.Function (on)
 import           Data.Proxy
 import           NoThunks.Class (NoThunks (..))
 import           Ouroboros.Consensus.Util ((.:))
-import           Ouroboros.Consensus.Util.IOLike (IOLike (..), StrictMVar,
+import           Ouroboros.Consensus.Util.IOLike (IOLike (..), StrictSVar,
                      StrictTVar)
 
 {-------------------------------------------------------------------------------
@@ -282,7 +282,7 @@ instance MonadEventlog m => MonadEventlog (WithEarlyExit m) where
 
 instance ( IOLike m
          , forall a. NoThunks (StrictTVar (WithEarlyExit m) a)
-         , forall a. NoThunks (StrictMVar (WithEarlyExit m) a)
+         , forall a. NoThunks (StrictSVar (WithEarlyExit m) a)
            -- The simulator does not currently support @MonadCatch (STM m)@,
            -- making this @IOLike@ instance applicable to @IO@ only. Once that
            -- missing @MonadCatch@ instance is added, @IOLike@ should require

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/IOLike.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/IOLike.hs
@@ -77,7 +77,7 @@ class ( MonadAsync              m
       , MonadThrow         (STM m)
       , forall a. NoThunks (m a)
       , forall a. NoThunks a => NoThunks (StrictTVar m a)
-      , forall a. NoThunks a => NoThunks (StrictMVar m a)
+      , forall a. NoThunks a => NoThunks (StrictSVar m a)
       ) => IOLike m where
   -- | Securely forget a KES signing key.
   --

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/MonadSTM/NormalForm.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/MonadSTM/NormalForm.hs
@@ -2,13 +2,13 @@ module Ouroboros.Consensus.Util.MonadSTM.NormalForm (
     module LazySTM
   , module Ouroboros.Consensus.Util.MonadSTM.StrictSVar
   , module StrictSTM
-  , newEmptyMVar
-  , newMVar
+  , newEmptySVar
+  , newSVar
   , newTVar
   , newTVarIO
     -- * Temporary
-  , uncheckedNewEmptyMVar
-  , uncheckedNewMVar
+  , uncheckedNewEmptySVar
+  , uncheckedNewSVar
   , uncheckedNewTVarM
   ) where
 
@@ -24,8 +24,8 @@ import           Control.Monad.Class.MonadSTM as StrictSTM
 import           GHC.Stack
 import           NoThunks.Class (NoThunks (..), unsafeNoThunks)
 import           Ouroboros.Consensus.Util.MonadSTM.StrictSVar hiding
-                     (newEmptyMVar, newEmptyMVarWithInvariant, newMVar,
-                     newMVarWithInvariant)
+                     (newEmptySVar, newEmptySVarWithInvariant, newSVar,
+                     newSVarWithInvariant)
 import qualified Ouroboros.Consensus.Util.MonadSTM.StrictSVar as Strict
 
 -- TODO: use strict versions of 'TQueue' and 'TBQueue'.  Previously the
@@ -45,12 +45,12 @@ newTVar :: (MonadSTM m, HasCallStack, NoThunks a)
           => a -> STM m (StrictTVar m a)
 newTVar = Strict.newTVarWithInvariant (fmap show . unsafeNoThunks)
 
-newMVar :: (MonadSTM m, HasCallStack, NoThunks a)
-        => a -> m (StrictMVar m a)
-newMVar = Strict.newMVarWithInvariant (fmap show . unsafeNoThunks)
+newSVar :: (MonadSTM m, HasCallStack, NoThunks a)
+        => a -> m (StrictSVar m a)
+newSVar = Strict.newSVarWithInvariant (fmap show . unsafeNoThunks)
 
-newEmptyMVar :: (MonadSTM m, NoThunks a) => a -> m (StrictMVar m a)
-newEmptyMVar = Strict.newEmptyMVarWithInvariant (fmap show . unsafeNoThunks)
+newEmptySVar :: (MonadSTM m, NoThunks a) => a -> m (StrictSVar m a)
+newEmptySVar = Strict.newEmptySVarWithInvariant (fmap show . unsafeNoThunks)
 
 {-------------------------------------------------------------------------------
   Unchecked wrappers (where we don't check for thunks)
@@ -61,8 +61,8 @@ newEmptyMVar = Strict.newEmptyMVarWithInvariant (fmap show . unsafeNoThunks)
 uncheckedNewTVarM :: MonadSTM m => a -> m (StrictTVar m a)
 uncheckedNewTVarM = Strict.newTVarIO
 
-uncheckedNewMVar :: MonadSTM m => a -> m (StrictMVar m a)
-uncheckedNewMVar = Strict.newMVar
+uncheckedNewSVar :: MonadSTM m => a -> m (StrictSVar m a)
+uncheckedNewSVar = Strict.newSVar
 
-uncheckedNewEmptyMVar :: MonadSTM m => a -> m (StrictMVar m a)
-uncheckedNewEmptyMVar = Strict.newEmptyMVar
+uncheckedNewEmptySVar :: MonadSTM m => a -> m (StrictSVar m a)
+uncheckedNewEmptySVar = Strict.newEmptySVar

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/MonadSTM/NormalForm.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/MonadSTM/NormalForm.hs
@@ -1,6 +1,6 @@
 module Ouroboros.Consensus.Util.MonadSTM.NormalForm (
     module LazySTM
-  , module Ouroboros.Consensus.Util.MonadSTM.StrictMVar
+  , module Ouroboros.Consensus.Util.MonadSTM.StrictSVar
   , module StrictSTM
   , newEmptyMVar
   , newMVar
@@ -23,10 +23,10 @@ import           Control.Concurrent.Class.MonadSTM.TQueue as LazySTM
 import           Control.Monad.Class.MonadSTM as StrictSTM
 import           GHC.Stack
 import           NoThunks.Class (NoThunks (..), unsafeNoThunks)
-import           Ouroboros.Consensus.Util.MonadSTM.StrictMVar hiding
+import           Ouroboros.Consensus.Util.MonadSTM.StrictSVar hiding
                      (newEmptyMVar, newEmptyMVarWithInvariant, newMVar,
                      newMVarWithInvariant)
-import qualified Ouroboros.Consensus.Util.MonadSTM.StrictMVar as Strict
+import qualified Ouroboros.Consensus.Util.MonadSTM.StrictSVar as Strict
 
 -- TODO: use strict versions of 'TQueue' and 'TBQueue'.  Previously the
 -- 'Control.Monad.Class.MonadSTM.Strict' was imported which

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/MonadSTM/RAWLock.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/MonadSTM/RAWLock.hs
@@ -134,7 +134,7 @@ import           Prelude hiding (read)
 --   such a scenario.
 --
 -- * When you have no writers and you only need a read-append lock, consider
---   using a @StrictMVar@ instead. The \"stale\" state can be used by the
+--   using a @StrictSVar@ instead. The \"stale\" state can be used by the
 --   readers.
 --
 -- * The state @st@ is always evaluated to WHNF and is subject to the

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/MonadSTM/StrictSVar.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/MonadSTM/StrictSVar.hs
@@ -7,7 +7,7 @@
 
 -- TODO: this module ought to use 'MonadMVar'
 -- See https://github.com/input-output-hk/io-sim/issues/34
-module Ouroboros.Consensus.Util.MonadSTM.StrictMVar (
+module Ouroboros.Consensus.Util.MonadSTM.StrictSVar (
     castStrictMVar
   , isEmptyMVar
   , modifyMVar

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/BlockchainTime/Simple.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/BlockchainTime/Simple.hs
@@ -376,8 +376,8 @@ deriving via AllowThunk (OverrideDelay s a)
 deriving via AllowThunk (StrictTVar (OverrideDelay s) a)
          instance NoThunks (StrictTVar (OverrideDelay s) a)
 
-deriving via AllowThunk (StrictMVar (OverrideDelay s) a)
-         instance NoThunks (StrictMVar (OverrideDelay s) a)
+deriving via AllowThunk (StrictSVar (OverrideDelay s) a)
+         instance NoThunks (StrictSVar (OverrideDelay s) a)
 
 instance MonadTimer.MonadDelay (OverrideDelay (IOSim s)) where
   threadDelay d = OverrideDelay $ ReaderT $ \schedule -> do

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Util/MonadSTM/NormalForm.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Util/MonadSTM/NormalForm.hs
@@ -9,7 +9,7 @@ import           Control.Monad.IOSim
 import           GHC.Generics
 import           NoThunks.Class
 import           Ouroboros.Consensus.Util.MonadSTM.NormalForm (MonadSTM,
-                     newMVar, updateMVar)
+                     newSVar, updateSVar)
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
@@ -23,16 +23,16 @@ import           Test.Tasty.QuickCheck
 -- GHC 8.10 and GHC 9.2).
 tests :: TestTree
 tests = testGroup "Ouroboros.Consensus.Util.MonadSTM.NormalForm"
-  [ testGroup "updateMVar"
-    [ testGroup "updateMVar strictness"
+  [ testGroup "updateSVar"
+    [ testGroup "updateSVar strictness"
       [ testProperty "IO @Integer @String"
-          (prop_update_mvar_strictness_io @Integer @String)
+          (prop_update_svar_strictness_io @Integer @String)
       , testProperty "IOSim @Integer @String"
-          (prop_update_mvar_strictness_iosim @Integer @String)
+          (prop_update_svar_strictness_iosim @Integer @String)
       , testProperty "IO @StrictnessTestType @String"
-          (prop_update_mvar_strictness_io @StrictnessTestType @String)
+          (prop_update_svar_strictness_io @StrictnessTestType @String)
       , testProperty "IOSim @StrictnessTestType @String"
-          (prop_update_mvar_strictness_iosim @StrictnessTestType @String)
+          (prop_update_svar_strictness_iosim @StrictnessTestType @String)
       ]
     ]
   ]
@@ -46,20 +46,20 @@ instance Arbitrary StrictnessTestType where
   shrink (StrictnessTestType a b) = do
     StrictnessTestType <$> shrink a <*> shrink b
 
-prop_update_mvar_strictness_io
+prop_update_svar_strictness_io
   :: forall a b. NoThunks a
   => Fun a (a, b) -> a -> Property
-prop_update_mvar_strictness_io f a =
-  ioProperty $ updateMVarTest f a
+prop_update_svar_strictness_io f a =
+  ioProperty $ updateSVarTest f a
 
-prop_update_mvar_strictness_iosim
+prop_update_svar_strictness_iosim
   :: forall a b. NoThunks a
   => Fun a (a, b) -> a -> Property
-prop_update_mvar_strictness_iosim f a =
-  property $ runSimOrThrow $ updateMVarTest f a
+prop_update_svar_strictness_iosim f a =
+  property $ runSimOrThrow $ updateSVarTest f a
 
-updateMVarTest :: (MonadSTM m, NoThunks a) => Fun a (a, b) -> a -> m ()
-updateMVarTest (Fun _ f) a = do
-  mvar <- newMVar a
-  _ <- updateMVar mvar f
+updateSVarTest :: (MonadSTM m, NoThunks a) => Fun a (a, b) -> a -> m ()
+updateSVarTest (Fun _ f) a = do
+  mvar <- newSVar a
+  _ <- updateSVar mvar f
   pure ()

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -352,7 +352,7 @@ data ChainDBState m blk = ChainDBState
 
 -- | Environment to run commands against the real ChainDB implementation.
 data ChainDBEnv m blk = ChainDBEnv {
-    varDB           :: StrictMVar m (ChainDBState m blk)
+    varDB           :: StrictSVar m (ChainDBState m blk)
   , registry        :: ResourceRegistry m
   , varCurSlot      :: StrictTVar m SlotNo
   , varNextId       :: StrictTVar m Id
@@ -376,7 +376,7 @@ reopen
   => ChainDBEnv m blk -> m ()
 reopen ChainDBEnv { varDB, args } = do
     chainDBState <- open args
-    void $ swapMVar varDB chainDBState
+    void $ swapSVar varDB chainDBState
 
 close :: IOLike m => ChainDBState m blk -> m ()
 close ChainDBState { chainDB, addBlockAsync } = do
@@ -389,7 +389,7 @@ run :: forall m blk.
     ->    Cmd     blk (TestIterator m blk) (TestFollower m blk)
     -> m (Success blk (TestIterator m blk) (TestFollower m blk))
 run env@ChainDBEnv { varDB, .. } cmd =
-    readMVar varDB >>= \st@ChainDBState { chainDB = ChainDB{..}, internal } -> case cmd of
+    readSVar varDB >>= \st@ChainDBState { chainDB = ChainDB{..}, internal } -> case cmd of
       AddBlock blk             -> Point               <$> (advanceAndAdd st (blockSlot blk) blk)
       AddFutureBlock blk s     -> Point               <$> (advanceAndAdd st s               blk)
       GetCurrentChain          -> Chain               <$> atomically getCurrentChain
@@ -433,7 +433,7 @@ run env@ChainDBEnv { varDB, .. } cmd =
       close st
       atomically $ writeTVar varVolatileDbFs Mock.empty
       reopen env
-      ChainDB { getTipPoint } <- chainDB <$> readMVar varDB
+      ChainDB { getTipPoint } <- chainDB <$> readSVar varDB
       atomically getTipPoint
 
     giveWithEq :: a -> m (WithEq a)
@@ -1541,11 +1541,11 @@ runCmdsLockstep maxClockSkew (SmallChunkInfo chunkInfo) cmds =
                    maxClockSkew varCurSlot
 
       (hist, model, res, trace) <- bracket
-        (open args >>= newMVar)
+        (open args >>= newSVar)
         -- Note: we might be closing a different ChainDB than the one we
         -- opened, as we can reopen it the ChainDB, swapping the ChainDB in
-        -- the MVar.
-        (\varDB -> readMVar varDB >>= close)
+        -- the SVar.
+        (\varDB -> readSVar varDB >>= close)
 
         $ \varDB -> do
           let env = ChainDBEnv

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/Unit.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/Unit.hs
@@ -401,7 +401,7 @@ withTestChainDbEnv topLevelConfig chunkInfo extLedgerState cont
       nodeDbs <- emptyNodeDBs
       (tracer, getTrace) <- recordingTracerTVar
       let args = chainDbArgs threadRegistry nodeDbs tracer
-      varDB <- open args >>= newMVar
+      varDB <- open args >>= newSVar
       let env = ChainDBEnv
             { varDB
             , registry = iteratorRegistry
@@ -413,7 +413,7 @@ withTestChainDbEnv topLevelConfig chunkInfo extLedgerState cont
       pure (env, getTrace)
 
     closeChainDbEnv (env, _) = do
-      readMVar (varDB env) >>= close
+      readSVar (varDB env) >>= close
       closeRegistry (registry env)
       closeRegistry (cdbRegistry $ args env)
 
@@ -437,20 +437,20 @@ instance IOLike m => SupportsUnitTest (SystemM blk m) where
   addBlock blk = do
     env <- ask
     SystemM $ lift $ lift $ do
-      api <- chainDB <$> readMVar (varDB env)
+      api <- chainDB <$> readSVar (varDB env)
       void $ API.addBlock api API.noPunishment blk
       pure blk
 
   persistBlks shouldGarbageCollect = do
     env <- ask
     SystemM $ lift $ lift $ do
-      internal <- internal <$> readMVar (varDB env)
+      internal <- internal <$> readSVar (varDB env)
       SM.persistBlks shouldGarbageCollect internal
 
   newFollower = do
     env <- ask
     SystemM $ lift $ lift $ do
-      api <- chainDB <$> readMVar (varDB env)
+      api <- chainDB <$> readSVar (varDB env)
       API.newFollower api (registry env) API.SelectedChain allComponents
 
   followerInstruction = SystemM . lift . lift . fmap Right
@@ -462,7 +462,7 @@ instance IOLike m => SupportsUnitTest (SystemM blk m) where
   stream from to = do
     env <- ask
     SystemM $ lift $ lift $ fmap Right $ do
-      api <- chainDB <$> readMVar (varDB env)
+      api <- chainDB <$> readSVar (varDB env)
       API.stream api (registry env) allComponents from to
 
   iteratorNext iterator = SystemM $ lift $ lift (API.iteratorNext iterator)

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
@@ -480,7 +480,7 @@ shrinkCmd _ cmd = case cmd of
 -- | Environment to run commands against the real VolatileDB implementation.
 data VolatileDBEnv = VolatileDBEnv
   { varErrors :: StrictTVar IO Errors
-  , varDB     :: StrictMVar IO (VolatileDB IO Block)
+  , varDB     :: StrictSVar IO (VolatileDB IO Block)
   , args      :: VolatileDbArgs Identity IO Block
   }
 
@@ -490,7 +490,7 @@ data VolatileDBEnv = VolatileDBEnv
 reopenDB :: VolatileDBEnv -> IO ()
 reopenDB VolatileDBEnv { varDB, args } = do
     db <- openDB args runWithTempRegistry
-    void $ swapMVar varDB db
+    void $ swapSVar varDB db
 
 semanticsImpl :: VolatileDBEnv -> At CmdErr Concrete -> IO (At Resp Concrete)
 semanticsImpl env@VolatileDBEnv { varDB, varErrors }  (At (CmdErr cmd mbErrors)) =
@@ -501,7 +501,7 @@ semanticsImpl env@VolatileDBEnv { varDB, varErrors }  (At (CmdErr cmd mbErrors))
           tryVolatileDB (Proxy @Block) (runDB env cmd)
         -- As all operations on the VolatileDB are idempotent, close (not
         -- idempotent by default!), reopen it, and run the command again.
-        readMVar varDB >>= idemPotentCloseDB
+        readSVar varDB >>= idemPotentCloseDB
         reopenDB env
         tryVolatileDB (Proxy @Block) (runDB env cmd)
 
@@ -517,7 +517,7 @@ idemPotentCloseDB db =
     isClosedDBError _                             = Nothing
 
 runDB :: HasCallStack => VolatileDBEnv -> Cmd -> IO Success
-runDB env@VolatileDBEnv { varDB, args = VolatileDbArgs { volHasFS = SomeHasFS hasFS } } cmd = readMVar varDB >>= \db -> case cmd of
+runDB env@VolatileDBEnv { varDB, args = VolatileDbArgs { volHasFS = SomeHasFS hasFS } } cmd = readSVar varDB >>= \db -> case cmd of
     GetBlockComponent hash          -> MbAllComponents           <$> getBlockComponent db allComponents hash
     PutBlock blk                    -> Unit                      <$> putBlock db blk
     FilterByPredecessor hashes      -> Successors . (<$> hashes) <$> atomically (filterByPredecessor db)
@@ -526,7 +526,7 @@ runDB env@VolatileDBEnv { varDB, args = VolatileDbArgs { volHasFS = SomeHasFS ha
     GetMaxSlotNo                    -> MaxSlot                   <$> atomically (getMaxSlotNo db)
     Close                           -> Unit                      <$> closeDB db
     ReOpen                          -> do
-        readMVar varDB >>= idemPotentCloseDB
+        readSVar varDB >>= idemPotentCloseDB
         Unit <$> reopenDB env
     Corruption corrs                ->
       withClosedDB $
@@ -538,7 +538,7 @@ runDB env@VolatileDBEnv { varDB, args = VolatileDbArgs { volHasFS = SomeHasFS ha
   where
     withClosedDB :: IO () -> IO Success
     withClosedDB action = do
-      readMVar varDB >>= closeDB
+      readSVar varDB >>= closeDB
       action
       reopenDB env
       return $ Unit ()
@@ -593,11 +593,11 @@ test cmds = do
                  }
 
     (hist, res, trace) <- bracket
-      (openDB args runWithTempRegistry >>= newMVar)
+      (openDB args runWithTempRegistry >>= newSVar)
       -- Note: we might be closing a different VolatileDB than the one we
       -- opened, as we can reopen it the VolatileDB, swapping the VolatileDB
-      -- in the MVar.
-      (\varDB -> readMVar varDB >>= closeDB)
+      -- in the SVar.
+      (\varDB -> readSVar varDB >>= closeDB)
       $ \varDB -> do
         let env = VolatileDBEnv { varErrors, varDB, args }
             sm' = sm env dbm


### PR DESCRIPTION
# Description

The `StrictMVar` identifier from `Ouroboros.Consensus.Util.MonadSTM.StrictMVar` clashes with `StrictMVar` from the new `strict-mvar` package. Furthermore, the former is not truly an `MVar`, since it does not offer the same fairness guarantees that an actual `MVar` does offer. For this reason, we rename the former `StrictMVar` to `StrictSVar`, which means "Strict Stale Var". "Stale" refers to the fact that we can read the last ("stale") value from the variable if it is currently empty.

NOTE: it is probably useful to review the diff per commit. The full diff of the PR shows that `StrictMVar` was deleted, and that `StrictSVar` is a completely new file, even though I used `git mv` to rename the file.