### PR TITLE
Make `LedgerTables` a `newtype` instead of a data family, implement Bifunctor Barbie classes

### DIFF
--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -402,7 +402,6 @@ library cardano-testlib
     , containers
     , microlens
     , mtl
-    , nothunks
     , ouroboros-consensus-cardano
     , ouroboros-consensus-diffusion:{ouroboros-consensus-diffusion, diffusion-testlib}
     , ouroboros-consensus-protocol:{ouroboros-consensus-protocol, protocol-testlib}

--- a/ouroboros-consensus-cardano/src/byron-testlib/Test/Consensus/Byron/Examples.hs
+++ b/ouroboros-consensus-cardano/src/byron-testlib/Test/Consensus/Byron/Examples.hs
@@ -110,7 +110,7 @@ examples = Golden.Examples {
     , exampleChainDepState    = unlabelled exampleChainDepState
     , exampleExtLedgerState   = unlabelled $ forgetLedgerTables exampleExtLedgerState
     , exampleSlotNo           = unlabelled exampleSlotNo
-    , exampleLedgerTables     = unlabelled NoByronLedgerTables
+    , exampleLedgerTables     = unlabelled emptyLedgerTables
     }
   where
     regularAndEBB :: a -> a -> Labelled a

--- a/ouroboros-consensus-cardano/src/byron-testlib/Test/Consensus/Byron/Generators.hs
+++ b/ouroboros-consensus-cardano/src/byron-testlib/Test/Consensus/Byron/Generators.hs
@@ -46,6 +46,7 @@ import           Ouroboros.Consensus.Config.SecurityParam
 import           Ouroboros.Consensus.HeaderValidation (AnnTip (..))
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsMempool (GenTxId)
+import           Ouroboros.Consensus.Ledger.Tables.Utils (emptyLedgerTables)
 import           Ouroboros.Consensus.Protocol.PBFT.State (PBftState)
 import qualified Ouroboros.Consensus.Protocol.PBFT.State as PBftState
 import           Ouroboros.Network.SizeInBytes
@@ -291,8 +292,8 @@ genByronLedgerState = do
         Left _  -> pure Origin
         Right _ -> At <$> arbitrary
 
-instance Arbitrary (LedgerTables (LedgerState ByronBlock) mk) where
-  arbitrary = pure NoByronLedgerTables
+instance IsMapKind mk => Arbitrary (LedgerTables (LedgerState ByronBlock) mk) where
+  arbitrary = pure emptyLedgerTables
 
 genByronLedgerConfig :: Gen Byron.Config
 genByronLedgerConfig = hedgehog $ CC.genConfig protocolMagicId

--- a/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
+++ b/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
@@ -62,6 +62,7 @@ import           Data.ByteString (ByteString)
 import           Data.Kind (Type)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import           Data.Void (Void)
 import           GHC.Generics (Generic)
 import           NoThunks.Class (NoThunks)
 import           Ouroboros.Consensus.Block
@@ -181,21 +182,16 @@ instance IsLedger (LedgerState ByronBlock) where
             byronLedgerTransition
         }
 
-instance HasLedgerTables (LedgerState ByronBlock) where
-  data LedgerTables (LedgerState ByronBlock) mk = NoByronLedgerTables
-    deriving (Generic, Eq, Show, NoThunks)
+type instance Key   (LedgerState ByronBlock) = Void
+type instance Value (LedgerState ByronBlock) = Void
 
-instance CanSerializeLedgerTables (LedgerState ByronBlock) where
-
-instance LedgerTablesAreTrivial (LedgerState ByronBlock) where
-  convertMapKind ByronLedgerState{..} = ByronLedgerState{..}
-  trivialLedgerTables = NoByronLedgerTables
-
-instance HasTickedLedgerTables (LedgerState ByronBlock) where
-  withLedgerTablesTicked (TickedByronLedgerState st trans) NoByronLedgerTables =
-    TickedByronLedgerState st trans
-
-instance CanStowLedgerTables (LedgerState ByronBlock) where
+instance HasLedgerTables (LedgerState ByronBlock)
+instance HasLedgerTables (Ticked1 (LedgerState ByronBlock))
+instance HasTickedLedgerTables (LedgerState ByronBlock)
+instance CanSerializeLedgerTables (LedgerState ByronBlock)
+instance CanStowLedgerTables (LedgerState ByronBlock)
+instance LedgerTablesAreTrivial (LedgerState ByronBlock)
+instance LedgerTablesAreTrivial (Ticked1 (LedgerState ByronBlock))
 
 {-------------------------------------------------------------------------------
   Supporting the various consensus interfaces
@@ -220,7 +216,7 @@ data instance BlockQuery ByronBlock :: Type -> Type where
 instance QueryLedger ByronBlock where
   answerBlockQuery _cfg GetUpdateInterfaceState (DiskLedgerView (ExtLedgerState ledgerState _) _ _ _) =
     pure $ CC.cvsUpdateState (byronLedgerState ledgerState)
-  getQueryKeySets _ = NoByronLedgerTables
+  getQueryKeySets _ = trivialLedgerTables
   tableTraversingQuery _ = Nothing
 
 instance SameDepIndex (BlockQuery ByronBlock) where

--- a/ouroboros-consensus-cardano/src/byronspec/Ouroboros/Consensus/ByronSpec/Ledger/Ledger.hs
+++ b/ouroboros-consensus-cardano/src/byronspec/Ouroboros/Consensus/ByronSpec/Ledger/Ledger.hs
@@ -24,6 +24,7 @@ import qualified Byron.Spec.Ledger.Update as Spec
 import           Codec.Serialise
 import           Control.Monad.Except
 import qualified Control.State.Transition as Spec
+import           Data.Void (Void)
 import           GHC.Generics (Generic)
 import           NoThunks.Class (AllowThunk (..), NoThunks)
 import           Ouroboros.Consensus.Block
@@ -121,39 +122,15 @@ instance IsLedger (LedgerState ByronSpecBlock) where
   Ledger Tables
 -------------------------------------------------------------------------------}
 
-instance HasLedgerTables (LedgerState ByronSpecBlock) where
-  data LedgerTables (LedgerState ByronSpecBlock) mk = NoByronSpecLedgerTables
-    deriving (Generic, Eq, Show, NoThunks)
-
-instance CanSerializeLedgerTables (LedgerState ByronSpecBlock) where
-    codecLedgerTables = NoByronSpecLedgerTables
-
-instance HasTickedLedgerTables (LedgerState ByronSpecBlock) where
-  projectLedgerTablesTicked _st                     = NoByronSpecLedgerTables
-  withLedgerTablesTicked st NoByronSpecLedgerTables =
-      TickedByronSpecLedgerState { untickedByronSpecLedgerTip
-                                 , tickedByronSpecLedgerState
-                                 }
-    where
-      TickedByronSpecLedgerState { untickedByronSpecLedgerTip
-                                 , tickedByronSpecLedgerState
-                                 } = st
-
-instance LedgerTablesAreTrivial (LedgerState ByronSpecBlock) where
-  convertMapKind st =
-      ByronSpecLedgerState { byronSpecLedgerTip
-                           , byronSpecLedgerState
-                           }
-    where
-      ByronSpecLedgerState { byronSpecLedgerTip
-                           , byronSpecLedgerState
-                           } = st
-
-  trivialLedgerTables = NoByronSpecLedgerTables
-
-instance CanStowLedgerTables (LedgerState ByronSpecBlock) where
-  stowLedgerTables     = convertMapKind
-  unstowLedgerTables   = convertMapKind
+type instance Key   (LedgerState ByronSpecBlock) = Void
+type instance Value (LedgerState ByronSpecBlock) = Void
+instance HasLedgerTables (LedgerState ByronSpecBlock)
+instance HasLedgerTables (Ticked1 (LedgerState ByronSpecBlock))
+instance CanSerializeLedgerTables (LedgerState ByronSpecBlock)
+instance HasTickedLedgerTables (LedgerState ByronSpecBlock)
+instance LedgerTablesAreTrivial (LedgerState ByronSpecBlock)
+instance LedgerTablesAreTrivial (Ticked1 (LedgerState ByronSpecBlock))
+instance CanStowLedgerTables (LedgerState ByronSpecBlock)
 
 {-------------------------------------------------------------------------------
   Applying blocks

--- a/ouroboros-consensus-cardano/src/cardano-testlib/Test/Consensus/Cardano/Examples.hs
+++ b/ouroboros-consensus-cardano/src/cardano-testlib/Test/Consensus/Cardano/Examples.hs
@@ -45,7 +45,7 @@ import           Ouroboros.Consensus.HeaderValidation (AnnTip)
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.SupportsMempool (ApplyTxErr)
 import           Ouroboros.Consensus.Ledger.Tables (EmptyMK, IsMapKind,
-                     ValuesMK)
+                     ValuesMK, castLedgerTables)
 import           Ouroboros.Consensus.Protocol.Praos.Translate ()
 import           Ouroboros.Consensus.Protocol.TPraos (TPraos)
 import           Ouroboros.Consensus.Shelley.Ledger (ShelleyBlock)
@@ -164,8 +164,8 @@ injectWrapLedgerTables ::
    -> Index xs x
    -> WrapLedgerTables x
    -> WrapLedgerTables (HardForkBlock xs)
-injectWrapLedgerTables _startBounds idx (WrapLedgerTables (ExtLedgerStateTables lt)) =
-    WrapLedgerTables $ ExtLedgerStateTables $ injectLedgerTables lt
+injectWrapLedgerTables _startBounds idx (WrapLedgerTables lt) =
+    WrapLedgerTables $ castLedgerTables $ injectLedgerTables (castLedgerTables lt)
   where
     injectLedgerTables ::
          (IsMapKind mk)

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/CanHardFork.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/CanHardFork.hs
@@ -421,7 +421,7 @@ translateLedgerStateByronToShelleyWrapper =
                       ShelleyTransitionInfo{shelleyAfterVoting = 0}
                   , shelleyLedgerTables = emptyLedgerTables
                   }
-          , translateLedgerTablesWith = \NoByronLedgerTables -> emptyLedgerTables
+          , translateLedgerTablesWith = const emptyLedgerTables
           }
 
 translateChainDepStateByronToShelleyWrapper ::
@@ -555,7 +555,7 @@ translateLedgerStateShelleyToAllegraWrapper =
                   -- this, for now we choose to generate the differences out of
                   -- thin air and when the time comes in which ticking produces
                   -- differences, we will have to revisit this.
