### PR TITLE
Fix `pure @(NonEmpty xs)` implementation

### DIFF
--- a/ouroboros-consensus/changelog.d/20230614_095553_alexander.esgen_sop_nonempty_applicative.md
+++ b/ouroboros-consensus/changelog.d/20230614_095553_alexander.esgen_sop_nonempty_applicative.md
@@ -1,0 +1,4 @@
+### Non-Breaking
+
+- The `pure @(NonEmpty xs)` implementation was unlawful; this has been fixed by
+  making it return an `a` for every `xs` (similar to `ZipList`).

--- a/ouroboros-consensus/src/ouroboros-consensus/Data/SOP/Counting.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Data/SOP/Counting.hs
@@ -1,20 +1,22 @@
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE DeriveFoldable      #-}
-{-# LANGUAGE DeriveFunctor       #-}
-{-# LANGUAGE DeriveTraversable   #-}
-{-# LANGUAGE EmptyCase           #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE FlexibleInstances   #-}
-{-# LANGUAGE GADTs               #-}
-{-# LANGUAGE KindSignatures      #-}
-{-# LANGUAGE LambdaCase          #-}
-{-# LANGUAGE PatternSynonyms     #-}
-{-# LANGUAGE RankNTypes          #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving  #-}
-{-# LANGUAGE TypeApplications    #-}
-{-# LANGUAGE TypeOperators       #-}
-{-# LANGUAGE ViewPatterns        #-}
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE DeriveFoldable       #-}
+{-# LANGUAGE DeriveFunctor        #-}
+{-# LANGUAGE DeriveTraversable    #-}
+{-# LANGUAGE EmptyCase            #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE GADTs                #-}
+{-# LANGUAGE InstanceSigs         #-}
+{-# LANGUAGE KindSignatures       #-}
+{-# LANGUAGE LambdaCase           #-}
+{-# LANGUAGE PatternSynonyms      #-}
+{-# LANGUAGE RankNTypes           #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE StandaloneDeriving   #-}
+{-# LANGUAGE TypeApplications     #-}
+{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ViewPatterns         #-}
 
 -- | Type-level counting
 --
@@ -270,9 +272,14 @@ atMostNonEmpty = \case
   Working with 'NonEmpty'
 -------------------------------------------------------------------------------}
 
-instance IsNonEmpty xs => Applicative (NonEmpty xs) where
-  pure x = case isNonEmpty (Proxy @xs) of
-             ProofNonEmpty{} -> NonEmptyOne x
+instance (IsNonEmpty xs, SListI xs) => Applicative (NonEmpty xs) where
+  pure :: forall a. a -> NonEmpty xs a
+  pure a = case isNonEmpty (Proxy @xs) of
+             ProofNonEmpty{} -> go shape
+    where
+      go :: forall x xs'. Shape xs' -> NonEmpty (x : xs') a
+      go ShapeNil        = NonEmptyOne a
+      go (ShapeCons xs') = NonEmptyCons a (go xs')
   (<*>) = go
     where
       go :: NonEmpty xs' (a -> b) -> NonEmpty xs' a -> NonEmpty xs' b


### PR DESCRIPTION
The previous implementation violated e.g. the Identity law, e.g. for

```haskell
v :: NonEmpty [String, Bool, Char] ()
v = NonEmptyCons () (NonEmptyOne ())
```

we have

```haskell
pure id <*> v = NonEmptyOne ()
```

which is not equal to `v`.

The correct implementation is similar to the `Applicative ZipList` instance: We provide an `a` for every `xs`.

Luckily, `pure @(NonEmpty xs)` was not used anywhere in our code base so far.