### PR TITLE
Bifunctor Barbie

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -93,7 +93,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: febddc58683186232db5fa376de65c58973f9686
+  tag: ff9982e22d6c8e5a3af4bd3e87794a3b27e91afa
   subdir:
    libs/cardano-ledger-binary
-  --sha256: 0q6c2f4ld5l85153q8xrm2qc64k8p0y66j6adcl8bga31yd0pl16
+  --sha256: 0nk2b5sv7cbdlf7rq3affjyc9xq8lhjk2mjb536rqxqyvd6kfgmi

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -53,6 +53,7 @@ common common-bench
     -Wredundant-constraints -Wmissing-export-lists -Wunused-packages
     -Wno-unticked-promoted-constructors -rtsopts -with-rtsopts=-A32m
     -threaded
+
   -- We use this option to avoid skewed results due to changes in cache-line
   -- alignment. See
   -- https://github.com/Bodigrim/tasty-bench#comparison-against-baseline
@@ -63,6 +64,8 @@ library
   import:           common-lib
   hs-source-dirs:   src/ouroboros-consensus
   exposed-modules:
+    Data.Bifunctor.Barbie
+    Data.Bifunctor.Barbie.Constraints
     Data.SOP.Counting
     Data.SOP.Functors
     Data.SOP.Index

