### PR TITLE
Use `cryptoInit` everywhere

### DIFF
--- a/ouroboros-consensus-cardano/app/db-analyser.hs
+++ b/ouroboros-consensus-cardano/app/db-analyser.hs
@@ -15,6 +15,7 @@
 --                    [--num-blocks-to-process INT]
 module Main (main) where
 
+import           Cardano.Crypto.Init (cryptoInit)
 import           Cardano.Tools.DBAnalyser.Run
 import           Cardano.Tools.DBAnalyser.Types
 import           Control.Monad (void)
@@ -25,6 +26,7 @@ import           Options.Applicative (execParser, fullDesc, helper, info,
 
 main :: IO ()
 main = do
+    cryptoInit
     cmdLine <- getCmdLine
     void $ case blockType cmdLine of
       ByronBlock   args -> analyse cmdLine args

--- a/ouroboros-consensus-cardano/app/db-synthesizer.hs
+++ b/ouroboros-consensus-cardano/app/db-synthesizer.hs
@@ -23,6 +23,7 @@
 --   -a                       Append to an existing Chain DB
 module Main (main) where
 
+import           Cardano.Crypto.Init (cryptoInit)
 import           Cardano.Tools.DBSynthesizer.Run
 import           DBSynthesizer.Parsers
 import           System.Exit
@@ -30,6 +31,7 @@ import           System.Exit
 
 main :: IO ()
 main = do
+    cryptoInit
     (paths, creds, forgeOpts) <- parseCommandLine
     result <- initialize paths creds forgeOpts >>= either die (uncurry synthesize)
     putStrLn $ "--> done; result: " ++ show result

--- a/ouroboros-consensus-cardano/app/db-truncater.hs
+++ b/ouroboros-consensus-cardano/app/db-truncater.hs
@@ -1,5 +1,6 @@
 module Main (main) where
 
+import           Cardano.Crypto.Init (cryptoInit)
 import           Cardano.Tools.DBAnalyser.Types (BlockType (..))
 import           Cardano.Tools.DBTruncater.Run
 import           Cardano.Tools.DBTruncater.Types
@@ -11,6 +12,7 @@ import           Prelude hiding (truncate)
 
 main :: IO ()
 main = do
+  cryptoInit
   config <- getCommandLineConfig
   case blockType config of
     CardanoBlock args -> truncate config args

--- a/ouroboros-consensus-cardano/app/immdb-server.hs
+++ b/ouroboros-consensus-cardano/app/immdb-server.hs
@@ -3,6 +3,7 @@
 
 module Main (main) where
 
+import           Cardano.Crypto.Init (cryptoInit)
 import qualified Cardano.Tools.DBAnalyser.Block.Cardano as Cardano
 import           Cardano.Tools.DBAnalyser.HasAnalysis (mkProtocolInfo)
 import qualified Cardano.Tools.ImmDBServer.Diffusion as ImmDBServer
@@ -13,6 +14,7 @@ import           Ouroboros.Consensus.Node.ProtocolInfo (ProtocolInfo (..))
 
 main :: IO ()
 main = do
+    cryptoInit
     Opts {immDBDir, port, configFile} <- execParser optsParser
     let sockAddr = Socket.SockAddrInet port hostAddr
           where

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -537,6 +537,7 @@ executable db-analyser
   main-is:        db-analyser.hs
   build-depends:
     , base
+    , cardano-crypto-class
     , cardano-crypto-wrapper
     , optparse-applicative
     , ouroboros-consensus
@@ -550,6 +551,7 @@ executable db-synthesizer
   main-is:        db-synthesizer.hs
   build-depends:
     , base
+    , cardano-crypto-class
     , cardano-tools
     , optparse-applicative
     , ouroboros-consensus
@@ -562,6 +564,7 @@ executable db-truncater
   main-is:        db-truncater.hs
   build-depends:
     , base
+    , cardano-crypto-class
     , cardano-crypto-wrapper
     , optparse-applicative
     , ouroboros-consensus
@@ -577,6 +580,7 @@ executable immdb-server
   main-is:        immdb-server.hs
   build-depends:
     , base
+    , cardano-crypto-class
     , network
     , optparse-applicative
     , ouroboros-consensus

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -590,5 +590,6 @@ test-suite tools-test
   build-depends:
     , base
     , cardano-tools
+    , ouroboros-consensus:consensus-testlib
     , tasty
     , tasty-hunit

--- a/ouroboros-consensus-cardano/test/cardano-test/Main.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Main.hs
@@ -1,6 +1,5 @@
 module Main (main) where
 
-import           Cardano.Crypto.Init (cryptoInit)
 import           System.IO (BufferMode (LineBuffering), hSetBuffering,
                      hSetEncoding, stdout, utf8)
 import qualified Test.Consensus.Cardano.ByronCompatibility (tests)
@@ -18,7 +17,6 @@ main :: IO ()
 main = do
   hSetBuffering stdout LineBuffering
   hSetEncoding stdout utf8
-  cryptoInit
   defaultMainWithTestEnv defaultTestEnvConfig tests
 
 tests :: TestTree

--- a/ouroboros-consensus-cardano/test/shelley-test/Main.hs
+++ b/ouroboros-consensus-cardano/test/shelley-test/Main.hs
@@ -1,6 +1,5 @@
 module Main (main) where
 
-import           Cardano.Crypto.Init (cryptoInit)
 import qualified Test.Consensus.Shelley.Coherence (tests)
 import qualified Test.Consensus.Shelley.Golden (tests)
 import qualified Test.Consensus.Shelley.Serialisation (tests)
@@ -10,7 +9,7 @@ import           Test.Util.TestEnv (defaultMainWithTestEnv,
                      defaultTestEnvConfig)
 
 main :: IO ()
-main = cryptoInit >> defaultMainWithTestEnv defaultTestEnvConfig tests
+main = defaultMainWithTestEnv defaultTestEnvConfig tests
 
 tests :: TestTree
 tests =

--- a/ouroboros-consensus-cardano/test/tools-test/Main.hs
+++ b/ouroboros-consensus-cardano/test/tools-test/Main.hs
@@ -7,6 +7,7 @@ import qualified Cardano.Tools.DBSynthesizer.Run as DBSynthesizer
 import           Cardano.Tools.DBSynthesizer.Types
 import           Test.Tasty
 import           Test.Tasty.HUnit
+import           Test.Util.TestEnv
 
 
 nodeConfig, chainDB :: FilePath
@@ -97,4 +98,4 @@ tests =
       ]
 
 main :: IO ()
