### PR TITLE
Expose flush frequency and query batch size as node arguments

### DIFF
--- a/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBAnalyser/Run.hs
+++ b/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBAnalyser/Run.hs
@@ -63,7 +63,10 @@ analyse DBAnalyserConfig{analysis, confLimit, dbDir, selectDB, validation, verbo
         mkProtocolInfo args
       let chunkInfo  = Node.nodeImmutableDbChunkInfo (configStorage cfg)
           k          = configSecurityParam cfg
-          diskPolicy = defaultDiskPolicy k DefaultSnapshotInterval
+          diskPolicy = defaultDiskPolicy k
+                         DefaultSnapshotInterval
+                         DefaultFlushFrequency
+                         DefaultQueryBatchSize
           args' =
             Node.mkChainDbArgs
               registry InFuture.dontCheck cfg genesisLedger chunkInfo $
@@ -110,7 +113,10 @@ analyse DBAnalyserConfig{analysis, confLimit, dbDir, selectDB, validation, verbo
               , limit = confLimit
               , tracer = analysisTracer
               , bstore = bs
-              , policy = defaultDiskPolicy (configSecurityParam cfg) DefaultSnapshotInterval
+              , policy = defaultDiskPolicy (configSecurityParam cfg)
+                           DefaultSnapshotInterval
+                           DefaultFlushFrequency
+                           DefaultQueryBatchSize
               }
             tipPoint <- atomically $ ImmutableDB.getTipPoint immutableDB
             putStrLn $ "ImmutableDB tip: " ++ show tipPoint
@@ -127,7 +133,10 @@ analyse DBAnalyserConfig{analysis, confLimit, dbDir, selectDB, validation, verbo
               , limit = confLimit
               , tracer = analysisTracer
               , bstore = bs
-              , policy = defaultDiskPolicy (configSecurityParam cfg) DefaultSnapshotInterval
+              , policy = defaultDiskPolicy (configSecurityParam cfg)
+                           DefaultSnapshotInterval
+                           DefaultFlushFrequency
+                           DefaultQueryBatchSize
               }
             tipPoint <- atomically $ ChainDB.getTipPoint chainDB
             putStrLn $ "ChainDB tip: " ++ show tipPoint

--- a/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBSynthesizer/Run.hs
+++ b/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBSynthesizer/Run.hs
@@ -118,7 +118,10 @@ synthesize DBSynthesizerConfig{confOptions, confShelleyGenesis, confDbDir} (Some
             epochSize   = sgEpochLength confShelleyGenesis
             chunkInfo   = Node.nodeImmutableDbChunkInfo (configStorage pInfoConfig)
             k           = configSecurityParam pInfoConfig
-            diskPolicy  = defaultDiskPolicy k DefaultSnapshotInterval
+            diskPolicy  = defaultDiskPolicy k
+                            DefaultSnapshotInterval
+                            DefaultFlushFrequency
+                            DefaultQueryBatchSize
             dbArgs      = Node.mkChainDbArgs
                 registry InFuture.dontCheck pInfoConfig pInfoInitLedger chunkInfo $
                     ChainDB.defaultArgs (Node.stdMkChainDbHasFS confDbDir) diskPolicy InMemoryBackingStore

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
@@ -773,7 +773,6 @@ data StdRunNodeArgs m blk (p2p :: Diffusion.P2P) = StdRunNodeArgs
   , srnBfcMaxConcurrencyDeadline    :: Maybe Word
   , srnChainDbValidateOverride      :: Bool
     -- ^ If @True@, validate the ChainDB on init no matter what
-  , srnSnapshotInterval             :: SnapshotInterval
   , srnDatabasePath                 :: FilePath
     -- ^ Location of the DBs
   , srnDiffusionArguments           :: Diffusion.Arguments
@@ -793,6 +792,11 @@ data StdRunNodeArgs m blk (p2p :: Diffusion.P2P) = StdRunNodeArgs
   , srnMaybeMempoolCapacityOverride :: Maybe MempoolCapacityBytesOverride
     -- ^ Determine whether to use the system default mempool capacity or explicitly set
     -- capacity of the mempool.
+
+    -- LedgerDB
+  , srnSnapshotInterval :: SnapshotInterval
+  , srnFlushFrequency   :: FlushFrequency
+  , srnQueryBatchSize   :: QueryBatchSize
   }
 
 -- | Conveniently packaged 'LowLevelRunNodeArgs' arguments from a standard
@@ -865,7 +869,10 @@ stdLowLevelRunNodeArgsIO RunNodeArgs{ rnProtocolInfo
       let
         cfg = pInfoConfig rnProtocolInfo
         k   = configSecurityParam cfg
-      in defaultDiskPolicy k srnSnapshotInterval
+      in defaultDiskPolicy k
+           srnSnapshotInterval
+           srnFlushFrequency
+           srnQueryBatchSize
 
     mkHasFS :: ChainDB.RelativeMountPoint -> SomeHasFS IO
     mkHasFS = stdMkChainDbHasFS srnDatabasePath

--- a/ouroboros-consensus/src/consensus-testlib/Test/Util/ChainDB.hs
+++ b/ouroboros-consensus/src/consensus-testlib/Test/Util/ChainDB.hs
@@ -92,6 +92,8 @@ fromMinimalChainDbArgs MinimalChainDbArgs {..} = ChainDbArgs {
   , cdbMaxBlocksPerFile       = VolatileDB.mkBlocksPerFile 4
   , cdbDiskPolicy             = LedgerDB.defaultDiskPolicy (configSecurityParam mcdbTopLevelConfig)
                                   LedgerDB.DefaultSnapshotInterval
+                                  LedgerDB.DefaultFlushFrequency
+                                  LedgerDB.DefaultQueryBatchSize
   -- Keep 2 ledger snapshots, and take a new snapshot at least every 2 * k seconds, where k is the
   -- security parameter.
   , cdbTopLevelConfig         = mcdbTopLevelConfig

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Query.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Query.hs
@@ -45,6 +45,7 @@ import           Data.Monoid
 import           Data.Semigroup
 import qualified Data.Set as Set
 import           Data.Typeable (Typeable)
+import           Data.Word (Word64)
 import           Ouroboros.Consensus.Block.Abstract (CodecConfig)
 import           Ouroboros.Consensus.BlockchainTime (SystemStart)
 import           Ouroboros.Consensus.Config
@@ -65,7 +66,6 @@ import           Ouroboros.Consensus.Storage.LedgerDB
 import           Ouroboros.Consensus.Storage.LedgerDB.API (LedgerDBView (..),
                      closeLedgerDBView)
 import qualified Ouroboros.Consensus.Storage.LedgerDB.BackingStore as BackingStore
-import           Ouroboros.Consensus.Storage.LedgerDB.Config (QueryBatchSize)
 import           Ouroboros.Consensus.Storage.LedgerDB.DbChangelog
 import qualified Ouroboros.Consensus.Storage.LedgerDB.DbChangelog.Query as DbChangelog
 import           Ouroboros.Consensus.Util (ShowProxy (..), SomeSecond (..))
@@ -330,7 +330,8 @@ data DiskLedgerView m l = DiskLedgerView {
   , dlvRangeRead      :: !(RangeQuery (LedgerTables l KeysMK)
                          -> m (LedgerTables l ValuesMK))
   , dlvClose          :: !(m ())
-  , dlvQueryBatchSize :: !QueryBatchSize
+    -- | See 'onDiskQueryBatchSize'.
+  , dlvQueryBatchSize :: !Word64
   }
 
 mkDiskLedgerView ::

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/API.hs
@@ -30,7 +30,8 @@ import           Ouroboros.Consensus.Util.IOLike (Time)
 data LedgerDBView m l = LedgerDBView {
     viewHandle         :: !(LedgerBackingStoreValueHandle m l)
   , viewChangelog      :: !(AnchorlessDbChangelog l)
-  , viewQueryBatchSize :: !QueryBatchSize
+    -- | See 'onDiskQueryBatchSize'.
+  , viewQueryBatchSize :: !Word64
   }
 
 closeLedgerDBView :: LedgerDBView m l -> m ()

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Config.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Config.hs
@@ -64,44 +64,45 @@ data SnapCounters = SnapCounters {
   , ntBlocksSinceLastSnap :: !Word64
   }
 
--- | Length of time, requested by the user, that has to pass after which
--- a snapshot is taken. It can be:
---
--- 1. either explicitly provided by user in seconds
--- 2. or default value can be requested - the specific DiskPolicy determines
---    what that is exactly, see `defaultDiskPolicy` as an example
+-- | Length of time that has to pass after which a snapshot is taken.
 data SnapshotInterval =
+    -- | A default value, which is determined by a specific 'DiskPolicy'. See
+    -- 'defaultDiskPolicy' as an example.
     DefaultSnapshotInterval
+    -- | A requested value: provided in seconds.
   | RequestedSnapshotInterval DiffTime
   deriving stock (Eq, Generic, Show)
 
 -- | The number of diffs in the immutable part of the chain that we have to see
--- before we flush ledger state to disk. See 'onDiskShouldFlush'. It can be:
---
--- 1. either explicitly provided by a user in the number of diffs in the
---    immutable part of the chain.
--- 2. a default value, which is determined by a specific 'DiskPolicy'. See
--- 'defaultDiskPolicy' as an example.
+-- before we flush the ledger state to disk. See 'onDiskShouldFlush'.
 --
 -- INVARIANT: Should be at least 0.
 data FlushFrequency =
+  -- | A default value, which is determined by a specific 'DiskPolicy'. See
+    -- 'defaultDiskPolicy' as an example.
     DefaultFlushFrequency
+    -- | A requested value: the number of diffs in the immutable part of the
+    -- chain required before flushing.
   | RequestedFlushFrequency Word64
   deriving stock (Show, Eq, Generic)
 
--- | The number of keys to read /at most/ in a backing store range query, as
--- requested by the user. It can be:
+-- | The /maximum/ number of keys to read in a backing store range query.
 --
--- 1. either explicitly provided by a user in the number of keys to read from disk.
--- 2. a default value, which is determined by a specific 'DiskPolicy'. See
--- 'defaultDiskPolicy' as an example.
+-- When performing a ledger state query that involves on-disk parts of the
+-- ledger state, we might have to read ranges of key-value pair data (e.g.,
+-- UTxO) from disk using backing store range queries. Instead of reading all
+-- data in one go, we read it in batches. 'QueryBatchSize' determines the size
+-- of these batches.
 --
 -- INVARIANT: Should be at least 1.
 --
 -- It is fine if the result of a range read contains less than this number of
 -- keys, but it should never return more.
 data QueryBatchSize =
+    -- | A default value, which is determined by a specific 'DiskPolicy'. See
+    -- 'defaultDiskPolicy' as an example.
     DefaultQueryBatchSize
+    -- | A requested value: the number of keys to read from disk in each batch.
   | RequestedQueryBatchSize Word64
   deriving stock (Show, Eq, Generic)
 

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
@@ -256,7 +256,10 @@ initLedgerDB k chain = do
     args = LedgerDB.LedgerDBArgs
       { LedgerDB.lgrTopLevelConfig       = cfg
       , LedgerDB.lgrHasFS                = SomeHasFS (error "lgrHasFS" :: HasFS m ())
-      , LedgerDB.lgrDiskPolicy           = LedgerDB.defaultDiskPolicy k LedgerDB.DefaultSnapshotInterval
+      , LedgerDB.lgrDiskPolicy           = LedgerDB.defaultDiskPolicy k
+                                            LedgerDB.DefaultSnapshotInterval
+                                            LedgerDB.DefaultFlushFrequency
+                                            LedgerDB.DefaultQueryBatchSize
       , LedgerDB.lgrGenesis              = return testInitExtLedger
       , LedgerDB.lgrTracer               = nullTracer
       , LedgerDB.lgrTraceLedger          = nullTracer

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/DiskPolicy.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/DiskPolicy.hs
@@ -10,6 +10,7 @@ import           Data.Time.Clock (DiffTime, diffTimeToPicoseconds,
 import           Data.Word
 import           Ouroboros.Consensus.Config.SecurityParam (SecurityParam (..))
 import           Ouroboros.Consensus.Storage.LedgerDB.Config (DiskPolicy (..),
+                     FlushFrequency (..), QueryBatchSize (..),
                      SnapshotInterval (..), defaultDiskPolicy)
 import           Test.QuickCheck
 import           Test.Tasty
@@ -43,7 +44,10 @@ data TestSetup = TestSetup {
 
 -- | The represented default 'DiskPolicy'
 toDiskPolicy :: TestSetup -> DiskPolicy
-toDiskPolicy ts = defaultDiskPolicy (tsK ts) (tsSnapshotInterval ts)
+toDiskPolicy ts =
+    defaultDiskPolicy (tsK ts) (tsSnapshotInterval ts)
+      DefaultFlushFrequency
+      DefaultQueryBatchSize
 
 -- | The result of the represented call to 'onDiskShouldTakeSnapshot'
 shouldTakeSnapshot :: TestSetup -> Bool

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
@@ -1108,7 +1108,10 @@ runDB standalone@DB{..} cmd =
             S.decode
             S.decode
             dbLedgerDbCfg
-            (defaultDiskPolicy (SecurityParam 100) DefaultSnapshotInterval)
+            (defaultDiskPolicy (SecurityParam 100)
+               DefaultSnapshotInterval
+               DefaultFlushFrequency
+               DefaultQueryBatchSize)
             (return (testInitExtLedgerWithState initialTestLedgerState))
             streamAPI
             sdbBackingStoreSelector


### PR DESCRIPTION
# Description

The flush frequency and query batch size are now implemented similarly to `SnapShotInterval`. The `StdRunNodeArgs` are expanded to include the flush frequency and query batch size configuration options. This opens the door for configuring these options at the `cardano-node` level.
