### PR TITLE
Replace `StrictSVar` where possible by `StrictMVar` with NoThunks checks

### DIFF
--- a/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBTruncater/Run.hs
+++ b/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBTruncater/Run.hs
@@ -9,6 +9,7 @@ module Cardano.Tools.DBTruncater.Run (truncate) where
 import           Cardano.Slotting.Slot (WithOrigin (..))
 import           Cardano.Tools.DBAnalyser.HasAnalysis
 import           Cardano.Tools.DBTruncater.Types
+import           Control.Concurrent.Class.MonadMVar.Strict.NoThunks
 import           Control.Monad
 import           Control.Tracer
 import           Data.Functor.Identity
@@ -103,15 +104,15 @@ findNewTip target iter =
         IteratorResult item -> do
           if acceptable item then go (Just item) else pure acc
 
-mkLock :: MonadSTM m => m (StrictSVar m ())
-mkLock = newSVar ()
+mkLock :: MonadMVar m => m (StrictMVar m ())
+mkLock = newMVar ()
 
-mkTracer :: Show a => StrictSVar IO () -> Bool -> IO (Tracer IO a)
+mkTracer :: Show a => StrictMVar IO () -> Bool -> IO (Tracer IO a)
 mkTracer _ False = pure mempty
 mkTracer lock True = do
   startTime <- getMonotonicTime
   pure $ Tracer $ \ev -> do
-    bracket_ (takeSVar lock) (putSVar lock ()) $ do
+    bracket_ (takeMVar lock) (putMVar lock ()) $ do
       traceTime <- getMonotonicTime
       let diff = diffTime traceTime startTime
       hPutStrLn stderr $ concat ["[", show diff, "] ", show ev]

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -539,6 +539,7 @@ test-suite consensus-test
     , random
     , serialise
     , si-timers
+    , strict-mvar
     , tasty
     , tasty-hunit
     , tasty-quickcheck