--- a/ouroboros-consensus/src/ouroboros-consensus/Data/Bifunctor/Barbie.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Data/Bifunctor/Barbie.hs
@@ -1,0 +1,279 @@
+{-# LANGUAGE ConstraintKinds            #-}
+{-# LANGUAGE DeriveTraversable          #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE PolyKinds                  #-}
+{-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE StandaloneKindSignatures   #-}
+{-# LANGUAGE TypeApplications           #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE TypeOperators              #-}
+
+-- | Barbies but parametric over bifunctors
+module Data.Bifunctor.Barbie (
+    -- * Functor
+    FunctorB2 (..)
+    -- * Traversable
+  , TraversableB2 (..)
+    -- ** Custom utility functions
+  , b2sequence
+    -- * Applicative
+  , ApplicativeB2 (..)
+    -- ** Custom utility functions
+  , b2ap
+  , b2liftA
+  , b2liftA2
+  , b2liftA3
+  , b2liftA4
+    -- * Constraints and instance dictionaries
+  , ConstraintsB2 (..)
+    -- ** Utility functions
+  , b2dicts
+  , b2mapC
+  , b2pureC
+  , b2traverseC
+    -- ** Custom utility functions
+  , b2liftAC
+  , b2liftAC2
+  , b2liftAC3
+  , b2liftAC4
+    -- * Lifted functions
+  , fn2_1
+  , fn2_2
+  , fn2_3
+  , fn2_4
+  , type (-..->) (..)
+    -- * Basic bifunctors
+  , K2 (..)
+  , type (:..:) (..)
+  ) where
+
+import           Data.Bifunctor (Bifunctor (..))
+import           Data.Bifunctor.Barbie.Constraints (Dict2 (..), requiringDict2)
+import           Data.Kind (Constraint, Type)
+import           Data.SOP.Functors (Product2 (..))
+
+{-------------------------------------------------------------------------------
+  Functor
+-------------------------------------------------------------------------------}
+
+-- | Like 'FunctorB', but for functors from bi-indexed-types to types.
+type FunctorB2 :: ((k1 -> k2 -> Type) -> Type) -> Constraint
+class FunctorB2 h where
+  b2map :: (forall a b. f a b -> g a b) -> h f -> h g
+
+{-------------------------------------------------------------------------------
+  Traversable
+-------------------------------------------------------------------------------}
+
+-- | Like 'TraversableB', but for functors from bi-indexed-types to types.
+type TraversableB2 :: ((k1 -> k2 -> Type) -> Type) -> Constraint
+class FunctorB2 h => TraversableB2 h where
+  b2traverse ::
+       Applicative e
+    => (forall a b. f a b -> e (g a b)) -> h f -> e (h g)
+
+--
+-- Utility functions
+--
+
+b2sequence :: (Applicative e, TraversableB2 h) => h (e :..: f) -> e (h f)
+b2sequence = b2traverse unComp2
+
+{-------------------------------------------------------------------------------
+  Applicative
+-------------------------------------------------------------------------------}
+
+-- | Like 'ApplicativeB', but for functors from bi-indexed-types to types.
+type ApplicativeB2 :: ((k1 -> k2 -> Type) -> Type) -> Constraint
+class FunctorB2 h => ApplicativeB2 h where
+  b2pure :: (forall a b. f a b) -> h f
+  b2prod :: h f -> h g -> h (f `Product2` g)
+
+--
+-- Custom utility functions
+--
+
+b2ap :: ApplicativeB2 h => h (f -..-> g) -> h f -> h g
+b2ap f x = b2map g $ b2prod f x
+  where g (Pair2 f' x') = apFn2 f' x'
+
+b2liftA ::
+     ApplicativeB2 h
+  => (forall a b. f a b -> f' a b)
+  -> h f
+  -> h f'
+b2liftA f x = b2pure (fn2_1 f) `b2ap` x
+
+b2liftA2 ::
+     ApplicativeB2 h
+  => (forall a b. f a b -> f' a b -> f'' a b)
+  -> h f
+  -> h f'
+  -> h f''
+b2liftA2 f x x' = b2pure (fn2_2 f) `b2ap` x `b2ap` x'
+
+b2liftA3 ::
+     ApplicativeB2 h
+  => (forall a b. f a b -> f' a b -> f'' a b -> f''' a b)
+  -> h f -> h f' -> h f'' -> h f'''
+b2liftA3 f x x' x'' = b2pure (fn2_3 f) `b2ap` x `b2ap` x' `b2ap` x''
+
+b2liftA4 ::
+     ApplicativeB2 h
+  => (forall a b. f a b -> f' a b -> f'' a b -> f''' a b -> f'''' a b)
+  -> h f -> h f' -> h f'' -> h f''' -> h f''''
+b2liftA4 f x x' x'' x''' =
+    b2pure (fn2_4 f) `b2ap` x `b2ap` x' `b2ap` x'' `b2ap` x'''
+
+{-------------------------------------------------------------------------------
+  Constraints and instance dictionaries
+-------------------------------------------------------------------------------}
+
+-- | Like 'ConstraintsB', but for functors from bi-indexed-types to types.
+type ConstraintsB2 :: ((k1 -> k2 -> Type) -> Type) -> Constraint
+class FunctorB2 h => ConstraintsB2 h where
+  type AllB2 (c :: k1 -> k2 -> Constraint) h  :: Constraint
+  badd2Dicts :: forall c f. AllB2 c h => h f -> h (Dict2 c `Product2` f)
+
+data Proxy2 a b = Proxy2
+
+--
+-- Utility functions
+--
+
+-- | Similar to 'badd2Dicts' but can produce the instance dictionaries "out of
+--   the blue".
+b2dicts ::
+     forall c h. (ConstraintsB2 h, ApplicativeB2 h, AllB2 c h)
+  => h (Dict2 c)
+b2dicts
+  = b2map (\(Pair2 c _) -> c) $ badd2Dicts $ b2pure Proxy2
+
+-- | 'b2map' with constraints.
+b2mapC ::
+     forall c h f g. (AllB2 c h, ConstraintsB2 h)
+  => (forall a b. c a b => f a b -> g a b)
+  -> h f
+  -> h g
+b2mapC f bf = b2map go (badd2Dicts bf)
+  where
+    go :: forall a b. (Dict2 c `Product2` f) a b -> g a b
+    go (d `Pair2` fa) = requiringDict2 (f fa) d
+
+-- | 'b2traverse' with constraints.
+b2traverseC ::
+     forall c h f g e. (TraversableB2 h, ConstraintsB2 h, AllB2 c h, Applicative e)
+  => (forall a b. c a b => f a b -> e (g a b))
+  -> h f
+  -> e (h g)
+b2traverseC f b =
+    b2traverse (\(Pair2 (Dict2 :: Dict2 c a b) x) -> f x) (badd2Dicts b)
+
+-- | 'b2pure' with constraints.
+b2pureC ::
+     forall c f h. (AllB2 c h, ConstraintsB2 h, ApplicativeB2 h)
+  => (forall a b. c a b => f a b)
+  -> h f
+b2pureC fa = b2map (requiringDict2 @c fa) b2dicts
+
+--
+-- Custom utility functions
+--
+
+-- | 'b2liftA' with constraints.
+b2liftAC ::
+     forall c h f f'. (ApplicativeB2 h, ConstraintsB2 h, AllB2 c h)
+  => (forall a b. c a b => f a b -> f' a b)
+  -> h f
+  -> h f'
+b2liftAC f x = b2pureC @c (fn2_1 f) `b2ap` x
+
+-- | 'b2liftA2' with constraints.
+b2liftAC2 ::
+     forall c h f f' f''. (ApplicativeB2 h, ConstraintsB2 h, AllB2 c h)
+  => (forall a b. c a b => f a b -> f' a b -> f'' a b)
+  -> h f
+  -> h f'
+  -> h f''
+b2liftAC2 f x x' = b2pureC @c (fn2_2 f) `b2ap` x `b2ap` x'
+
+-- | 'b2liftA3' with constraints.
+b2liftAC3 ::
+     forall c h f f' f'' f'''. (ApplicativeB2 h, ConstraintsB2 h, AllB2 c h)
+  => (forall a b. c a b => f a b -> f' a b -> f'' a b -> f''' a b)
+  -> h f -> h f' -> h f'' -> h f'''
+b2liftAC3 f x x' x'' = b2pureC @c (fn2_3 f) `b2ap` x `b2ap` x' `b2ap` x''
+
+-- | 'b2liftA4' with constraints.
+b2liftAC4 ::
+     forall c h f f' f'' f''' f''''. (ApplicativeB2 h, ConstraintsB2 h, AllB2 c h)
+  => (forall a b. c a b => f a b -> f' a b -> f'' a b -> f''' a b -> f'''' a b)
+  -> h f -> h f' -> h f'' -> h f''' -> h f''''
+b2liftAC4 f x x' x'' x''' =
+    b2pureC @c (fn2_4 f) `b2ap` x `b2ap` x' `b2ap` x'' `b2ap` x'''
+
+{-------------------------------------------------------------------------------
+  Lifted functions
+-------------------------------------------------------------------------------}
+
+-- | Lifted functions
+type (-..->) :: (k1 -> k2 -> Type) -> (k1 -> k2 -> Type) -> k1 -> k2 -> Type
+newtype (f -..-> g) a b = Fn2 { apFn2 :: f a b -> g a b }
+
+infixr 1 -..->
+
+-- | Construct a lifted function.
+fn2_1 :: (f a b -> g a b) -> (f -..-> g) a b
+fn2_1 = Fn2
+
+-- | Construct a binary lifted function
+fn2_2 :: (f a b -> f' a b -> f'' a b ) -> (f -..-> f' -..-> f'') a b
+fn2_2 f = Fn2 $ \x -> Fn2 $ \x' -> f x x'
+
+-- | Construct a ternary lifted function.
+fn2_3 ::
+     (f a b -> f' a b -> f'' a b -> f''' a b)
+  -> (f -..-> f' -..-> f'' -..-> f''') a b
+fn2_3 f = Fn2 $ \x -> Fn2 $ \x' -> Fn2 $ \x'' -> f x x' x''
+
+-- | Construct a quaternary lifted function.
+fn2_4 ::
+     (f a b -> f' a b -> f'' a b -> f''' a b -> f'''' a b)
+  -> (f -..-> f' -..-> f'' -..-> f''' -..-> f'''') a b
+fn2_4 f = Fn2 $ \x -> Fn2 $ \x' -> Fn2 $ \x'' -> Fn2 $ \x''' -> f x x' x'' x'''
+
+{-------------------------------------------------------------------------------
+  Basic bifunctors
+-------------------------------------------------------------------------------}
+
+-- | The constant type bifunctor.
+type K2 :: Type -> k1 -> k2 -> Type
+newtype K2 a b c = K2 { unK2 :: a }
+  deriving stock (Show, Eq)
+  deriving stock (Functor, Foldable, Traversable)
+  deriving newtype (Monoid, Semigroup)
+
+instance Bifunctor (K2 a) where
+  bimap _ _ (K2 x) = K2 x
+
+-- | Composition of functor after bifunctor.
+--
+-- Example: @Comp2 (Just (17, True)) :: (Maybe :..: (,)) Int Bool@
+type (:..:) :: (k3 -> Type) -> (k1 -> k2 -> k3) -> k1 -> k2 -> Type
+newtype (:..:) f g a b = Comp2 { unComp2 :: f (g a b) }
+  deriving stock (Show, Eq)
+  deriving stock (Functor, Foldable)
+  deriving newtype (Monoid, Semigroup)
+
+infixr 7 :..:
+
+deriving stock instance (Traversable f, Traversable (g a))
+                     => Traversable ((f :..: g) a)
+
+instance (Functor f, Bifunctor g) => Bifunctor (f :..: g) where
+  bimap f g (Comp2 x) = Comp2 $ fmap (bimap f g) x

--- a/ouroboros-consensus/src/ouroboros-consensus/Data/Bifunctor/Barbie/Constraints.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Data/Bifunctor/Barbie/Constraints.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE ConstraintKinds          #-}
+{-# LANGUAGE FlexibleInstances        #-}
+{-# LANGUAGE GADTs                    #-}
+{-# LANGUAGE MultiParamTypeClasses    #-}
+{-# LANGUAGE PolyKinds                #-}
+{-# LANGUAGE RankNTypes               #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
+{-# LANGUAGE UndecidableSuperClasses  #-}
+
+module Data.Bifunctor.Barbie.Constraints (
+    -- * Instance dictionaries
+    Dict2 (..)
+  , requiringDict2
+    -- * Getting constraints
+  , ClassB2
+  ) where
+
+import           Data.Kind (Constraint, Type)
+
+{-------------------------------------------------------------------------------
+  Instance dictionaries
+-------------------------------------------------------------------------------}
+
+-- | @'Dict2' c a b@ is evidence that there exists an instance of @c a b@.
+type Dict2 :: (k1 -> k2 -> Constraint) -> k1 -> k2 -> Type
+data Dict2 c a b where
+  Dict2 :: c a b => Dict2 c a b
+
+-- | Turn a constrained-function into an unconstrained one that uses the packed
+-- instance dictionary instead.
+requiringDict2 :: (c a b => r) -> Dict2 c a b -> r
+requiringDict2 r Dict2 = r
+
+{-------------------------------------------------------------------------------
+  Getting constraints
+-------------------------------------------------------------------------------}
+
+-- | Create a bifunctor constraint from two functor constraints.
+type ClassB2 ::
+     (k1 -> Constraint)
+  -> (k2 -> Constraint)
+  -> (k1 -> k2 -> Constraint)
+class (c1 k, c2 v) => ClassB2 c1 c2 k v
+instance (c1 k, c2 v) => ClassB2 c1 c2 k v

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/BackingStore/LMDB.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/BackingStore/LMDB.hs
@@ -33,6 +33,7 @@ import           Control.Monad (forM_, unless, void, when)
 import qualified Control.Monad.Class.MonadSTM as IOLike
 import           Control.Monad.IO.Class (MonadIO (liftIO))
 import qualified Control.Tracer as Trace
+import           Data.Bifunctor.Barbie ((:..:) (..))
 import           Data.Functor (($>), (<&>))
 import           Data.Map (Map)
 import           Data.Map.Diff.Strict
@@ -51,7 +52,7 @@ import qualified Ouroboros.Consensus.Storage.LedgerDB.BackingStore.LMDB.Bridge a
 import           Ouroboros.Consensus.Storage.LedgerDB.BackingStore.LMDB.Status
                      (Status (..), StatusLock)
 import qualified Ouroboros.Consensus.Storage.LedgerDB.BackingStore.LMDB.Status as Status
-import           Ouroboros.Consensus.Util (foldlM', unComp2, (:..:) (..))
+import           Ouroboros.Consensus.Util (foldlM')
 import           Ouroboros.Consensus.Util.IOLike (Exception (..), IOLike,
                      MonadCatch (..), MonadThrow (..), bracket)
 import qualified System.FS.API as FS
@@ -429,7 +430,7 @@ newLMDBBackingStoreInitialiser dbTracer limits sfs initFrom = do
      -- Here we get the LMDB.Databases for the tables of the ledger state
      -- Must be read-write transaction because tables may need to be created
      dbBackingTables <- liftIO $ LMDB.readWriteTransaction dbEnv $
-       traverseLedgerTables getDb namesLedgerTables
+       traverseLedgerTables getDb (pureLedgerTables $ NameMK "utxo")
 
      dbNextId <- IOLike.newTVarIO 0
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util.hs
@@ -65,8 +65,6 @@ module Ouroboros.Consensus.Util (
   , (...:)
   , (..:)
   , (.:)
-    -- * Type-level composition
-  , (:..:) (..)
     -- * Product
   , pairFst
   , pairSnd
@@ -403,18 +401,6 @@ dimap keyFn valFn = Map.foldlWithKey update Map.empty
 
 (......:) :: (y -> z) -> (x0 -> x1 -> x2 -> x3 -> x4 -> x5 -> x6 -> y) -> (x0 -> x1 -> x2 -> x3 -> x4 -> x5 -> x6 -> z)
 (f ......: g) x0 x1 x2 x3 x4 x5 x6 = f (g x0 x1 x2 x3 x4 x5 x6)
-
-{-------------------------------------------------------------------------------
-  Type-level composition
--------------------------------------------------------------------------------}
-
--- | Compose two types where the second one expects two type variables
---
--- @@
---   Comp2 (Just (Left "hi")) :: (Maybe :..: Either) String Int
--- @@
-type (:..:) :: (y -> Type) -> (x0 -> x1 -> y) -> (x0 -> x1 -> Type)
-newtype (f :..: g) p r = Comp2 { unComp2 :: f (g p r) }
 
 {-------------------------------------------------------------------------------
   Product


### PR DESCRIPTION
# Description

This PR adds a variant of `barbies` classes for types that are parametric over bifunctors instead of (uni-)functors. We implement instances of the class for `LedgerTables` in #134.