-                  avvmsAsDeletions = ShelleyLedgerTables
+                  avvmsAsDeletions = LedgerTables
                                    . DiffMK
                                    . Diff.Internal.fromMapDeletes
                                    . Map.map (  unTxOutWrapper
@@ -570,7 +570,7 @@ translateLedgerStateShelleyToAllegraWrapper =
                   -- them, modifying the reserves accordingly.
                   stowedState = stowLedgerTables
                               . withLedgerTables ls
-                              . ShelleyLedgerTables
+                              . LedgerTables
                               . ValuesMK
                               $ avvms
 
@@ -582,7 +582,7 @@ translateLedgerStateShelleyToAllegraWrapper =
               in resultingState `withLedgerTables` avvmsAsDeletions
 
         , translateLedgerTablesWith =
-             ShelleyLedgerTables . fmap (SL.translateEra' ()) . shelleyUTxOTable
+             LedgerTables . fmap (SL.translateEra' ()) . getLedgerTables
         }
 
 translateTxShelleyToAllegraWrapper ::
@@ -623,9 +623,8 @@ translateLedgerStateAllegraToMaryWrapper =
               . Comp
               . Flip
         , translateLedgerTablesWith =
-            \ShelleyLedgerTables { shelleyUTxOTable = diffMK } ->
-             ShelleyLedgerTables { shelleyUTxOTable = fmap (SL.translateEra' ()) diffMK
-                                 }
+            \(LedgerTables diffMK) ->
+             LedgerTables $ fmap (SL.translateEra' ()) diffMK
         }
 
 translateTxAllegraToMaryWrapper ::
@@ -666,9 +665,8 @@ translateLedgerStateMaryToAlonzoWrapper =
               . Comp
               . Flip
         , translateLedgerTablesWith =
-            \ShelleyLedgerTables { shelleyUTxOTable = diffMK } ->
-             ShelleyLedgerTables { shelleyUTxOTable = fmap Alonzo.translateTxOut diffMK
-                                 }
+            \(LedgerTables diffMK) ->
+             LedgerTables $ fmap Alonzo.translateTxOut diffMK
         }
 
 getAlonzoTranslationContext ::
@@ -719,9 +717,8 @@ translateLedgerStateAlonzoToBabbageWrapper =
               . Flip
               . transPraosLS
         , translateLedgerTablesWith =
-            \ShelleyLedgerTables { shelleyUTxOTable = diffMK } ->
-             ShelleyLedgerTables { shelleyUTxOTable = fmap Babbage.translateTxOut diffMK
-                                 }
+            \(LedgerTables diffMK) ->
+             LedgerTables $ fmap Babbage.translateTxOut diffMK
         }
   where
     transPraosLS ::
@@ -793,9 +790,8 @@ translateLedgerStateBabbageToConwayWrapper =
               . Comp
               . Flip
         , translateLedgerTablesWith =
-            \ShelleyLedgerTables { shelleyUTxOTable = diffMK } ->
-             ShelleyLedgerTables { shelleyUTxOTable = fmap Conway.translateTxOut diffMK
-                                 }
+            \(LedgerTables diffMK)  ->
+             LedgerTables $ fmap Conway.translateTxOut diffMK
         }
 
 getConwayTranslationContext ::

--- a/ouroboros-consensus-cardano/src/shelley-testlib/Test/Consensus/Shelley/Examples.hs
+++ b/ouroboros-consensus-cardano/src/shelley-testlib/Test/Consensus/Shelley/Examples.hs
@@ -83,7 +83,7 @@ mkLedgerTables :: forall proto era.
   => LC.Tx era
   -> LedgerTables (LedgerState (ShelleyBlock proto era)) ValuesMK
 mkLedgerTables tx =
-      ShelleyLedgerTables
+      LedgerTables
     $ ValuesMK
     $ Map.fromList
     $ zip exampleTxIns exampleTxOuts
@@ -167,7 +167,7 @@ fromShelleyLedgerExamples ShelleyLedgerExamples {
                                   }
     , shelleyLedgerState      = sleNewEpochState
     , shelleyLedgerTransition = ShelleyTransitionInfo {shelleyAfterVoting = 0}
-    , shelleyLedgerTables     = ShelleyLedgerTables EmptyMK
+    , shelleyLedgerTables     = LedgerTables EmptyMK
     }
     chainDepState = TPraosState (NotOrigin 1) sleChainDepState
     extLedgerState = ExtLedgerState

--- a/ouroboros-consensus-cardano/src/shelley-testlib/Test/Consensus/Shelley/Generators.hs
+++ b/ouroboros-consensus-cardano/src/shelley-testlib/Test/Consensus/Shelley/Generators.hs
@@ -190,7 +190,7 @@ instance CanMock proto era
     <$> arbitrary
     <*> arbitrary
     <*> arbitrary
-    <*> pure (ShelleyLedgerTables EmptyMK)
+    <*> pure (LedgerTables EmptyMK)
 
 instance CanMock proto era
       => Arbitrary (LedgerState (ShelleyBlock proto era) ValuesMK) where
@@ -198,7 +198,7 @@ instance CanMock proto era
     <$> arbitrary
     <*> arbitrary
     <*> arbitrary
-    <*> (ShelleyLedgerTables . ValuesMK <$> arbitrary)
+    <*> (LedgerTables . ValuesMK <$> arbitrary)
 
 instance CanMock proto era => Arbitrary (AnnTip (ShelleyBlock proto era)) where
   arbitrary = AnnTip

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
@@ -68,7 +68,6 @@ import           Ouroboros.Consensus.Shelley.Ledger.Ledger
                      (ShelleyLedgerConfig (shelleyLedgerGlobals),
                      Ticked1 (TickedShelleyLedgerState, tickedShelleyLedgerState),
                      getPParams)
-import qualified Ouroboros.Consensus.Shelley.Ledger.Ledger as ShelleyLedger
 import           Ouroboros.Consensus.Util (ShowProxy (..))
 import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Network.Block (unwrapCBORinCBOR, wrapCBORinCBOR)
@@ -148,7 +147,7 @@ instance ShelleyCompatible proto era
   txForgetValidated (ShelleyValidatedTx txid vtx) = ShelleyTx txid (SL.extractTx vtx)
 
   getTransactionKeySets (ShelleyTx _ tx) =