--- a/ouroboros-consensus/src/consensus-testlib/Test/Util/Orphans/NoThunks.hs
+++ b/ouroboros-consensus/src/consensus-testlib/Test/Util/Orphans/NoThunks.hs
@@ -1,9 +1,13 @@
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE NamedFieldPuns    #-}
+{-# LANGUAGE FlexibleInstances   #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+-- TODO: remove ScopedTypeVariables
+{-# LANGUAGE InstanceSigs        #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Test.Util.Orphans.NoThunks () where
 
 
+import           Control.Concurrent.Class.MonadMVar.Strict.NoThunks
 import           Control.Monad.IOSim
 import           Control.Monad.ST.Lazy
 import           Control.Monad.ST.Unsafe (unsafeSTToIO)
@@ -15,4 +19,11 @@ instance NoThunks a => NoThunks (StrictSVar (IOSim s) a) where
   showTypeOf _ = "StrictSVar IOSim"
   wNoThunks ctxt StrictSVar { tvar } = do
       a <- unsafeSTToIO $ lazyToStrictST $ inspectTVar (Proxy :: Proxy (IOSim s)) tvar
+      noThunks ctxt a
+
+-- TODO: we need to be able to inspect the value inside the mvar a la MonadInspectSTM.
+instance NoThunks a => NoThunks (StrictMVar (IOSim s) a) where
+  showTypeOf _ = "StrictMVar IOSim"
+  wNoThunks ctxt _v = do
+      a <- undefined :: IO a -- TODO
       noThunks ctxt a

--- a/ouroboros-consensus/src/mock-block/Ouroboros/Consensus/Mock/Protocol/Praos.hs
+++ b/ouroboros-consensus/src/mock-block/Ouroboros/Consensus/Mock/Protocol/Praos.hs
@@ -213,7 +213,7 @@ deriving instance PraosCrypto c => Show (HotKey c)
 newtype HotKeyEvolutionError = HotKeyEvolutionError Period
   deriving (Show)
 
--- | To be used in conjunction with, e.g., 'updateSVar'.
+-- | To be used in conjunction with, e.g., 'modifyMVar'.
 --
 -- NOTE: when the key's period is after the target period, we shouldn't use
 -- it, but we currently do. In real TPraos we check this in

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
@@ -35,6 +35,7 @@ module Ouroboros.Consensus.Storage.ChainDB.Impl (
   , openDBInternal
   ) where
 
+import           Control.Concurrent.Class.MonadMVar.Strict.NoThunks
 import           Control.Monad (when)
 import           Control.Monad.Trans.Class (lift)
 import           Control.Tracer
@@ -170,7 +171,7 @@ openDBInternal args launchBgTasks = runWithTempRegistry $ do
       varFollowers       <- newTVarIO Map.empty
       varNextIteratorKey <- newTVarIO (IteratorKey 0)
       varNextFollowerKey <- newTVarIO (FollowerKey   0)
-      varCopyLock        <- newSVar  ()
+      varCopyLock        <- newMVar ()
       varKillBgThreads   <- newTVarIO $ return ()
       blocksToAdd        <- newBlocksToAdd (Args.cdbBlocksToAddSize args)
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
@@ -37,6 +37,7 @@ module Ouroboros.Consensus.Storage.ChainDB.Impl.Background (
   , addBlockRunner
   ) where
 
+import           Control.Concurrent.Class.MonadMVar.Strict.NoThunks
 import           Control.Exception (assert)
 import           Control.Monad (forM_, forever, void)
 import           Control.Tracer
@@ -197,8 +198,8 @@ copyToImmutableDB CDB{..} = withCopyLock $ do
 
     withCopyLock :: forall a. HasCallStack => m a -> m a
     withCopyLock = bracket_
-      (fmap mustBeUnlocked $ tryTakeSVar cdbCopyLock)
-      (putSVar  cdbCopyLock ())
+      (fmap mustBeUnlocked $ tryTakeMVar cdbCopyLock)
+      (putMVar  cdbCopyLock ())
 
     mustBeUnlocked :: forall b. HasCallStack => Maybe b -> b
     mustBeUnlocked = fromMaybe

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
@@ -60,6 +60,7 @@ module Ouroboros.Consensus.Storage.ChainDB.Impl.Types (
   , TraceValidationEvent (..)
   ) where
 
+import           Control.Concurrent.Class.MonadMVar.Strict.NoThunks
 import           Control.Tracer
 import           Data.Map.Strict (Map)
 import           Data.Maybe.Strict (StrictMaybe (..))
@@ -225,7 +226,7 @@ data ChainDbEnv m blk = CDB
     -- not when hashes are garbage-collected from the map.
   , cdbNextIteratorKey :: !(StrictTVar m IteratorKey)
   , cdbNextFollowerKey :: !(StrictTVar m FollowerKey)
-  , cdbCopyLock        :: !(StrictSVar m ())
+  , cdbCopyLock        :: !(StrictMVar m ())
     -- ^ Lock used to ensure that 'copyToImmutableDB' is not executed more than
     -- once concurrently.
     --

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/EarlyExit.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/EarlyExit.hs
@@ -20,6 +20,7 @@ module Ouroboros.Consensus.Util.EarlyExit (
 
 import           Control.Applicative
 import           Control.Concurrent.Class.MonadMVar
+import           Control.Concurrent.Class.MonadMVar.Strict.NoThunks (StrictMVar)
 import           Control.Monad
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadEventlog
@@ -283,6 +284,7 @@ instance MonadEventlog m => MonadEventlog (WithEarlyExit m) where
 instance ( IOLike m
          , forall a. NoThunks (StrictTVar (WithEarlyExit m) a)
          , forall a. NoThunks (StrictSVar (WithEarlyExit m) a)
+         , forall a. NoThunks (StrictMVar (WithEarlyExit m) a)
            -- The simulator does not currently support @MonadCatch (STM m)@,
            -- making this @IOLike@ instance applicable to @IO@ only. Once that
            -- missing @MonadCatch@ instance is added, @IOLike@ should require

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/IOLike.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/IOLike.hs
@@ -44,7 +44,7 @@ module Ouroboros.Consensus.Util.IOLike (
 import           Cardano.Crypto.KES (KESAlgorithm, SignKeyKES)
 import qualified Cardano.Crypto.KES as KES
 import           Control.Applicative (Alternative)
-import           Control.Concurrent.Class.MonadMVar
+import           Control.Concurrent.Class.MonadMVar.Strict.NoThunks
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadEventlog
 import           Control.Monad.Class.MonadFork
@@ -78,6 +78,7 @@ class ( MonadAsync              m
       , forall a. NoThunks (m a)
       , forall a. NoThunks a => NoThunks (StrictTVar m a)
       , forall a. NoThunks a => NoThunks (StrictSVar m a)
+      , forall a. NoThunks a => NoThunks (StrictMVar m a)
       ) => IOLike m where
   -- | Securely forget a KES signing key.
   --

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/BlockchainTime/Simple.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/BlockchainTime/Simple.hs
@@ -37,7 +37,8 @@
 module Test.Consensus.BlockchainTime.Simple (tests) where
 
 import           Control.Applicative (Alternative (..))
-import           Control.Concurrent.Class.MonadMVar (MonadMVar)
+import           Control.Concurrent.Class.MonadMVar.Strict.NoThunks (MonadMVar,
+                     StrictMVar)
 import qualified Control.Monad.Class.MonadSTM.Internal as LazySTM
 import           Control.Monad.Class.MonadTime
 import qualified Control.Monad.Class.MonadTimer as MonadTimer
@@ -378,6 +379,9 @@ deriving via AllowThunk (StrictTVar (OverrideDelay s) a)
 
 deriving via AllowThunk (StrictSVar (OverrideDelay s) a)
          instance NoThunks (StrictSVar (OverrideDelay s) a)
+
+deriving via AllowThunk (StrictMVar (OverrideDelay s) a)
+         instance NoThunks (StrictMVar (OverrideDelay s) a)
 
 instance MonadTimer.MonadDelay (OverrideDelay (IOSim s)) where
   threadDelay d = OverrideDelay $ ReaderT $ \schedule -> do

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/ResourceRegistry.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/ResourceRegistry.hs
@@ -30,6 +30,7 @@
 --
 module Test.Consensus.ResourceRegistry (tests) where
 
+import           Control.Concurrent.Class.MonadMVar.Strict
 import           Control.Monad.Class.MonadTimer.SI
 import           Control.Monad.Except
 import           Data.Foldable (toList)
@@ -285,14 +286,14 @@ data ThreadInstr m :: Type -> Type where
   -- | Raise an exception in the thread
   ThreadCrash :: ThreadInstr m ()
 
--- | Instruction along with an SVar for the result
-data QueuedInstr m = forall a. QueuedInstr (ThreadInstr m a) (StrictSVar m a)
+-- | Instruction along with an MVar for the result
+data QueuedInstr m = forall a. QueuedInstr (ThreadInstr m a) (StrictMVar m a)
 
 runInThread :: IOLike m => TestThread m -> ThreadInstr m a -> m a
 runInThread TestThread{..} instr = do
-    result <- uncheckedNewEmptySVar (error "no result yet")
+    result <- newEmptyMVar
     atomically $ writeTQueue threadComms (QueuedInstr instr result)
-    takeSVar result
+    takeMVar result
 
 instance (IOLike m) => Show (TestThread m) where
   show TestThread{..} = "<Thread " ++ show (threadId testThread) ++ ">"
@@ -312,7 +313,7 @@ newThread :: forall m. IOLike m
           -> m (TestThread m)
 newThread alive parentReg = \shouldLink -> do
     comms      <- atomically $ newTQueue
-    spawned    <- uncheckedNewEmptySVar (error "no thread spawned yet")
+    spawned    <- newEmptyMVar
 
     thread <- forkThread parentReg "newThread" $
                 withRegistry $ \childReg ->
@@ -330,15 +331,15 @@ newThread alive parentReg = \shouldLink -> do
 
     -- Make sure to register thread before starting it
     atomically $ modifyTVar alive (testThread:)
-    putSVar spawned testThread
+    putMVar spawned testThread
     return testThread
   where
     threadBody :: ResourceRegistry m
-               -> StrictSVar m (TestThread m)
+               -> StrictMVar m (TestThread m)
                -> TQueue m (QueuedInstr m)
                -> m ()
     threadBody childReg spawned comms = do
-        us <- readSVar spawned
+        us <- readMVar spawned
         loop us `finally` (atomically $ modifyTVar alive (delete us))
       where
         loop :: TestThread m -> m ()
@@ -347,12 +348,12 @@ newThread alive parentReg = \shouldLink -> do
           case instr of
             ThreadFork linked -> do
               child <- newThread alive childReg (const us <$> linked)
-              putSVar result child
+              putMVar result child
               loop us
             ThreadTerminate -> do
-              putSVar result ()
+              putMVar result ()
             ThreadCrash -> do
-              putSVar result ()
+              putMVar result ()
               error "crashing"
 
 runIO :: forall m. (IOLike m, MonadTimer m)

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
@@ -46,6 +46,7 @@ module Test.Ouroboros.Storage.ImmutableDB.StateMachine (
   , tests
   ) where
 
+import           Control.Concurrent.Class.MonadMVar.Strict.NoThunks
 import           Control.Monad (forM_, void)
 import           Data.Bifunctor (first)
 import           Data.ByteString.Lazy (ByteString)
@@ -216,7 +217,7 @@ open args = do
 reopen :: ImmutableDBEnv -> ValidationPolicy -> IO ()
 reopen ImmutableDBEnv { varDB, args } valPol = do
     immutableDbState <- open args { immValidationPolicy = valPol }
-    void $ swapSVar varDB immutableDbState
+    void $ swapMVar varDB immutableDbState
 
 -- | Run the command against the given database.
 run ::
@@ -233,7 +234,7 @@ run env@ImmutableDBEnv {
           , immHasFS = SomeHasFS hasFS
           }
       } cmd =
-    readSVar varDB >>= \ImmutableDBState { db, internal } -> case cmd of
+    readMVar varDB >>= \ImmutableDBState { db, internal } -> case cmd of
       GetTip               -> ImmTip          <$> atomically (getTip            db)
       GetBlockComponent pt -> ErAllComponents <$>             getBlockComponent db allComponents pt
       AppendBlock blk      -> Unit            <$>             appendBlock       db blk
@@ -799,15 +800,15 @@ data ImmutableDBEnv = ImmutableDBEnv {
       -- During truncation we might need to delete a file that is still opened
       -- by an iterator. As this is not allowed by the MockFS implementation, we
       -- first close all open iterators in these cases.
-    , varDB     :: StrictSVar IO ImmutableDBState
+    , varDB     :: StrictMVar IO ImmutableDBState
     , args      :: ImmutableDbArgs Identity IO TestBlock
     }
 
 getImmutableDB :: ImmutableDBEnv -> IO (ImmutableDB IO TestBlock)
-getImmutableDB = fmap db . readSVar . varDB
+getImmutableDB = fmap db . readMVar . varDB
 
 getInternal :: ImmutableDBEnv -> IO (ImmutableDB.Internal IO TestBlock)
-getInternal = fmap internal . readSVar . varDB
+getInternal = fmap internal . readMVar . varDB
 
 semantics ::
      ImmutableDBEnv
@@ -1208,11 +1209,11 @@ test cacheConfig chunkInfo cmds = do
             }
 
       (hist, model, res, trace) <- bracket
-        (open args >>= newSVar)
+        (open args >>= newMVar)
         -- Note: we might be closing a different ImmutableDB than the one we
         -- opened, as we can reopen it the ImmutableDB, swapping the
-        -- ImmutableDB in the SVar.
-        (\varDB -> readSVar varDB >>= closeDB . db)
+        -- ImmutableDB in the MVar.
+        (\varDB -> readMVar varDB >>= closeDB . db)
         $ \varDB -> do
           let env = ImmutableDBEnv
                 { varErrors


### PR DESCRIPTION
# Description

We replace `StrictSVar` by `StrictMVar` with `NoThunks` checks where possible. In general, we can replace the `StrictSVar` if we do not use on `readMVarSTM`, which is not provided by `StrictMVar`.