### PR TITLE
Call `cryptoInit` before running test suites

### DIFF
--- a/ouroboros-consensus-cardano/test/cardano-test/Main.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Main.hs
@@ -1,6 +1,6 @@
 module Main (main) where
 
-import           Cardano.Crypto.Libsodium (sodiumInit)
+import           Cardano.Crypto.Init (cryptoInit)
 import           System.IO (BufferMode (LineBuffering), hSetBuffering,
                      hSetEncoding, stdout, utf8)
 import qualified Test.Consensus.Cardano.ByronCompatibility (tests)
@@ -18,7 +18,7 @@ main :: IO ()
 main = do
   hSetBuffering stdout LineBuffering
   hSetEncoding stdout utf8
-  sodiumInit
+  cryptoInit
   defaultMainWithTestEnv defaultTestEnvConfig tests
 
 tests :: TestTree

--- a/ouroboros-consensus-cardano/test/shelley-test/Main.hs
+++ b/ouroboros-consensus-cardano/test/shelley-test/Main.hs
@@ -1,6 +1,6 @@
 module Main (main) where
 
-import           Cardano.Crypto.Libsodium (sodiumInit)
+import           Cardano.Crypto.Init (cryptoInit)
 import qualified Test.Consensus.Shelley.Coherence (tests)
 import qualified Test.Consensus.Shelley.Golden (tests)
 import qualified Test.Consensus.Shelley.Serialisation (tests)
@@ -10,7 +10,7 @@ import           Test.Util.TestEnv (defaultMainWithTestEnv,
                      defaultTestEnvConfig)
 
 main :: IO ()
-main = sodiumInit >> defaultMainWithTestEnv defaultTestEnvConfig tests
+main = cryptoInit >> defaultMainWithTestEnv defaultTestEnvConfig tests
 
 tests :: TestTree
 tests =


### PR DESCRIPTION
https://github.com/input-output-hk/cardano-base/blob/a344b32d97b0d0e83b773069f6a20f7e5fa67478/cardano-crypto-class/src/Cardano/Crypto/Init.hs#L25