-main = defaultMain tests
+main = defaultMainWithTestEnv defaultTestEnvConfig tests

--- a/ouroboros-consensus/src/consensus-testlib/Test/Util/TestEnv.hs
+++ b/ouroboros-consensus/src/consensus-testlib/Test/Util/TestEnv.hs
@@ -8,6 +8,7 @@ module Test.Util.TestEnv (
   , defaultTestEnvConfig
   ) where
 
+import           Cardano.Crypto.Init (cryptoInit)
 import           Data.Proxy (Proxy (..))
 import           Options.Applicative (metavar)
 import           Test.Tasty
@@ -17,9 +18,10 @@ import           Test.Tasty.QuickCheck
 
 -- | 'defaultMain' extended with 'iohkTestEnvIngredient'
 defaultMainWithTestEnv :: TestEnvConfig -> TestTree -> IO ()
-defaultMainWithTestEnv testConfig testTree =
-    defaultMainWithIngredients (testEnvIngredient : defaultIngredients) $ withTestEnv testConfig testTree
-
+defaultMainWithTestEnv testConfig testTree = do
+    cryptoInit
+    defaultMainWithIngredients (testEnvIngredient : defaultIngredients) $
+      withTestEnv testConfig testTree
     where
       testEnvIngredient :: Ingredient
       testEnvIngredient = includingOptions [Option (Proxy :: Proxy TestEnv)]


### PR DESCRIPTION
Follow-up to #119 that makes sure that we call `cryptoInit` before all test suites and executables.

As for why we didn't notice that this was missing for e.g. db-analyser so far: According to the cardano-base maintainers, not calling `cryptoInit` does at least not cause random segfaults, but may impact performance and cryptographic security.