-        ShelleyLedger.ShelleyLedgerTables
+        LedgerTables
       $ KeysMK
       $ SL.getAllTxInputs (tx ^. bodyTxL)
 

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs
@@ -382,7 +382,7 @@ instance ( ShelleyCompatible proto era
       DiskLedgerView ext _ _ _ = dlv
 
   getQueryKeySets = \case
-    GetUTxOByTxIn ks -> ShelleyLedgerTables $ KeysMK ks
+    GetUTxOByTxIn ks -> LedgerTables $ KeysMK ks
     _other           -> emptyLedgerTables
 
   tableTraversingQuery = \case

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node/TPraos.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node/TPraos.hs
@@ -68,7 +68,6 @@ import qualified Ouroboros.Consensus.HardFork.History as History
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
-import           Ouroboros.Consensus.Ledger.Tables.Utils
 import           Ouroboros.Consensus.Mempool (TxLimits)
 import qualified Ouroboros.Consensus.Mempool as Mempool
 import           Ouroboros.Consensus.Node.ProtocolInfo
@@ -312,9 +311,9 @@ protocolInfoTPraosShelleyBased ProtocolParamsShelleyBased {
     initLedgerState :: LedgerState (ShelleyBlock (TPraos c) era) ValuesMK
     initLedgerState = ShelleyLedgerState {
           shelleyLedgerTip        = Origin
-        , shelleyLedgerState      = st `withUtxoSL` shelleyUTxOTable emptyLedgerTables
+        , shelleyLedgerState      = st `withUtxoSL` emptyMK
         , shelleyLedgerTransition = ShelleyTransitionInfo {shelleyAfterVoting = 0}
-        , shelleyLedgerTables     = ShelleyLedgerTables $ projectUtxoSL st
+        , shelleyLedgerTables     = LedgerTables $ projectUtxoSL st
         }
       where
         st = registerGenesisStaking (SL.sgStaking genesis) $

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/ShelleyHFC.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/ShelleyHFC.hs
@@ -366,8 +366,8 @@ translateShelleyTables ::
   => SL.TranslationContext era
   -> LedgerTables (LedgerState (ShelleyBlock proto (SL.PreviousEra era))) mk
   -> LedgerTables (LedgerState (ShelleyBlock proto                 era))  mk
-translateShelleyTables ctxt (ShelleyLedgerTables utxoTable) =
-      ShelleyLedgerTables
+translateShelleyTables ctxt (LedgerTables utxoTable) =
+      LedgerTables
     $ mapMK
         (unTxOutWrapper . SL.translateEra' ctxt . TxOutWrapper)
         utxoTable

--- a/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBAnalyser/Analysis.hs
+++ b/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBAnalyser/Analysis.hs
@@ -651,7 +651,7 @@ benchmarkLedgerOps mOutfile AnalysisEnv {db, registry, initLedger, cfg, limit, b
           urs <- readKeySets bstore aks
           case forwardTableKeySets ldb urs of
             Left err -> error $ "Rewind;read;forward failed" <> show err
-            Right forwarded -> pure $ applyLedgerTablesDiffsTicked' (unExtLedgerStateTables forwarded) st
+            Right forwarded -> pure $ applyLedgerTablesDiffsTicked' (castLedgerTables forwarded) st
 
         tickTheLedgerState ::
              SlotNo
@@ -697,7 +697,7 @@ reproMempoolForge numBlks env = do
       Mempool.LedgerInterface {
           Mempool.getCurrentLedgerState = ledgerState . DbChangelog.current <$> IOLike.readTVar ref
         , Mempool.getLedgerTablesAtFor = \pt txs -> do
-            let keys = ExtLedgerStateTables
+            let keys = castLedgerTables
                   $ foldl' (zipLedgerTables (<>)) emptyLedgerTables
                   $ map getTransactionKeySets txs
             let f = do
@@ -710,7 +710,7 @@ reproMempoolForge numBlks env = do
                       case eValues of
                         Right v -> pure $ Right v
                         Left _  -> f
-            fmap unExtLedgerStateTables <$> f
+            fmap castLedgerTables <$> f
       }
       lCfg
       -- one megabyte should generously accomodate two blocks' worth of txs

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/Consensus/Cardano/Translation.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/Consensus/Cardano/Translation.hs
@@ -59,7 +59,7 @@ import           Ouroboros.Consensus.Shelley.Eras
 import           Ouroboros.Consensus.Shelley.HFEras ()
 import           Ouroboros.Consensus.Shelley.Ledger (ShelleyBlock,
                      ShelleyLedgerConfig, mkShelleyLedgerConfig,
-                     shelleyLedgerState, shelleyLedgerTables, shelleyUTxOTable)
+                     shelleyLedgerState, shelleyLedgerTables)
 import           Ouroboros.Consensus.Shelley.Ledger.SupportsProtocol ()
 import           Ouroboros.Consensus.TypeFamilyWrappers
 import           Ouroboros.Consensus.Util (dimap)
@@ -273,7 +273,7 @@ extractUtxoDiff
   :: LedgerState (ShelleyBlock proto era) DiffMK
   -> Diff (TxIn (EraCrypto era)) (Core.TxOut era)
 extractUtxoDiff shelleyLedgerState =
-  let DiffMK tables = shelleyUTxOTable $ shelleyLedgerTables shelleyLedgerState
+  let DiffMK tables = getLedgerTables $ shelleyLedgerTables shelleyLedgerState
   in tables
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus-diffusion/src/diffusion-testlib/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-diffusion/src/diffusion-testlib/Test/ThreadNet/Network.hs
@@ -618,7 +618,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
                 -- most 1 to the number of requested keys, hence the
                 -- subtraction. When we revisit the range query implementation
                 -- we should remove this workaround.
-                fullUTxO <- unExtLedgerStateTables <$> doRangeQuery (RangeQuery Nothing (maxBound-1))
+                fullUTxO <- castLedgerTables <$> doRangeQuery (RangeQuery Nothing (maxBound-1))
                 let f (DiffMK d) (ValuesMK m) = ValuesMK $ applyDiff m d
                 pure $! zipOverLedgerTablesTicked f st fullUTxO
               pure $ isRight $ Exc.runExcept $ applyTx lcfg DoNotIntervene slot tx fullLedgerSt
@@ -895,7 +895,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
                   -- if it is valid, we retick to the /same/ slot
                   let apply  = applyLedgerBlock (configLedger pInfoConfig)
                       tables = emptyLedgerTables   -- EBBs need no input tables
-                  tickedLdgSt' <- case Exc.runExcept $ apply ebb (tickedLdgSt `withLedgerTablesTicked` tables) of
+                  tickedLdgSt' <- case Exc.runExcept $ apply ebb (tickedLdgSt `withLedgerTables` tables) of
                     Left e   -> Exn.throw $ JitEbbError @blk e
                     Right st -> pure $ applyChainTick
                                         (configLedger pInfoConfig)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/A.hs
@@ -195,22 +195,16 @@ newtype instance Ticked1 (LedgerState BlockA) mk = TickedLedgerStateA {
   Ledger Tables
 -------------------------------------------------------------------------------}
 
-instance HasLedgerTables (LedgerState BlockA) where
-  data instance LedgerTables (LedgerState BlockA) mk = NoATables
-    deriving stock    (Generic, Eq, Show)
-    deriving anyclass (NoThunks)
+type instance Key   (LedgerState BlockA) = Void
+type instance Value (LedgerState BlockA) = Void
 
-instance HasTickedLedgerTables (LedgerState BlockA) where
-  withLedgerTablesTicked (TickedLedgerStateA st) tables =
-      TickedLedgerStateA $ withLedgerTables st tables
-
-instance CanSerializeLedgerTables (LedgerState BlockA) where
-
-instance CanStowLedgerTables (LedgerState BlockA) where
-
-instance LedgerTablesAreTrivial (LedgerState BlockA) where
-  convertMapKind (LgrA tip tr) = LgrA tip tr
-  trivialLedgerTables = NoATables
+instance HasLedgerTables (LedgerState BlockA)
+instance HasLedgerTables (Ticked1 (LedgerState BlockA))
+instance HasTickedLedgerTables (LedgerState BlockA)
+instance CanSerializeLedgerTables (LedgerState BlockA)
+instance CanStowLedgerTables (LedgerState BlockA)
+instance LedgerTablesAreTrivial (LedgerState BlockA)
+instance LedgerTablesAreTrivial (Ticked1 (LedgerState BlockA))
 
 data PartialLedgerConfigA = LCfgA {
       lcfgA_k           :: SecurityParam
@@ -265,7 +259,7 @@ instance ApplyBlock (LedgerState BlockA) BlockA where
         Left  _ -> error "reapplyBlockLedgerResult: unexpected error"
         Right b -> b
 
-  getBlockKeySets _blk = NoATables
+  getBlockKeySets _blk = trivialLedgerTables
 
 instance UpdateLedger BlockA
 
@@ -365,7 +359,7 @@ instance LedgerSupportsMempool BlockA where
 
   txForgetValidated = forgetValidatedGenTxA
 
-  getTransactionKeySets _tx = NoATables
+  getTransactionKeySets _tx = trivialLedgerTables
 
 newtype instance TxId (GenTx BlockA) = TxIdA Int
   deriving stock   (Show, Eq, Ord, Generic)
@@ -382,7 +376,7 @@ data instance BlockQuery BlockA result
 
 instance QueryLedger BlockA where
   answerBlockQuery _ qry = case qry of {}
-  getQueryKeySets _ = NoATables
+  getQueryKeySets _ = trivialLedgerTables
   tableTraversingQuery _ = Nothing
 
 instance SameDepIndex (BlockQuery BlockA) where

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/B.hs
@@ -171,22 +171,17 @@ data instance LedgerState BlockB mk = LgrB {
   Ledger Tables
 -------------------------------------------------------------------------------}
 
-instance HasLedgerTables (LedgerState BlockB) where
-  data instance LedgerTables (LedgerState BlockB) mk = NoBTables
-    deriving stock    (Generic, Eq, Show)
-    deriving anyclass (NoThunks)
 
-instance HasTickedLedgerTables (LedgerState BlockB) where
-  withLedgerTablesTicked (TickedLedgerStateB st) tables =
-      TickedLedgerStateB $ withLedgerTables st tables
+type instance Key   (LedgerState BlockB) = Void
+type instance Value (LedgerState BlockB) = Void
 
-instance CanSerializeLedgerTables (LedgerState BlockB) where
-
-instance CanStowLedgerTables (LedgerState BlockB) where
-
-instance LedgerTablesAreTrivial (LedgerState BlockB) where
-  convertMapKind (LgrB t) = LgrB t
-  trivialLedgerTables = NoBTables
+instance HasLedgerTables (LedgerState BlockB)
+instance HasLedgerTables (Ticked1 (LedgerState BlockB))
+instance HasTickedLedgerTables (LedgerState BlockB)
+instance CanSerializeLedgerTables (LedgerState BlockB)
+instance CanStowLedgerTables (LedgerState BlockB)
+instance LedgerTablesAreTrivial (LedgerState BlockB)
+instance LedgerTablesAreTrivial (Ticked1 (LedgerState BlockB))
 
 type instance LedgerCfg (LedgerState BlockB) = ()
 
@@ -216,7 +211,7 @@ instance ApplyBlock (LedgerState BlockB) BlockB where
   applyBlockLedgerResult   = \_ b _ -> return $ pureLedgerResult $ LgrB (blockPoint b)
   reapplyBlockLedgerResult = \_ b _ ->          pureLedgerResult $ LgrB (blockPoint b)
 
-  getBlockKeySets _blk = NoBTables
+  getBlockKeySets _blk = trivialLedgerTables
 
 instance UpdateLedger BlockB
 
@@ -293,7 +288,7 @@ instance LedgerSupportsMempool BlockB where
 
   txForgetValidated = \case {}
 
-  getTransactionKeySets _tx = NoBTables
+  getTransactionKeySets _tx = trivialLedgerTables
 
 data instance TxId (GenTx BlockB)
   deriving stock    (Show, Eq, Ord, Generic)
@@ -310,7 +305,7 @@ data instance BlockQuery BlockB result
 
 instance QueryLedger BlockB where
   answerBlockQuery _ qry = case qry of {}
-  getQueryKeySets _ = NoBTables
+  getQueryKeySets _ = trivialLedgerTables
   tableTraversingQuery _ = Nothing
 
 instance SameDepIndex (BlockQuery BlockB) where

--- a/ouroboros-consensus/bench/backingstore-bench/Main.hs
+++ b/ouroboros-consensus/bench/backingstore-bench/Main.hs
@@ -17,7 +17,7 @@ import           Data.Set (Set)
 import qualified Data.Set as Set
 import           Data.Word (Word64)
 import           Ouroboros.Consensus.Ledger.Tables (DiffMK (..), KeysMK (..),
-                     ValuesMK)
+                     LedgerTables (..), ValuesMK)
 import           Ouroboros.Consensus.Ledger.Tables.Utils (emptyLedgerTables)
 import           Ouroboros.Consensus.Storage.LedgerDB.BackingStore
                      (BackingStorePath (..))
@@ -37,8 +37,7 @@ import           Test.Tasty (TestTree, testGroup, withResource)
 import           Test.Tasty.Bench (Benchmark, bench, bgroup, defaultMain,
                      envWithCleanup, nfAppIO)
 import           Test.Tasty.QuickCheck (testProperty)
-import           Test.Util.LedgerStateOnlyTables (OTLedgerTables,
-                     pattern OTLedgerTables)
+import           Test.Util.LedgerStateOnlyTables (OTLedgerTables)
 
 {-------------------------------------------------------------------------------
   Main benchmarks
@@ -179,10 +178,10 @@ mkKey :: k -> OTLedgerTables k v KeysMK
 mkKey = mkKeys . Set.singleton
 
 mkKeys :: Set k -> OTLedgerTables k v KeysMK
-mkKeys = OTLedgerTables . KeysMK
+mkKeys = LedgerTables . KeysMK
 
 mkDiffs :: Diff k v -> OTLedgerTables k v DiffMK
-mkDiffs = OTLedgerTables . DiffMK
+mkDiffs = LedgerTables . DiffMK
 
 groupsOfN :: Int -> [a] -> [[a]]
 groupsOfN n

--- a/ouroboros-consensus/src/consensus-testlib/Test/LedgerTables.hs
+++ b/ouroboros-consensus/src/consensus-testlib/Test/LedgerTables.hs
@@ -14,8 +14,6 @@ import           Test.QuickCheck
 (==?) ::
   ( IsMapKind mk
   , HasLedgerTables (LedgerState blk)
-  , Eq (LedgerTables (LedgerState blk) mk)
-  , Show (LedgerTables (LedgerState blk) mk)
   )
   => LedgerState blk mk
   -> LedgerState blk mk
@@ -32,9 +30,6 @@ infix 4 ==?
 prop_stowable_laws ::
      ( HasLedgerTables (LedgerState blk)
      , CanStowLedgerTables (LedgerState blk)
-     , Eq (LedgerTables (LedgerState blk) EmptyMK)
-     , Show (LedgerTables (LedgerState blk) EmptyMK)
-     , Show (LedgerTables (LedgerState blk) ValuesMK)
      )
   => LedgerState blk EmptyMK
   -> LedgerState blk ValuesMK
@@ -49,11 +44,7 @@ prop_stowable_laws = \ls ls' ->
 --
 -- > project . with == id
 prop_tablestuff_laws ::
-     ( HasLedgerTables (LedgerState blk)
-     , Eq (LedgerTables (LedgerState blk) EmptyMK)
-     , Show (LedgerTables (LedgerState blk) EmptyMK)
-     , Show (LedgerTables (LedgerState blk) ValuesMK)
-     )
+     HasLedgerTables (LedgerState blk)
   => LedgerState blk EmptyMK
   -> LedgerTables (LedgerState blk) ValuesMK
   -> Property

--- a/ouroboros-consensus/src/consensus-testlib/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/src/consensus-testlib/Test/Util/TestBlock.hs
@@ -99,6 +99,7 @@ import           Data.Tree (Tree (..))
 import qualified Data.Tree as Tree
 import           Data.TreeDiff (ToExpr)
 import           Data.Typeable (Typeable)
+import           Data.Void (Void)
 import           Data.Word
 import           GHC.Generics (Generic)
 import           NoThunks.Class (NoThunks)
@@ -373,7 +374,7 @@ instance PayloadSemantics () where
 
   applyPayload _ _ = Right EmptyPLDS
 
-  getPayloadKeySets = const NoTestLedgerTables
+  getPayloadKeySets = const trivialLedgerTables
 
 -- | Apply the payload directly to the payload dependent state portion of a
 -- ticked state, leaving the rest of the input ticked state unaltered.
@@ -456,22 +457,20 @@ instance ( Typeable ptype
 
 type instance LedgerCfg (LedgerState TestBlock) = HardFork.EraParams
 
-instance HasLedgerTables (LedgerState TestBlock) where
-  data LedgerTables (LedgerState TestBlock) mk = NoTestLedgerTables
-    deriving stock    (Generic, Eq, Show)
-    deriving anyclass (NoThunks)
+type instance Key   (LedgerState TestBlock) = Void
+type instance Value (LedgerState TestBlock) = Void
 
-instance LedgerTablesAreTrivial (LedgerState (TestBlockWith ())) where
-  convertMapKind (TestLedger lap EmptyPLDS) = TestLedger lap EmptyPLDS
-  trivialLedgerTables = NoTestLedgerTables
+instance HasLedgerTables (LedgerState TestBlock)
+instance HasLedgerTables (Ticked1 (LedgerState TestBlock))
 
-instance CanSerializeLedgerTables (LedgerState TestBlock) where
+instance LedgerTablesAreTrivial (LedgerState TestBlock)
+instance LedgerTablesAreTrivial (Ticked1 (LedgerState TestBlock))
 
-instance HasTickedLedgerTables (LedgerState TestBlock) where
-  withLedgerTablesTicked (TickedTestLedger st) tables =
-      TickedTestLedger $ withLedgerTables st tables
+instance CanSerializeLedgerTables (LedgerState TestBlock)
 
-instance CanStowLedgerTables (LedgerState TestBlock) where
+instance HasTickedLedgerTables (LedgerState TestBlock)
+
+instance CanStowLedgerTables (LedgerState TestBlock)
 
 instance PayloadSemantics ptype
          => ApplyBlock (LedgerState (TestBlockWith ptype)) (TestBlockWith ptype) where

--- a/ouroboros-consensus/src/mock-block/Ouroboros/Consensus/Mock/Node/Serialisation.hs
+++ b/ouroboros-consensus/src/mock-block/Ouroboros/Consensus/Mock/Node/Serialisation.hs
@@ -55,7 +55,7 @@ instance Serialise ext => DecodeDisk (MockBlock ext) (Lazy.ByteString -> Header 
 instance EncodeDisk (MockBlock ext) (LedgerState (MockBlock ext) EmptyMK) where
   encodeDisk _ = encode . simpleLedgerState
 instance DecodeDisk (MockBlock ext) (LedgerState (MockBlock ext) EmptyMK) where
-  decodeDisk _ = flip SimpleLedgerState (SimpleLedgerTables EmptyMK) <$> decode
+  decodeDisk _ = flip SimpleLedgerState (LedgerTables EmptyMK) <$> decode
 
 instance EncodeDisk (MockBlock ext) (AnnTip (MockBlock ext)) where
   encodeDisk _ = defaultEncodeAnnTip encode

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Ledger.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Ledger.hs
@@ -32,7 +32,6 @@ module Ouroboros.Consensus.HardFork.Combinator.Ledger (
   ) where
 
 import           Control.Monad.Except
-import           Data.Coerce
 import           Data.Functor ((<&>))
 import           Data.Functor.Product
 import           Data.Proxy
@@ -809,64 +808,35 @@ injectLedgerEvent index =
   for the unary HF block.
 -------------------------------------------------------------------------------}
 
+type instance Key   (LedgerState (HardForkBlock '[blk])) = Key   (LedgerState blk)
+type instance Value (LedgerState (HardForkBlock '[blk])) = Value (LedgerState blk)
+
 instance HasLedgerTables (LedgerState blk)
       => HasLedgerTables (LedgerState (HardForkBlock '[blk])) where
 
-  newtype LedgerTables (LedgerState (HardForkBlock '[blk])) mk = OneEraLedgerTables {
-      unOneEraLedgerTables :: LedgerTables (LedgerState blk) mk
-      }
-    deriving (Generic)
-
   projectLedgerTables (HardForkLedgerState (HardForkState (Telescope.TZ (Current _ (Flip lstate))))) =
-      OneEraLedgerTables (projectLedgerTables lstate)
-  withLedgerTables (HardForkLedgerState (HardForkState (Telescope.TZ (Current s (Flip lstate))))) (OneEraLedgerTables tables) =
-      HardForkLedgerState (HardForkState (Telescope.TZ (Current s (Flip $ lstate `withLedgerTables` tables))))
-
-  traverseLedgerTables f (OneEraLedgerTables  l) =
-    OneEraLedgerTables  <$> traverseLedgerTables f l
-
-  pureLedgerTables  f = coerce $ pureLedgerTables  @(LedgerState blk) f
-  mapLedgerTables   f = coerce $ mapLedgerTables   @(LedgerState blk) f
-  zipLedgerTables   f = coerce $ zipLedgerTables   @(LedgerState blk) f
-  zipLedgerTables3  f = coerce $ zipLedgerTables3  @(LedgerState blk) f
-  foldLedgerTables  f = coerce $ foldLedgerTables  @(LedgerState blk) f
-  foldLedgerTables2 f = coerce $ foldLedgerTables2 @(LedgerState blk) f
-  namesLedgerTables   = coerce $ namesLedgerTables @(LedgerState blk)
-  zipLedgerTablesA  f (OneEraLedgerTables l) (OneEraLedgerTables r) =
-    OneEraLedgerTables <$> zipLedgerTablesA f l r
-  zipLedgerTables3A  f tl tc tr =
-     OneEraLedgerTables <$> zipLedgerTables3A f l c r
-   where
-     OneEraLedgerTables l = tl
-     OneEraLedgerTables c = tc
-     OneEraLedgerTables r = tr
-
-deriving instance Eq (LedgerTables (LedgerState blk) mk)
-               => Eq (LedgerTables (LedgerState (HardForkBlock '[blk])) mk)
-deriving newtype instance NoThunks (LedgerTables (LedgerState blk) mk)
-                       => NoThunks (LedgerTables (LedgerState (HardForkBlock '[blk])) mk)
-deriving instance Show (LedgerTables (LedgerState blk) mk)
-               => Show (LedgerTables (LedgerState (HardForkBlock '[blk])) mk)
+      castLedgerTables (projectLedgerTables lstate)
+  withLedgerTables (HardForkLedgerState (HardForkState (Telescope.TZ (Current s (Flip lstate))))) tables =
+      HardForkLedgerState (HardForkState (Telescope.TZ (Current s (Flip $ lstate `withLedgerTables` castLedgerTables tables))))
 
 instance CanSerializeLedgerTables (LedgerState blk)
       => CanSerializeLedgerTables (LedgerState (HardForkBlock '[blk])) where
-  codecLedgerTables = OneEraLedgerTables codecLedgerTables
+  codecLedgerTables = castLedgerTables $ codecLedgerTables @(LedgerState blk)
 
 instance LedgerTablesAreTrivial (LedgerState blk)
       => LedgerTablesAreTrivial (LedgerState (HardForkBlock '[blk])) where
-  convertMapKind (HardForkLedgerState (HardForkState (Telescope.TZ (Current s (Flip lstate))))) =
-      HardForkLedgerState (HardForkState (Telescope.TZ (Current s (Flip $ convertMapKind lstate))))
 
-  trivialLedgerTables = OneEraLedgerTables trivialLedgerTables
+instance HasLedgerTables (Ticked1 (LedgerState blk))
+      => HasLedgerTables (Ticked1 (LedgerState (HardForkBlock '[blk]))) where
+  projectLedgerTables (TickedHardForkLedgerState _ (HardForkState (Telescope.TZ (Current _ (FlipTickedLedgerState lstate))))) =
+      castLedgerTables (projectLedgerTables lstate)
+  withLedgerTables
+    (TickedHardForkLedgerState i (HardForkState (Telescope.TZ (Current s (FlipTickedLedgerState lstate)))))
+    tables =
+      TickedHardForkLedgerState i (HardForkState (Telescope.TZ (Current s (FlipTickedLedgerState $ lstate `withLedgerTables` castLedgerTables tables))))
 
 instance HasTickedLedgerTables (LedgerState blk)
       => HasTickedLedgerTables (LedgerState (HardForkBlock '[blk])) where
-  projectLedgerTablesTicked (TickedHardForkLedgerState _ (HardForkState (Telescope.TZ (Current _ (FlipTickedLedgerState lstate))))) =
-      OneEraLedgerTables (projectLedgerTablesTicked lstate)
-  withLedgerTablesTicked
-    (TickedHardForkLedgerState i (HardForkState (Telescope.TZ (Current s (FlipTickedLedgerState lstate)))))
-    (OneEraLedgerTables tables) =
-      TickedHardForkLedgerState i (HardForkState (Telescope.TZ (Current s (FlipTickedLedgerState $ lstate `withLedgerTablesTicked` tables))))
 
 instance CanStowLedgerTables (LedgerState blk)
       => CanStowLedgerTables (LedgerState (HardForkBlock '[blk])) where
@@ -878,7 +848,7 @@ instance CanStowLedgerTables (LedgerState blk)
 
 instance LedgerTablesCanHardFork '[blk] where
   hardForkInjectLedgerTables =
-       (InjectLedgerTables { applyInjectLedgerTables = OneEraLedgerTables
-                           , applyDistribLedgerTables = unOneEraLedgerTables
+       (InjectLedgerTables { applyInjectLedgerTables = castLedgerTables
+                           , applyDistribLedgerTables = castLedgerTables
                            })
     :* Nil

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Ledger/Query.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Ledger/Query.hs
@@ -199,9 +199,9 @@ distribDiskLedgerView dlv =
      => Index xs x
      -> LedgerTables (ExtLedgerState x) mk
      -> LedgerTables (ExtLedgerState (HardForkBlock xs)) mk
-   injectLedgerTables i = ExtLedgerStateTables
+   injectLedgerTables i = castLedgerTables
                         . applyInjectLedgerTables (projectNP i hardForkInjectLedgerTables)
-                        . unExtLedgerStateTables
+                        . castLedgerTables
 
    injectRangeQuery :: forall x mk.
         IsMapKind mk
@@ -215,9 +215,9 @@ distribDiskLedgerView dlv =
      => Index xs x
      -> LedgerTables (ExtLedgerState (HardForkBlock xs)) mk
      -> LedgerTables (ExtLedgerState x) mk
-   distribLedgerTables i = ExtLedgerStateTables
+   distribLedgerTables i = castLedgerTables
                          . applyDistribLedgerTables (projectNP i hardForkInjectLedgerTables)
-                         . unExtLedgerStateTables
+                         . castLedgerTables
 
 -- | Precondition: the 'ledgerState' and 'headerState' should be from the same
 -- era. In practice, this is _always_ the case, unless the 'ExtLedgerState' was

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Extended.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Extended.hs
@@ -32,7 +32,6 @@ module Ouroboros.Consensus.Ledger.Extended (
 import           Codec.CBOR.Decoding (Decoder, decodeListLenOf)
 import           Codec.CBOR.Encoding (Encoding, encodeListLen)
 import           Control.Monad.Except
-import           Data.Coerce
 import           Data.Functor ((<&>))
 import           Data.Proxy
 import           Data.Typeable
@@ -182,7 +181,7 @@ instance LedgerSupportsProtocol blk => ApplyBlock (ExtLedgerState blk) blk where
           (getHeader blk)
           tickedHeaderState
 
-  getBlockKeySets = ExtLedgerStateTables . getBlockKeySets
+  getBlockKeySets = castLedgerTables . getBlockKeySets @(LedgerState blk)
 
 {-------------------------------------------------------------------------------
   Serialisation
@@ -225,64 +224,42 @@ decodeExtLedgerState decodeLedgerState
   Ledger Tables
 -------------------------------------------------------------------------------}
 
+type instance Key   (ExtLedgerState blk) = Key   (LedgerState blk)
+type instance Value (ExtLedgerState blk) = Value (LedgerState blk)
+
 instance HasLedgerTables (LedgerState blk)
       => HasLedgerTables (ExtLedgerState blk) where
-
-  newtype LedgerTables (ExtLedgerState blk) mk = ExtLedgerStateTables {
-      unExtLedgerStateTables :: LedgerTables (LedgerState blk) mk
-      }
-    deriving (Generic)
-
   projectLedgerTables (ExtLedgerState lstate _) =
-      ExtLedgerStateTables (projectLedgerTables lstate)
-  withLedgerTables (ExtLedgerState lstate hstate) (ExtLedgerStateTables tables) =
-      ExtLedgerState (lstate `withLedgerTables` tables) hstate
-
-  traverseLedgerTables f (ExtLedgerStateTables l) =
-    ExtLedgerStateTables <$> traverseLedgerTables f l
-
-  pureLedgerTables  f = coerce $ pureLedgerTables  @(LedgerState blk) f
-  mapLedgerTables   f = coerce $ mapLedgerTables   @(LedgerState blk) f
-  zipLedgerTables   f = coerce $ zipLedgerTables   @(LedgerState blk) f
-  zipLedgerTables3  f = coerce $ zipLedgerTables3  @(LedgerState blk) f
-  foldLedgerTables  f = coerce $ foldLedgerTables  @(LedgerState blk) f
-  foldLedgerTables2 f = coerce $ foldLedgerTables2 @(LedgerState blk) f
-  namesLedgerTables   = coerce $ namesLedgerTables @(LedgerState blk)
-  zipLedgerTablesA  f (ExtLedgerStateTables l) (ExtLedgerStateTables r) =
-    ExtLedgerStateTables <$> zipLedgerTablesA f l r
-  zipLedgerTables3A  f tl tc tr =
-     ExtLedgerStateTables <$> zipLedgerTables3A f l c r
-   where
-     ExtLedgerStateTables l = tl
-     ExtLedgerStateTables c = tc
-     ExtLedgerStateTables r = tr
-
-deriving instance Eq (LedgerTables (LedgerState blk) mk)
-               => Eq (LedgerTables (ExtLedgerState blk) mk)
-deriving newtype instance NoThunks (LedgerTables (LedgerState blk) mk)
-                       => NoThunks (LedgerTables (ExtLedgerState blk) mk)
-deriving instance Show (LedgerTables (LedgerState blk) mk)
-               => Show (LedgerTables (ExtLedgerState blk) mk)
+      castLedgerTables (projectLedgerTables lstate)
+  withLedgerTables (ExtLedgerState lstate hstate) tables =
+      ExtLedgerState
+        (lstate `withLedgerTables` castLedgerTables tables)
+        hstate
 
 instance CanSerializeLedgerTables (LedgerState blk)
       => CanSerializeLedgerTables (ExtLedgerState blk) where
-  codecLedgerTables = ExtLedgerStateTables codecLedgerTables
+  codecLedgerTables = castLedgerTables $ codecLedgerTables @(LedgerState blk)
 
 instance LedgerTablesAreTrivial (LedgerState blk)
-      => LedgerTablesAreTrivial (ExtLedgerState blk) where
-  convertMapKind (ExtLedgerState st hst) =
-      flip ExtLedgerState hst $ convertMapKind st
+      => LedgerTablesAreTrivial (ExtLedgerState blk)
 
-  trivialLedgerTables = ExtLedgerStateTables trivialLedgerTables
+instance LedgerTablesAreTrivial (Ticked1 (LedgerState blk))
+      => LedgerTablesAreTrivial (Ticked1 (ExtLedgerState blk))
+
+instance HasLedgerTables (Ticked1 (LedgerState blk))
+      => HasLedgerTables (Ticked1 (ExtLedgerState blk)) where
+  projectLedgerTables (TickedExtLedgerState lstate _view _hstate) =
+      castLedgerTables (projectLedgerTables lstate)
+  withLedgerTables
+    (TickedExtLedgerState lstate view hstate)
+    tables =
+      TickedExtLedgerState
+        (lstate `withLedgerTables` castLedgerTables tables)
+        view
+        hstate
 
 instance HasTickedLedgerTables (LedgerState blk)
-      => HasTickedLedgerTables (ExtLedgerState blk) where
-  projectLedgerTablesTicked (TickedExtLedgerState lstate _view _hstate) =
-      ExtLedgerStateTables (projectLedgerTablesTicked lstate)
-  withLedgerTablesTicked
-    (TickedExtLedgerState lstate view hstate)
-    (ExtLedgerStateTables tables) =
-      TickedExtLedgerState (lstate `withLedgerTablesTicked` tables) view hstate
+      => HasTickedLedgerTables (ExtLedgerState blk)
 
 instance CanStowLedgerTables (LedgerState blk)
       => CanStowLedgerTables (ExtLedgerState blk) where

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Query.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Query.hs
@@ -463,7 +463,7 @@ handleQueryWithStowedKeySets ::
 handleQueryWithStowedKeySets dlv query f = do
     let DiskLedgerView st dbRead _dbReadRange _dbClose = dlv
         keys                                           = getQueryKeySets query
-    values <- dbRead (ExtLedgerStateTables keys)
+    values <- dbRead (castLedgerTables keys)
     pure $ f (stowLedgerTables $ st `withLedgerTables` values)
 
 data TraversingQueryHandler blk result where

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Tables/Utils.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Tables/Utils.hs
@@ -96,7 +96,7 @@ overLedgerTablesTicked ::
   -> Ticked1 l mk1
   -> Ticked1 l mk2
 overLedgerTablesTicked f l =
-    withLedgerTablesTicked l $ f $ projectLedgerTablesTicked l
+    withLedgerTables l $ castLedgerTables $ f $ castLedgerTables $ projectLedgerTables l
 
 mapOverLedgerTablesTicked ::
      (HasTickedLedgerTables l, IsMapKind mk1, IsMapKind mk2)
@@ -182,7 +182,7 @@ prependLedgerTablesDiffsFromTicked :: HasTickedLedgerTables l => Ticked1      l 
 prependLedgerTablesDiffsTicked     :: HasTickedLedgerTables l =>              l DiffMK -> Ticked1 l DiffMK -> Ticked1 l DiffMK
 prependLedgerTablesDiffsRaw        = flip (zipOverLedgerTables rawPrependDiffs)
 prependLedgerTablesDiffs           = prependLedgerTablesDiffsRaw . projectLedgerTables
-prependLedgerTablesDiffsFromTicked = prependLedgerTablesDiffsRaw . projectLedgerTablesTicked
+prependLedgerTablesDiffsFromTicked = prependLedgerTablesDiffsRaw . castLedgerTables . projectLedgerTables
 prependLedgerTablesDiffsTicked     = flip (zipOverLedgerTablesTicked rawPrependDiffs) . projectLedgerTables
 
 -- Apply diffs
@@ -201,7 +201,7 @@ applyLedgerTablesDiffsFromTicked :: HasTickedLedgerTables l => Ticked1      l Va
 applyLedgerTablesDiffs           = flip (zipOverLedgerTables       $ flip rawApplyDiffs) . projectLedgerTables
 applyLedgerTablesDiffsTicked     = flip (zipOverLedgerTablesTicked $ flip rawApplyDiffs) . projectLedgerTables
 applyLedgerTablesDiffsTicked'    = flip (zipOverLedgerTablesTicked $ flip rawApplyDiffs)
-applyLedgerTablesDiffsFromTicked = flip (zipOverLedgerTables       $ flip rawApplyDiffs) . projectLedgerTablesTicked
+applyLedgerTablesDiffsFromTicked = flip (zipOverLedgerTables       $ flip rawApplyDiffs) . castLedgerTables . projectLedgerTables
 
 -- Calculate differences
 
@@ -216,8 +216,8 @@ calculateAdditions        ::       HasLedgerTables l =>         l ValuesMK ->   
 calculateDifference       :: HasTickedLedgerTables l => Ticked1 l ValuesMK ->         l ValuesMK ->         l TrackingMK
 calculateDifferenceTicked :: HasTickedLedgerTables l => Ticked1 l ValuesMK -> Ticked1 l ValuesMK -> Ticked1 l TrackingMK
 calculateAdditions               after = zipOverLedgerTables       (flip rawCalculateDifference) after emptyLedgerTables
-calculateDifference       before after = zipOverLedgerTables       (flip rawCalculateDifference) after (projectLedgerTablesTicked before)
-calculateDifferenceTicked before after = zipOverLedgerTablesTicked (flip rawCalculateDifference) after (projectLedgerTablesTicked before)
+calculateDifference       before after = zipOverLedgerTables       (flip rawCalculateDifference) after (castLedgerTables $ projectLedgerTables before)
+calculateDifferenceTicked before after = zipOverLedgerTablesTicked (flip rawCalculateDifference) after (castLedgerTables $ projectLedgerTables before)
 
 rawAttachAndApplyDiffs ::
      Ord k
@@ -261,7 +261,8 @@ prependLedgerTablesTrackingDiffs ::
   -> Ticked1 l TrackingMK
 prependLedgerTablesTrackingDiffs after before =
     zipOverLedgerTablesTicked rawPrependTrackingDiffs after
-  $ projectLedgerTablesTicked before
+  $ castLedgerTables
+  $ projectLedgerTables before
 
 rawReapplyTracking ::
      Ord k

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Impl/Common.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Impl/Common.hs
@@ -49,8 +49,7 @@ import           GHC.Generics (Generic)
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
-import           Ouroboros.Consensus.Ledger.Extended (LedgerTables (..),
-                     ledgerState)
+import           Ouroboros.Consensus.Ledger.Extended (ledgerState)
 import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.Ledger.Tables.Utils
 import           Ouroboros.Consensus.Mempool.API
@@ -189,10 +188,10 @@ chainDBLedgerInterface chainDB = LedgerInterface
     { getCurrentLedgerState =
         ledgerState . current <$> ChainDB.getLedgerDB chainDB
     , getLedgerTablesAtFor = \pt txs -> do
-        let keys = ExtLedgerStateTables
-                 $ foldl' (<>) emptyLedgerTables
+        let keys = castLedgerTables
+                 $ foldl' (zipLedgerTables (<>)) emptyLedgerTables
                  $ map getTransactionKeySets txs
-        fmap unExtLedgerStateTables <$> ChainDB.getLedgerTablesAtFor chainDB pt keys
+        fmap castLedgerTables <$> ChainDB.getLedgerTablesAtFor chainDB pt keys
     }
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Query.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Query.hs
@@ -59,11 +59,11 @@ implGetSnapshotFor mpEnv slot ticked extChlog extLbsvh = do
   where
     LedgerBackingStoreValueHandle vhSlot vh =
       castLedgerBackingStoreValueHandle
-      unExtLedgerStateTables
-      ExtLedgerStateTables
+      castLedgerTables
+      castLedgerTables
       extLbsvh
 
-    chlog = unExtLedgerStateTables extChlog
+    chlog = castLedgerTables extChlog
 
     getSnap is tbs = pureGetSnapshotFor
                        capacityOverride

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/DbChangelog.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/DbChangelog.hs
@@ -117,11 +117,11 @@ data DbChangelog l = DbChangelog {
   }
   deriving (Generic)
 
-deriving instance (Eq       (LedgerTables l SeqDiffMK), Eq       (l EmptyMK))
+deriving instance (Eq       (Key l), Eq       (Value l), Eq       (l EmptyMK))
                =>  Eq       (DbChangelog l)
-deriving instance (NoThunks (LedgerTables l SeqDiffMK), NoThunks (l EmptyMK))
+deriving instance (NoThunks (Key l), NoThunks (Value l), NoThunks (l EmptyMK))
                =>  NoThunks (DbChangelog l)
-deriving instance (Show     (LedgerTables l SeqDiffMK), Show     (l EmptyMK))
+deriving instance (Show     (Key l), Show     (Value l), Show     (l EmptyMK))
                =>  Show     (DbChangelog l)
 
 instance GetTip l => AS.Anchorable (WithOrigin SlotNo) (l EmptyMK) (l EmptyMK) where

--- a/ouroboros-consensus/src/tutorials/Ouroboros/Consensus/Tutorial/Simple.lhs
+++ b/ouroboros-consensus/src/tutorials/Ouroboros/Consensus/Tutorial/Simple.lhs
@@ -623,7 +623,7 @@ the `ApplyBlock` typeclass:
 >                  , lrResult = convertMapKind $ block `applyBlockTo` tickedLdgrSt
 >                  }
 >
->   getBlockKeySets = const NoLedgerTables
+>   getBlockKeySets = const trivialLedgerTables
 >
 >
 
@@ -737,18 +737,13 @@ the `LedgerTables`. For a Ledger state definition as simple as the one we are
 defining there the tables are trivially empty so the operations are all trivial
 and we use the default implementation
 
-> instance HasLedgerTables (LedgerState BlockC) where
->   data LedgerTables (LedgerState BlockC) mk =
->        NoLedgerTables
->        deriving (Generic, Eq, Show, NoThunks)
+> type instance Key   (LedgerState BlockC) = Void
+> type instance Value (LedgerState BlockC) = Void
 >
-> instance HasTickedLedgerTables (LedgerState BlockC) where
->   withLedgerTablesTicked (TickedLedgerStateC st) tbs =
->     TickedLedgerStateC (withLedgerTables st tbs)
->
+> instance HasLedgerTables (LedgerState BlockC)
+> instance HasLedgerTables (Ticked1 (LedgerState BlockC))
+> instance HasTickedLedgerTables (LedgerState BlockC)
 > instance CanSerializeLedgerTables (LedgerState BlockC)
 > instance CanStowLedgerTables (LedgerState BlockC)
->
-> instance LedgerTablesAreTrivial (LedgerState BlockC) where
->   convertMapKind (LedgerC t c) = LedgerC t c
->   trivialLedgerTables = NoLedgerTables
+> instance LedgerTablesAreTrivial (LedgerState BlockC)
+> instance LedgerTablesAreTrivial (Ticked1 (LedgerState BlockC))

--- a/ouroboros-consensus/src/tutorials/Ouroboros/Consensus/Tutorial/WithEpoch.lhs
+++ b/ouroboros-consensus/src/tutorials/Ouroboros/Consensus/Tutorial/WithEpoch.lhs
@@ -56,6 +56,7 @@ And imports, of course:
 
 > import Control.Monad ()
 > import Control.Monad.Except (MonadError (throwError))
+> import Data.Void (Void)
 > import Data.Word (Word64)
 > import GHC.Generics (Generic)
 > import NoThunks.Class (NoThunks, OnlyCheckWhnfNamed (..))
@@ -414,7 +415,7 @@ applying each individual transaction - exactly as it was in for `BlockC`:
 >                  , lrEvents = []
 >                  }
 >
->   getBlockKeySets = const NoLedgerTables
+>   getBlockKeySets = const trivialLedgerTables
 
 Note that prior to `applyBlockLedgerResult` being invoked, the calling code will
 have already established that the header is valid and that the header matches
@@ -683,18 +684,13 @@ Appendix: UTxO-HD features
 For reference on these instances and their meaning, please see the appendix in
 [the Simple tutorial](./Simple.lhs).
 
-> instance HasLedgerTables (LedgerState BlockD) where
->   data LedgerTables (LedgerState BlockD) mk =
->        NoLedgerTables
->        deriving (Generic, Eq, Show, NoThunks)
+> type instance Key   (LedgerState BlockD) = Void
+> type instance Value (LedgerState BlockD) = Void
 >
-> instance HasTickedLedgerTables (LedgerState BlockD) where
->   withLedgerTablesTicked (TickedLedgerStateD st) tbs =
->     TickedLedgerStateD (withLedgerTables st tbs)
->
+> instance HasLedgerTables (LedgerState BlockD)
+> instance HasLedgerTables (Ticked1 (LedgerState BlockD))
+> instance HasTickedLedgerTables (LedgerState BlockD)
 > instance CanSerializeLedgerTables (LedgerState BlockD)
 > instance CanStowLedgerTables (LedgerState BlockD)
->
-> instance LedgerTablesAreTrivial (LedgerState BlockD) where
->   convertMapKind (LedgerD t c a b) = LedgerD t c a b
->   trivialLedgerTables = NoLedgerTables
+> instance LedgerTablesAreTrivial (LedgerState BlockD)
+> instance LedgerTablesAreTrivial (Ticked1 (LedgerState BlockD))

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool.hs
@@ -702,7 +702,7 @@ withTestMempool setup@TestSetup {..} prop =
                          snapshotSlotNo
                          tx
                          (forgetLedgerTablesDiffsTicked st)
-          let origTables = projectLedgerTablesTicked st
+          let origTables = castLedgerTables $ projectLedgerTables st
           pure (zipOverLedgerTablesTicked rawPrependTrackingDiffs
                                           (fst st')
                                           origTables

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/Fairness/TestBlock.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/Fairness/TestBlock.hs
@@ -18,14 +18,16 @@ module Test.Consensus.Mempool.Fairness.TestBlock (
 
 import           Codec.Serialise
 import           Control.DeepSeq (NFData)
+import           Data.Void (Void)
 import           Data.Word (Word32)
 import           GHC.Generics (Generic)
 import           NoThunks.Class (NoThunks)
 import qualified Ouroboros.Consensus.Block as Block
-import           Ouroboros.Consensus.Ledger.Abstract
-                     (LedgerTablesAreTrivial (convertMapKind))
+import           Ouroboros.Consensus.Ledger.Abstract (convertMapKind,
+                     trivialLedgerTables)
 import qualified Ouroboros.Consensus.Ledger.Abstract as Ledger
 import qualified Ouroboros.Consensus.Ledger.SupportsMempool as Ledger
+import           Ouroboros.Consensus.Ticked (Ticked1)
 import qualified Test.Util.TestBlock as TestBlock
 import           Test.Util.TestBlock (TestBlockWith)
 
@@ -57,7 +59,7 @@ instance TestBlock.PayloadSemantics Tx where
 
   applyPayload NoPayLoadDependentState _tx = Right NoPayLoadDependentState
 
-  getPayloadKeySets = const NoTestLedgerTables
+  getPayloadKeySets = const trivialLedgerTables
 
 
 data instance Block.CodecConfig TestBlock = TestBlockCodecConfig
@@ -118,7 +120,7 @@ instance Ledger.LedgerSupportsMempool TestBlock where
 
   txForgetValidated (ValidatedGenTx tx) = tx
 
-  getTransactionKeySets _ = NoTestLedgerTables
+  getTransactionKeySets _ = trivialLedgerTables
 
 {-------------------------------------------------------------------------------
   Ledger support (empty tables)
@@ -126,21 +128,13 @@ instance Ledger.LedgerSupportsMempool TestBlock where
 
 type instance Ledger.ApplyTxErr TestBlock = ()
 
-instance Ledger.HasLedgerTables (Ledger.LedgerState TestBlock) where
-  data LedgerTables (Ledger.LedgerState TestBlock) mk = NoTestLedgerTables
-    deriving stock    (Generic, Eq, Show)
-    deriving anyclass (NoThunks)
+type instance Ledger.Key   (Ledger.LedgerState TestBlock) = Void
+type instance Ledger.Value (Ledger.LedgerState TestBlock) = Void
 
-instance Ledger.LedgerTablesAreTrivial (Ledger.LedgerState TestBlock) where
-  convertMapKind st = TestBlock.TestLedger lap NoPayLoadDependentState
-    where
-        TestBlock.TestLedger lap NoPayLoadDependentState = st
-  trivialLedgerTables = NoTestLedgerTables
-
-instance Ledger.CanStowLedgerTables (Ledger.LedgerState TestBlock) where
-
-instance Ledger.HasTickedLedgerTables (Ledger.LedgerState TestBlock) where
-  withLedgerTablesTicked (TestBlock.TickedTestLedger st) tables =
-      TestBlock.TickedTestLedger $ Ledger.withLedgerTables st tables
-
-instance Ledger.CanSerializeLedgerTables (Ledger.LedgerState TestBlock) where
+instance Ledger.HasLedgerTables (Ledger.LedgerState TestBlock)
+instance Ledger.HasLedgerTables (Ticked1 (Ledger.LedgerState TestBlock))
+instance Ledger.HasTickedLedgerTables (Ledger.LedgerState TestBlock)
+instance Ledger.LedgerTablesAreTrivial (Ledger.LedgerState TestBlock)
+instance Ledger.LedgerTablesAreTrivial (Ticked1 (Ledger.LedgerState TestBlock))
+instance Ledger.CanStowLedgerTables (Ledger.LedgerState TestBlock)
+instance Ledger.CanSerializeLedgerTables (Ledger.LedgerState TestBlock)

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/Util.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/Util.hs
@@ -113,7 +113,7 @@ txIsValid ledgerState tx =
     isRight $ runExcept $ applyTxToLedger ledgerState tx
 
 genValidTx :: LedgerState TestBlock ValuesMK -> Gen (TestTx, LedgerState TestBlock ValuesMK)
-genValidTx ledgerState@(SimpleLedgerState MockState {} (SimpleLedgerTables (ValuesMK utxo))) = do
+genValidTx ledgerState@(SimpleLedgerState MockState {} (LedgerTables (ValuesMK utxo))) = do
     -- Never let someone go broke, otherwise we risk concentrating all the
     -- wealth in one person. That would be problematic (for the society) but
     -- also because we wouldn't be able to generate any valid transactions
@@ -164,7 +164,7 @@ genInvalidTx ledgerState = do
 
   where
     SimpleLedgerState {
-      simpleLedgerTables = SimpleLedgerTables (ValuesMK utxo)
+      simpleLedgerTables = LedgerTables (ValuesMK utxo)
     } = ledgerState
 
 

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
@@ -199,8 +199,8 @@ mkServer k chain = do
     mkDLV ldb =
       DiskLedgerView
         (LedgerDB.current ldb)
-        (\(ExtLedgerStateTables NoTestLedgerTables) -> pure $ ExtLedgerStateTables NoTestLedgerTables)
-        (\_rq -> pure $ ExtLedgerStateTables NoTestLedgerTables)
+        (\_ -> pure trivialLedgerTables)
+        (\_rq -> pure trivialLedgerTables)
         (pure ())
 
 -- | Initialise a 'LedgerDB' with the given chain.
@@ -223,7 +223,7 @@ initLedgerDB k chain = do
       bstore <- LedgerDB.newBackingStore
         backingStoreInitialiser
         (SomeHasFS (simHasFS v))
-        (ExtLedgerStateTables NoTestLedgerTables)
+        trivialLedgerTables
       let st = LedgerDB.LedgerDBState varDB bstore rawLock varPrevApplied
       LedgerDB.mkLedgerDB st args resolve
 

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/DbChangelog.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/DbChangelog.hs
@@ -27,7 +27,8 @@ import qualified Data.Set as Set
 import           GHC.Generics (Generic)
 import           NoThunks.Class (NoThunks)
 import           Ouroboros.Consensus.Config.SecurityParam (SecurityParam (..))
-import           Ouroboros.Consensus.Ledger.Basics hiding (LedgerState)
+import           Ouroboros.Consensus.Ledger.Basics hiding (Key, LedgerState)
+import qualified Ouroboros.Consensus.Ledger.Basics as Ledger
 import           Ouroboros.Consensus.Ledger.Tables.DiffSeq as DS
 import           Ouroboros.Consensus.Storage.LedgerDB.Config (FlushPolicy (..))
 import           Ouroboros.Consensus.Storage.LedgerDB.DbChangelog
@@ -103,24 +104,12 @@ instance StandardHash TestLedger
 
 deriving instance Eq (TestLedger EmptyMK)
 
-instance HasLedgerTables TestLedger where
-  data LedgerTables TestLedger mk = TestTables { unTestTables :: mk Key Int } deriving (Generic)
-  projectLedgerTables                                                 = TestTables . tlUtxos
-  withLedgerTables st    (TestTables x)                               = st { tlUtxos = x }
-  pureLedgerTables                                                    = TestTables
-  mapLedgerTables f      (TestTables x)                               = TestTables (f x)
-  traverseLedgerTables f (TestTables x)                               = TestTables <$> f x
-  zipLedgerTables f      (TestTables x) (TestTables y)                = TestTables (f x y)
-  zipLedgerTables3 f     (TestTables x) (TestTables y) (TestTables z) = TestTables (f x y z)
-  zipLedgerTablesA f     (TestTables x) (TestTables y)                = TestTables <$> f x y
-  zipLedgerTables3A f    (TestTables x) (TestTables y) (TestTables z) = TestTables <$> f x y z
-  foldLedgerTables f     (TestTables x)                               = f x
-  foldLedgerTables2 f    (TestTables x) (TestTables y)                = f x y
-  namesLedgerTables = TestTables $ NameMK "TestTables"
+type instance Ledger.Key   TestLedger = Key
+type instance Ledger.Value TestLedger = Int
 
-deriving instance (IsMapKind mk, Eq (mk Key Int)) => Eq (LedgerTables TestLedger mk)
-deriving instance (IsMapKind mk, NoThunks (mk Key Int)) => NoThunks (LedgerTables TestLedger mk)
-deriving instance (IsMapKind mk, Show (mk Key Int)) => Show (LedgerTables TestLedger mk)
+instance HasLedgerTables TestLedger where
+  projectLedgerTables                     = LedgerTables . tlUtxos
+  withLedgerTables st    (LedgerTables x) = st { tlUtxos = x }
 
 data DbChangelogTestSetup = DbChangelogTestSetup {
   -- The operations are applied on the right, i.e., the newest operation is at the head of the list.
@@ -206,9 +195,9 @@ prop_flushingSplitsTheChangelog setup = isNothing toFlush .||.
     (toFlush, toKeep)                        = DbChangelog.splitForFlushing FlushAllImmutable dblog
     toFlushTip                               = maybe undefined DbChangelog.toFlushSlot toFlush
     toKeepTip                                = DbChangelog.immutableTipSlot toKeep
-    TestTables (SeqDiffMK toKeepDiffs)  = changelogDiffs toKeep
-    TestTables (DiffMK toFlushDiffs)    = maybe undefined DbChangelog.toFlushDiffs toFlush
-    TestTables (SeqDiffMK diffs)        = changelogDiffs dblog
+    LedgerTables (SeqDiffMK toKeepDiffs)  = changelogDiffs toKeep
+    LedgerTables (DiffMK toFlushDiffs)    = maybe undefined DbChangelog.toFlushDiffs toFlush
+    LedgerTables (SeqDiffMK diffs)        = changelogDiffs dblog
 
 -- | Extending the changelog adds the correct head to the volatile states.
 prop_extendingAdvancesTipOfVolatileStates :: DbChangelogTestSetup -> Property

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/HD/BackingStore.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/HD/BackingStore.hs
@@ -266,17 +266,17 @@ instance Mock.LookupKeys K V where
         ValuesMK $ Map.restrictKeys vs ks
 
 instance Mock.ValuesLength V where
-  valuesLength (OTLedgerTables (ValuesMK m)) =
+  valuesLength (LedgerTables (ValuesMK m)) =
     Map.size m
 
 instance Mock.MakeDiff V D where
   diff t1 t2 = zipLedgerTables (rawForgetValues .: rawCalculateDifference) t1 t2
 
 instance Mock.DiffSize D where
-  diffSize (OTLedgerTables (DiffMK (Diff.Diff m))) = Map.size m
+  diffSize (LedgerTables (DiffMK (Diff.Diff m))) = Map.size m
 
 instance Mock.KeysSize K where
-  keysSize (OTLedgerTables (KeysMK s)) = Set.size s
+  keysSize (LedgerTables (KeysMK s)) = Set.size s
 
 instance Mock.HasOps K V D
 

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
@@ -14,6 +14,7 @@
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE StandaloneDeriving         #-}
 {-# LANGUAGE TupleSections              #-}
+{-# LANGUAGE TypeApplications           #-}
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE TypeOperators              #-}
 {-# LANGUAGE UndecidableInstances       #-}
@@ -66,7 +67,8 @@ import           Data.Word
 import           GHC.Generics (Generic)
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
-import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.Abstract hiding (Key, Value)
+import qualified Ouroboros.Consensus.Ledger.Abstract as Ledger
 import           Ouroboros.Consensus.Ledger.Extended
 import qualified Ouroboros.Consensus.Ledger.Tables.DiffSeq as DS
 import           Ouroboros.Consensus.Ledger.Tables.Utils
@@ -270,14 +272,14 @@ instance PayloadSemantics Tx where
       track :: PayloadDependentState Tx ValuesMK -> PayloadDependentState Tx TrackingMK
       track stAfter =
           stAfter { utxtoktables =
-                      TokenToTValue $ rawCalculateDifference utxtokBefore utxtokAfter
+                      LedgerTables $ rawCalculateDifference utxtokBefore utxtokAfter
                   }
         where
-          utxtokBefore = testUtxtokTable $ utxtoktables st
-          utxtokAfter  = testUtxtokTable $ utxtoktables stAfter
+          utxtokBefore = getLedgerTables $ utxtoktables st
+          utxtokAfter  = getLedgerTables $ utxtoktables stAfter
 
   getPayloadKeySets Tx{consumed} =
-    TokenToTValue $ KeysMK $ Set.singleton consumed
+    LedgerTables $ KeysMK $ Set.singleton consumed
 
 deriving instance Eq (LedgerTables (LedgerState TestBlock) mk) => Eq (PayloadDependentState Tx mk)
 deriving instance NoThunks (LedgerTables (LedgerState TestBlock) mk) => NoThunks (PayloadDependentState Tx mk)
@@ -288,7 +290,7 @@ onValues ::
      (Map Token TValue -> Map Token TValue)
   -> LedgerTables (LedgerState TestBlock) ValuesMK
   -> LedgerTables (LedgerState TestBlock) ValuesMK
-onValues f TokenToTValue {testUtxtokTable} = TokenToTValue $ updateMap testUtxtokTable
+onValues f (LedgerTables testUtxtokTable) = LedgerTables $ updateMap testUtxtokTable
   where
     updateMap :: ValuesMK Token TValue -> ValuesMK Token TValue
     updateMap (ValuesMK utxovals) =
@@ -298,45 +300,33 @@ queryKeys ::
      (Map Token TValue -> a)
   -> LedgerTables (LedgerState TestBlock) ValuesMK
   -> a
-queryKeys f (TokenToTValue (ValuesMK utxovals)) = f utxovals
+queryKeys f (LedgerTables (ValuesMK utxovals)) = f utxovals
 
 {-------------------------------------------------------------------------------
   Instances required for HD storage of ledger state tables
 -------------------------------------------------------------------------------}
 
-instance HasLedgerTables (LedgerState TestBlock) where
-  newtype LedgerTables (LedgerState TestBlock) mk =
-    TokenToTValue { testUtxtokTable :: mk Token TValue }
-    deriving stock (Generic)
+type instance Ledger.Key   (LedgerState TestBlock) = Token
+type instance Ledger.Value (LedgerState TestBlock) = TValue
 
+instance HasLedgerTables (LedgerState TestBlock) where
   projectLedgerTables st       = utxtoktables $ payloadDependentState st
   withLedgerTables    st table = st { payloadDependentState =
                                         (payloadDependentState st) {utxtoktables = table}
                                     }
 
-  pureLedgerTables = TokenToTValue
+instance HasLedgerTables (Ticked1 (LedgerState TestBlock)) where
+  projectLedgerTables (TickedTestLedger st)        =
+    castLedgerTables $ projectLedgerTables st
+  withLedgerTables    (TickedTestLedger st) tables =
+    TickedTestLedger $ withLedgerTables st $ castLedgerTables tables
 
-  mapLedgerTables      f                                     (TokenToTValue x) = TokenToTValue    (f x)
-  traverseLedgerTables f                                     (TokenToTValue x) = TokenToTValue <$> f x
-  zipLedgerTables      f                   (TokenToTValue x) (TokenToTValue y) = TokenToTValue    (f x y)
-  zipLedgerTables3     f (TokenToTValue x) (TokenToTValue y) (TokenToTValue z) = TokenToTValue    (f x y z)
-  zipLedgerTablesA     f                   (TokenToTValue x) (TokenToTValue y) = TokenToTValue <$> f x y
-  zipLedgerTables3A    f (TokenToTValue x) (TokenToTValue y) (TokenToTValue z) = TokenToTValue <$> f x y z
-  foldLedgerTables     f                                     (TokenToTValue x) =                   f x
-  foldLedgerTables2    f                   (TokenToTValue x) (TokenToTValue y) =                   f x y
-  namesLedgerTables                                                            = TokenToTValue $ NameMK "testblocktables"
-
-deriving instance Eq (mk Token TValue) => Eq (LedgerTables (LedgerState TestBlock) mk)
-deriving anyclass instance NoThunks (mk Token TValue) => NoThunks (LedgerTables (LedgerState TestBlock) mk)
-deriving instance Show (mk Token TValue) => Show (LedgerTables (LedgerState TestBlock) mk)
-
-instance CanSerializeLedgerTables (LedgerState TestBlock) where
-  codecLedgerTables = TokenToTValue $ CodecMK toCBOR toCBOR fromCBOR fromCBOR
+instance CanSerializeLedgerTables (LedgerState TestBlock)
 
 instance Serialise (LedgerTables (LedgerState TestBlock) EmptyMK) where
-  encode (TokenToTValue (_ :: EmptyMK Token TValue))
+  encode (LedgerTables (_ :: EmptyMK Token TValue))
          = CBOR.encodeNull
-  decode = TokenToTValue EmptyMK <$ CBOR.decodeNull
+  decode = LedgerTables EmptyMK <$ CBOR.decodeNull
 
 instance ToCBOR Token where
   toCBOR (Token pt) = S.encode pt
@@ -350,10 +340,7 @@ instance ToCBOR TValue where
 instance FromCBOR TValue where
   fromCBOR = fmap TValue S.decode
 
-instance HasTickedLedgerTables (LedgerState TestBlock) where
-  projectLedgerTablesTicked (TickedTestLedger st)        = projectLedgerTables st
-  withLedgerTablesTicked    (TickedTestLedger st) tables =
-    TickedTestLedger $ withLedgerTables st tables
+instance HasTickedLedgerTables (LedgerState TestBlock)
 
 instance CanStowLedgerTables (LedgerState TestBlock) where
   stowLedgerTables     = stowErr "stowLedgerTables"
@@ -418,7 +405,7 @@ instance ToExpr (LedgerState (TestBlockWith Tx) ValuesMK) where
 
 initialTestLedgerState :: PayloadDependentState Tx ValuesMK
 initialTestLedgerState = UTxTok {
-    utxtoktables =   TokenToTValue
+    utxtoktables =   LedgerTables
                    $ ValuesMK
                    $ Map.singleton initialToken (pointTValue initialToken)
   , utxhist      = Set.singleton initialToken
@@ -1315,8 +1302,7 @@ generator cd secParam (Model mock hs) =
         genGetTables =
           let randomGetTablesAtFor = do
                 pt <- QC.arbitrary
-                keys <- ExtLedgerStateTables
-                      . TokenToTValue
+                keys <- LedgerTables @(ExtLedgerState TestBlock)
                       . KeysMK
                     <$> QC.arbitrary
                 pure $ GetTablesAtFor pt keys
@@ -1333,8 +1319,7 @@ generator cd secParam (Model mock hs) =
                , (1, do
                      -- existing point, random keys
                      (blk, _) <- QC.elements (mockLedger mock)
-                     keys <- ExtLedgerStateTables
-                          .  TokenToTValue
+                     keys <- LedgerTables @(ExtLedgerState TestBlock)
                           .  KeysMK
                          <$> QC.arbitrary
                      pure $ GetTablesAtFor (blockPoint blk) keys)

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/TestBlock.hs
@@ -76,6 +76,7 @@ import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (maybeToList)
 import           Data.Typeable (Typeable)
+import           Data.Void (Void)
 import           Data.Word
 import           GHC.Generics (Generic)
 import           GHC.Stack (HasCallStack)
@@ -549,22 +550,20 @@ instance IsLedger (LedgerState TestBlock) where
                                  . TickedTestLedger
                                  . noNewTickingDiffs
 
-instance HasLedgerTables (LedgerState TestBlock) where
-  data LedgerTables (LedgerState TestBlock) mk = NoTestLedgerTables
-    deriving stock    (Generic, Eq, Show)
-    deriving anyclass (NoThunks)
+type instance Key   (LedgerState TestBlock) = Void
+type instance Value (LedgerState TestBlock) = Void
+
+instance HasLedgerTables (LedgerState TestBlock)
+instance HasLedgerTables (Ticked1 (LedgerState TestBlock))
 
 instance CanSerializeLedgerTables (LedgerState TestBlock) where
 
 instance CanStowLedgerTables (LedgerState TestBlock) where
 
-instance HasTickedLedgerTables (LedgerState TestBlock) where
-  withLedgerTablesTicked (TickedTestLedger st) tables =
-      TickedTestLedger $ withLedgerTables st tables
+instance HasTickedLedgerTables (LedgerState TestBlock)
 
-instance LedgerTablesAreTrivial (LedgerState TestBlock) where
-  convertMapKind TestLedger{..} = TestLedger{..}
-  trivialLedgerTables = NoTestLedgerTables
+instance LedgerTablesAreTrivial (LedgerState TestBlock)
+instance LedgerTablesAreTrivial (Ticked1 (LedgerState TestBlock))
 
 instance ApplyBlock (LedgerState TestBlock) TestBlock where
   applyBlockLedgerResult _ tb@TestBlock{..} (TickedTestLedger TestLedger{..})
@@ -578,7 +577,7 @@ instance ApplyBlock (LedgerState TestBlock) TestBlock where
   reapplyBlockLedgerResult _ tb _ =
                    pureLedgerResult $ TestLedger (Chain.blockPoint tb) (BlockHash (blockHash tb))
 
-  getBlockKeySets _blk = NoTestLedgerTables
+  getBlockKeySets _blk = trivialLedgerTables
 
 data instance LedgerState TestBlock mk =
     TestLedger {


### PR DESCRIPTION
# Description

In this PR we do two things:
* We make LedgerTables a newtype instead of a data family. `LedgerTable`s have the same structure, regardless of the `l` type parameter. Instead, we now have just one `LedgerTables` `newtype`, and we can cast between `LedgerTables` with different `l` parameters as long as the types of keys and values inside the `LedgerTables` match.
* We implement Bifunctor Barbie classes for `LedgerTables`. These classes provide a relatively minimal interface to changing `mk`s on `LedgerTable`s. These classes can then be used to define compound functions that do more elaborate work.