### PR TITLE
Refactor ledger tables (utility functions)

### DIFF
--- a/ouroboros-consensus-cardano/src/byron-testlib/Test/Consensus/Byron/Examples.hs
+++ b/ouroboros-consensus-cardano/src/byron-testlib/Test/Consensus/Byron/Examples.hs
@@ -184,18 +184,18 @@ emptyLedgerState = ByronLedgerState {
 
 ledgerStateAfterEBB :: LedgerState ByronBlock ValuesMK
 ledgerStateAfterEBB =
-      applyLedgerTablesDiffs emptyLedgerState
+      applyDiffs emptyLedgerState
     . reapplyLedgerBlock ledgerConfig exampleEBB
-    . applyLedgerTablesDiffsTicked emptyLedgerState
+    . applyDiffs emptyLedgerState
     . applyChainTick ledgerConfig (SlotNo 0)
     . forgetLedgerTables
     $ emptyLedgerState
 
 exampleLedgerState :: LedgerState ByronBlock ValuesMK
 exampleLedgerState =
-      applyLedgerTablesDiffs emptyLedgerState
+      applyDiffs emptyLedgerState
     . reapplyLedgerBlock ledgerConfig exampleBlock
-    . applyLedgerTablesDiffsTicked ledgerStateAfterEBB
+    . applyDiffs ledgerStateAfterEBB
     . applyChainTick ledgerConfig (SlotNo 1)
     . forgetLedgerTables
     $ ledgerStateAfterEBB

--- a/ouroboros-consensus-cardano/src/cardano-testlib/Test/ThreadNet/TxGen/Cardano.hs
+++ b/ouroboros-consensus-cardano/src/cardano-testlib/Test/ThreadNet/TxGen/Cardano.hs
@@ -42,8 +42,8 @@ import           Ouroboros.Consensus.HardFork.Combinator.State.Types
 import           Ouroboros.Consensus.Ledger.Basics (LedgerConfig, LedgerState,
                      TickedLedgerState, applyChainTick)
 import           Ouroboros.Consensus.Ledger.Tables (ValuesMK)
-import           Ouroboros.Consensus.Ledger.Tables.Utils
-                     (applyLedgerTablesDiffsTicked, forgetLedgerTables)
+import           Ouroboros.Consensus.Ledger.Tables.Utils (applyDiffs,
+                     forgetLedgerTables)
 import           Ouroboros.Consensus.NodeId (CoreNodeId (..))
 import           Ouroboros.Consensus.Protocol.TPraos (TPraos)
 import           Ouroboros.Consensus.Shelley.Ledger (ShelleyBlock, mkShelleyTx)
@@ -214,7 +214,7 @@ migrateUTxO migrationInfo curSlot lcfg lst
     mbUTxO =
           fmap getUTxOShelley
         . ejectShelleyTickedLedgerState
-        . applyLedgerTablesDiffsTicked lst
+        . applyDiffs lst
         . applyChainTick lcfg curSlot
         . forgetLedgerTables
         $ lst

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/CanHardFork.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/CanHardFork.hs
@@ -404,7 +404,7 @@ translateLedgerStateByronToShelleyWrapper =
     $ \_ (WrapLedgerConfig cfgShelley) ->
         TranslateLedgerState {
             translateLedgerStateWith = \epochNo ledgerByron ->
-                forgetLedgerTablesValues
+                forgetTrackingValues
               . calculateAdditions
               . unstowLedgerTables
               $ ShelleyLedgerState {

--- a/ouroboros-consensus-cardano/src/shelley-testlib/Test/ThreadNet/TxGen/Shelley.hs
+++ b/ouroboros-consensus-cardano/src/shelley-testlib/Test/ThreadNet/TxGen/Shelley.hs
@@ -59,7 +59,7 @@ instance HashAlgorithm h => TxGen (ShelleyBlock (TPraos (MockCrypto h)) (MockShe
       | otherwise               = do
       n <- choose (0, 20)
       go [] n
-        $ applyLedgerTablesDiffsTicked lst
+        $ applyDiffs lst
         $ applyChainTick lcfg curSlotNo
         $ forgetLedgerTables lst
     where
@@ -83,7 +83,7 @@ instance HashAlgorithm h => TxGen (ShelleyBlock (TPraos (MockCrypto h)) (MockShe
           Just tx -> case runExcept $ fst <$> applyTx lcfg DoNotIntervene curSlotNo tx st of
               -- We don't mind generating invalid transactions
               Left  _   -> go (tx:acc) (n - 1) st
-              Right st' -> go (tx:acc) (n - 1) (forgetLedgerTablesDiffsTicked st')
+              Right st' -> go (tx:acc) (n - 1) (forgetTrackingDiffs st')
 
 genTx
   :: forall h. HashAlgorithm h

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
@@ -595,7 +595,7 @@ applyHelper f cfg blk stBefore = do
 
 
     return $ ledgerResult <&> \newNewEpochState ->
-      forgetLedgerTablesValues $ track $ unstowLedgerTables $
+      forgetTrackingValues $ track $ unstowLedgerTables $
       ShelleyLedgerState {
           shelleyLedgerTip = NotOrigin ShelleyTip {
               shelleyTipBlockNo = blockNo   blk

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
@@ -246,7 +246,7 @@ applyShelleyTx cfg wti slot (ShelleyTx _ tx) st0 = do
          tx
 
     let st' :: TickedLedgerState (ShelleyBlock proto era) TrackingMK
-        st' = calculateDifferenceTicked st0
+        st' = calculateDifference st0
             $ unstowLedgerTables
             $ set theLedgerLens mempoolState' st1
 
@@ -270,7 +270,7 @@ reapplyShelleyTx cfg slot vgtx st0 = do
           (SL.mkMempoolState innerSt)
           vtx
 
-    let st2 = calculateDifferenceTicked st0
+    let st2 = calculateDifference st0
           $ unstowLedgerTables
           $ set theLedgerLens mempoolState' st1
 

--- a/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBAnalyser/Analysis.hs
+++ b/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBAnalyser/Analysis.hs
@@ -568,7 +568,7 @@ benchmarkLedgerOps mOutfile AnalysisEnv {db, registry, initLedger, cfg, limit, p
         (ldgrSt',    tBlkApp)   <- time $ applyTheBlock                                       hydTkLdgrSt
 
         -- this is an inline of DbChangelog.Update.pushLedgerState
-        let st   = ExtLedgerState (prependLedgerTablesDiffsFromTicked tkLdgrSt ldgrSt') hdrSt'
+        let st   = ExtLedgerState (prependDiffs tkLdgrSt ldgrSt') hdrSt'
             ldb' = onChangelog (DbChangelog.prune (ledgerDbCfgSecParam $ configLedgerDb cfg)
                  . DbChangelog.extend st) ldb
 
@@ -652,8 +652,8 @@ benchmarkLedgerOps mOutfile AnalysisEnv {db, registry, initLedger, cfg, limit, p
               aks = rewindTableKeySets (anchorlessChangelog ldb) ks
           urs <- readKeySets bstore aks
           case forwardTableKeySets (anchorlessChangelog ldb) urs of
-            Left err -> error $ "Rewind;read;forward failed" <> show err
-            Right forwarded -> pure $ applyLedgerTablesDiffsTicked' (castLedgerTables forwarded) st
+            Left err        -> error $ "Rewind;read;forward failed" <> show err
+            Right forwarded -> pure $ applyDiffs forwarded st
 
         tickTheLedgerState ::
              SlotNo

--- a/ouroboros-consensus-cardano/test/byron-test/Test/ThreadNet/DualByron.hs
+++ b/ouroboros-consensus-cardano/test/byron-test/Test/ThreadNet/DualByron.hs
@@ -260,7 +260,7 @@ instance TxGen DualByronBlock where
   testGenTxs _coreNodeId _numCoreNodes curSlotNo cfg () = \st -> do
       n <- choose (0, 20)
       go [] n
-        $ applyLedgerTablesDiffsTicked st
+        $ applyDiffs st
         $ applyChainTick (configLedger cfg) curSlotNo
         $ forgetLedgerTables st
     where
@@ -280,7 +280,7 @@ instance TxGen DualByronBlock where
                              tx
                              st of
             Right (st', _vtx) ->
-              go (tx:acc) (n - 1) (forgetLedgerTablesDiffsTicked st')
+              go (tx:acc) (n - 1) (forgetTrackingDiffs st')
             Left _            -> error "testGenTxs: unexpected invalid tx"
 
 -- | Generate transaction

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -148,7 +148,6 @@ library diffusion-testlib
     , cborg
     , containers
     , contra-tracer
-    , diff-containers                                               >=1.0
     , fgl
     , fs-sim                                                        >=0.2
     , graphviz                                                      >=2999.20.1.0

--- a/ouroboros-consensus-diffusion/src/diffusion-testlib/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-diffusion/src/diffusion-testlib/Test/ThreadNet/Network.hs
@@ -49,7 +49,6 @@ import           Data.Either (isRight)
 import           Data.Functor.Identity (Identity)
 import qualified Data.List as List
 import qualified Data.List.NonEmpty as NE
-import           Data.Map.Diff.Strict (applyDiff)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Set (Set)
@@ -618,9 +617,8 @@ runThreadNetwork systemTime ThreadNetworkArgs
                 -- most 1 to the number of requested keys, hence the
                 -- subtraction. When we revisit the range query implementation
                 -- we should remove this workaround.
-                fullUTxO <- castLedgerTables <$> doRangeQuery (RangeQuery Nothing (maxBound-1))
-                let f (DiffMK d) (ValuesMK m) = ValuesMK $ applyDiff m d
-                pure $! zipOverLedgerTablesTicked f st fullUTxO
+                fullUTxO <- doRangeQuery (RangeQuery Nothing (maxBound-1))
+                pure $! applyDiffs fullUTxO st
               pure $ isRight $ Exc.runExcept $ applyTx lcfg DoNotIntervene slot tx fullLedgerSt
 
 

--- a/ouroboros-consensus/bench/mempool-bench/Main.hs
+++ b/ouroboros-consensus/bench/mempool-bench/Main.hs
@@ -49,7 +49,7 @@ main = do
             unless success exitFailure
       where
         bsss = [defaultInMemoryBSS, defaultLMDB_BSS]
-        ns   = [10_000, 20_000]
+        ns   = [10_000]
 
         showBackingStoreSelector bss = case bss of
           InMemoryBackingStore -> "inmem"

--- a/ouroboros-consensus/src/consensus-testlib/Test/Util/LedgerStateOnlyTables.hs
+++ b/ouroboros-consensus/src/consensus-testlib/Test/Util/LedgerStateOnlyTables.hs
@@ -55,8 +55,8 @@ instance (ToCBOR k, FromCBOR k, ToCBOR v, FromCBOR v)
   Stowable
 -------------------------------------------------------------------------------}
 
-instance (Ord k, Eq v, Show k, Show v, NoThunks k, NoThunks v)
-    => CanStowLedgerTables (OTLedgerState k v) where
+instance (Ord k, Eq v)
+      => CanStowLedgerTables (OTLedgerState k v) where
   stowLedgerTables OTLedgerState{otlsLedgerTables} =
     OTLedgerState (getLedgerTables otlsLedgerTables) emptyLedgerTables
 

--- a/ouroboros-consensus/src/consensus-testlib/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/src/consensus-testlib/Test/Util/TestBlock.hs
@@ -485,7 +485,7 @@ instance PayloadSemantics ptype
     = case applyPayload payloadDependentState tbPayload of
         Left err  -> throwError $ InvalidPayload err
         Right st' -> return     $ pureLedgerResult
-                                $ forgetLedgerTablesValues
+                                $ forgetTrackingValues
                                 $ TestLedger {
                                     lastAppliedPoint      = Chain.blockPoint tb
                                   , payloadDependentState = st'
@@ -495,7 +495,7 @@ instance PayloadSemantics ptype
     case applyPayload payloadDependentState tbPayload of
         Left err  -> error $ "Found an error when reapplying a block: " ++ show err
         Right st' ->              pureLedgerResult
-                                $ forgetLedgerTablesValues
+                                $ forgetTrackingValues
                                 $ TestLedger {
                                     lastAppliedPoint      = Chain.blockPoint tb
                                   , payloadDependentState = st'

--- a/ouroboros-consensus/src/mock-block/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus/src/mock-block/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -363,7 +363,7 @@ instance MockProtocolSpecific c ext
       => ApplyBlock (LedgerState (SimpleBlock c ext)) (SimpleBlock c ext) where
   applyBlockLedgerResult _ blk st =
       fmap ( pureLedgerResult
-           . forgetLedgerTablesValues
+           . forgetTrackingValues
            . calculateDifference st
            . unstowLedgerTables
            )
@@ -522,7 +522,7 @@ instance MockProtocolSpecific c ext
      let st' = stowLedgerTables st
      st'' <- unstowLedgerTables
              <$> updateSimpleUTxO slot tx st'
-     return ( calculateDifferenceTicked st st''
+     return ( calculateDifference st st''
              , ValidatedSimpleGenTx tx )
 
   reapplyTx _cfg slot vtx st = fst

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Embed/Nary.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Embed/Nary.hs
@@ -207,16 +207,18 @@ injectInitialExtLedgerState cfg extLedgerState0 =
           cfg
 
     targetEraLedgerState :: LedgerState (HardForkBlock (x ': xs)) ValuesMK
-    targetEraLedgerState =
-       applyLedgerTablesDiffs
-         (HardForkLedgerState . initHardForkState . Flip . ledgerState $ extLedgerState0)
-         (HardForkLedgerState
-           -- We can immediately extend it to the right slot, executing any
-           -- scheduled hard forks in the first slot
-             (State.extendToSlot
-                (configLedger cfg)
-                (SlotNo 0)
-                (initHardForkState $ Flip $ forgetLedgerTables $ ledgerState extLedgerState0)))
+    targetEraLedgerState = applyDiffs st st'
+      where
+        st :: LedgerState (HardForkBlock (x ': xs)) ValuesMK
+        st = HardForkLedgerState . initHardForkState . Flip . ledgerState $ extLedgerState0
+        st' = HardForkLedgerState
+                -- We can immediately extend it to the right slot, executing any
+                -- scheduled hard forks in the first slot
+                  (State.extendToSlot
+                      (configLedger cfg)
+                      (SlotNo 0)
+                      (initHardForkState $ Flip $ forgetLedgerTables $ ledgerState extLedgerState0))
+
 
     firstEraChainDepState :: HardForkChainDepState (x ': xs)
     firstEraChainDepState =

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Ledger.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Ledger.hs
@@ -172,7 +172,7 @@ tickOne :: SingleEraBlock blk
 tickOne ei slot sopIdx partialCfg st =
       Comp
     . fmap ( FlipTickedLedgerState
-           . prependLedgerTablesDiffsTicked (unFlip st)
+           . prependDiffs (unFlip st)
            )
     . embedLedgerResult (injectLedgerEvent sopIdx)
     . applyChainTickLedgerResult (completeLedgerConfig' ei partialCfg) slot

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/State.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/State.hs
@@ -245,12 +245,12 @@ extendToSlot ledgerCfg@HardForkLedgerConfig{..} slot ledgerSt@(HardForkState st)
                              -- just be a no-op. See the haddock for
                              -- 'translateLedgerTablesWith' for more
                              -- information).
-                             . prependLedgerTablesDiffsRaw ( translateLedgerTablesWith f
-                                             . projectLedgerTables
-                                             . unFlip
-                                             . currentState
-                                             $ cur
-                                             )
+                             . prependDiffs ( translateLedgerTablesWith f
+                                            . projectLedgerTables
+                                            . unFlip
+                                            . currentState
+                                            $ cur
+                                            )
                              . translateLedgerStateWith f (History.boundEpoch currentEnd)
                              . forgetLedgerTables
                              . unFlip

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HeaderStateHistory.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HeaderStateHistory.hs
@@ -33,8 +33,7 @@ import           Ouroboros.Consensus.HeaderValidation hiding (validateHeader)
 import qualified Ouroboros.Consensus.HeaderValidation as HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
-import           Ouroboros.Consensus.Ledger.Tables.Utils
-                     (applyLedgerTablesDiffs)
+import           Ouroboros.Consensus.Ledger.Tables.Utils (applyDiffs)
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Network.AnchoredSeq (AnchoredSeq (..))
 import qualified Ouroboros.Network.AnchoredSeq as AS
@@ -163,7 +162,7 @@ fromChain cfg initState chain =
     anchorSnapshot NE.:| snapshots =
           fmap headerState
         . NE.scanl
-            (\st blk -> applyLedgerTablesDiffs st $ tickThenReapply (ExtLedgerCfg cfg) blk st)
+            (\st blk -> applyDiffs st $ tickThenReapply (ExtLedgerCfg cfg) blk st)
             initState
         . Chain.toOldestFirst
         $ chain

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Abstract.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Abstract.hs
@@ -157,7 +157,7 @@ tickThenReapplyLedgerResult ::
   -> LedgerResult l (l DiffMK)
 tickThenReapplyLedgerResult cfg blk l =
   let lrTick  = applyChainTickLedgerResult cfg (blockSlot blk) (forgetLedgerTables l)
-      lrBlock = reapplyBlockLedgerResult     cfg          blk  (applyDiffs l (lrResult lrTick))
+      lrBlock = reapplyBlockLedgerResult   cfg            blk  (applyDiffs l (lrResult lrTick))
   in LedgerResult {
       lrEvents = lrEvents lrTick <> lrEvents lrBlock
     , lrResult = prependDiffs (lrResult lrTick) (lrResult lrBlock)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Abstract.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Abstract.hs
@@ -143,10 +143,10 @@ tickThenApplyLedgerResult ::
   -> Except (LedgerErr l) (LedgerResult l (l DiffMK))
 tickThenApplyLedgerResult cfg blk l = do
   let lrTick = applyChainTickLedgerResult cfg (blockSlot blk) (forgetLedgerTables l)
-  lrBlock <-   applyBlockLedgerResult     cfg            blk  (applyLedgerTablesDiffsTicked l (lrResult lrTick))
+  lrBlock <-   applyBlockLedgerResult     cfg            blk  (applyDiffs l (lrResult lrTick))
   pure LedgerResult {
       lrEvents = lrEvents lrTick <> lrEvents lrBlock
-    , lrResult = prependLedgerTablesDiffsFromTicked (lrResult lrTick) (lrResult lrBlock)
+    , lrResult = prependDiffs (lrResult lrTick) (lrResult lrBlock)
     }
 
 tickThenReapplyLedgerResult ::
@@ -157,10 +157,10 @@ tickThenReapplyLedgerResult ::
   -> LedgerResult l (l DiffMK)
 tickThenReapplyLedgerResult cfg blk l =
   let lrTick  = applyChainTickLedgerResult cfg (blockSlot blk) (forgetLedgerTables l)
-      lrBlock = reapplyBlockLedgerResult   cfg            blk  (applyLedgerTablesDiffsTicked l (lrResult lrTick))
+      lrBlock = reapplyBlockLedgerResult     cfg          blk  (applyDiffs l (lrResult lrTick))
   in LedgerResult {
       lrEvents = lrEvents lrTick <> lrEvents lrBlock
-    , lrResult = prependLedgerTablesDiffsFromTicked (lrResult lrTick) (lrResult lrBlock)
+    , lrResult = prependDiffs (lrResult lrTick) (lrResult lrBlock)
     }
 
 tickThenApply ::
@@ -182,12 +182,12 @@ tickThenReapply = lrResult ..: tickThenReapplyLedgerResult
 foldLedger ::
      ApplyBlock l blk
   => LedgerCfg l -> [blk] -> l ValuesMK -> Except (LedgerErr l) (l ValuesMK)
-foldLedger cfg = repeatedlyM (\blk state -> fmap (applyLedgerTablesDiffs state) $ tickThenApply cfg blk state)
+foldLedger cfg = repeatedlyM (\blk state -> fmap (applyDiffs state) $ tickThenApply cfg blk state)
 
 refoldLedger ::
      ApplyBlock l blk
   => LedgerCfg l -> [blk] -> l ValuesMK -> l ValuesMK
-refoldLedger cfg = repeatedly (\blk state -> applyLedgerTablesDiffs state $ tickThenReapply cfg blk state)
+refoldLedger cfg = repeatedly (\blk state -> applyDiffs state $ tickThenReapply cfg blk state)
 
 {-------------------------------------------------------------------------------
   Short-hand

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Dual.hs
@@ -368,7 +368,7 @@ instance Bridge m a => IsLedger (LedgerState (DualBlock m a)) where
                              DualLedgerState{..} =
       castLedgerResult ledgerResult <&> \main -> TickedDualLedgerState {
           tickedDualLedgerStateMain    = main
-        , tickedDualLedgerStateAux     = applyLedgerTablesDiffsTicked dualLedgerStateAux dualLedger
+        , tickedDualLedgerStateAux     = applyDiffs dualLedgerStateAux dualLedger
         , tickedDualLedgerStateAuxOrig = dualLedgerStateAux
         , tickedDualLedgerStateBridge  = dualLedgerStateBridge
         }
@@ -401,7 +401,7 @@ instance Bridge m a => ApplyBlock (LedgerState (DualBlock m a)) (DualBlock m a) 
           )
       return $ castLedgerResult ledgerResult <&> \main' -> DualLedgerState {
           dualLedgerStateMain   = main'
-        , dualLedgerStateAux    = applyLedgerTablesDiffsFromTicked tickedDualLedgerStateAux aux'
+        , dualLedgerStateAux    = applyDiffs tickedDualLedgerStateAux aux'
         , dualLedgerStateBridge = updateBridgeWithBlock
                                     block
                                     tickedDualLedgerStateBridge
@@ -412,7 +412,7 @@ instance Bridge m a => ApplyBlock (LedgerState (DualBlock m a)) (DualBlock m a) 
                            TickedDualLedgerState{..} =
     castLedgerResult ledgerResult <&> \main' -> DualLedgerState {
         dualLedgerStateMain   = main'
-      , dualLedgerStateAux    = applyLedgerTablesDiffsFromTicked tickedDualLedgerStateAux auxLedger
+      , dualLedgerStateAux    = applyDiffs tickedDualLedgerStateAux auxLedger
       , dualLedgerStateBridge = updateBridgeWithBlock
                                   block
                                   tickedDualLedgerStateBridge
@@ -588,7 +588,7 @@ instance Bridge m a => LedgerSupportsMempool (DualBlock m a) where
               }
       return $ flip (,) vtx $ TickedDualLedgerState {
           tickedDualLedgerStateMain    = main'
-        , tickedDualLedgerStateAux     = forgetLedgerTablesDiffsTicked aux'
+        , tickedDualLedgerStateAux     = forgetTrackingDiffs aux'
         , tickedDualLedgerStateAuxOrig = tickedDualLedgerStateAuxOrig
         , tickedDualLedgerStateBridge  = updateBridgeWithTx
                                            vtx
@@ -615,7 +615,7 @@ instance Bridge m a => LedgerSupportsMempool (DualBlock m a) where
           )
       return $ TickedDualLedgerState {
           tickedDualLedgerStateMain    = main'
-        , tickedDualLedgerStateAux     = forgetLedgerTablesDiffsTicked aux'
+        , tickedDualLedgerStateAux     = forgetTrackingDiffs aux'
         , tickedDualLedgerStateAuxOrig = tickedDualLedgerStateAuxOrig
         , tickedDualLedgerStateBridge  = updateBridgeWithTx
                                            tx

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Tables/Utils.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Tables/Utils.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE FlexibleInstances   #-}
 {-# LANGUAGE Rank2Types          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
 {-# LANGUAGE TypeFamilies        #-}
 
 -- | A collection of useful combinators to shorten the code in other places.
@@ -11,163 +13,98 @@
 -- ergonomic. In particular for functions that take two ledger states, it is
 -- unclear if it will keep the in-memory part of the first or the second one.
 module Ouroboros.Consensus.Ledger.Tables.Utils (
-    applyLedgerTablesDiffs
-  , applyLedgerTablesDiffsFromTicked
-  , applyLedgerTablesDiffsTicked
-  , applyLedgerTablesDiffsTicked'
-  , attachAndApplyDiffsTicked
-  , attachAndApplyDiffsTickedToTables
+    -- * Projection and injection
+    ltprj
+  , over
+    -- * Utils aliases: tables
+  , applyDiffs
+  , applyDiffs'
+  , attachAndApplyDiffs
+  , attachAndApplyDiffs'
+  , attachEmptyDiffs
   , calculateAdditions
   , calculateDifference
-  , calculateDifferenceTicked
+  , calculateDifference'
   , emptyLedgerTables
   , forgetLedgerTables
-  , forgetLedgerTablesDiffs
-  , forgetLedgerTablesDiffsTicked
-  , forgetLedgerTablesValues
-  , forgetLedgerTablesValuesTicked
+  , forgetTrackingDiffs
+  , forgetTrackingValues
   , noNewTickingDiffs
-  , prependLedgerTablesDiffs
-  , prependLedgerTablesDiffsFromTicked
-  , prependLedgerTablesDiffsRaw
-  , prependLedgerTablesDiffsTicked
-  , prependLedgerTablesTrackingDiffs
-  , rawReapplyTracking
-  , reapplyTrackingTicked
+  , prependDiffs
+  , prependDiffs'
+  , prependTrackingDiffs
+  , prependTrackingDiffs'
+  , reapplyTracking
+  , restrictValues
     -- * Testing
-  , mapOverLedgerTables
-  , mapOverLedgerTablesTicked
   , rawApplyDiffs
   , rawAttachAndApplyDiffs
+  , rawAttachEmptyDiffs
   , rawCalculateDifference
-  , rawForgetValues
+  , rawForgetTrackingDiffs
+  , rawForgetTrackingValues
+  , rawPrependDiffs
   , rawPrependTrackingDiffs
-  , restrictValues
-  , zipOverLedgerTables
-  , zipOverLedgerTablesTicked
+  , rawReapplyTracking
+  , rawRestrictValues
   ) where
 
 import           Data.Map.Diff.Strict
 import qualified Data.Map.Strict as Map
 import           Ouroboros.Consensus.Ledger.Tables
-import           Ouroboros.Consensus.Ticked
 
 {-------------------------------------------------------------------------------
-  Util combinators
+  Projection and injection
 -------------------------------------------------------------------------------}
 
-overLedgerTables ::
-     (HasLedgerTables l, IsMapKind mk1, IsMapKind mk2)
-  => (LedgerTables l mk1 -> LedgerTables l mk2)
-  -> l mk1
-  -> l mk2
-overLedgerTables f l = withLedgerTables l $ f $ projectLedgerTables l
+over :: (HasLedgerTables l, IsMapKind mk') => l mk -> LedgerTables l mk' -> l mk'
+over = withLedgerTables
 
-mapOverLedgerTables ::
-     (HasLedgerTables l, IsMapKind mk1, IsMapKind mk2)
-  => (forall k v.
-          (Ord k, Eq v)
-       => mk1 k v
-       -> mk2 k v
-     )
-  -> l mk1
-  -> l mk2
-mapOverLedgerTables f = overLedgerTables $ mapLedgerTables f
-
-zipOverLedgerTables ::
-     (HasLedgerTables l, IsMapKind mk1, IsMapKind mk3)
-  => (forall k v.
-          (Ord k, Eq v)
-       => mk1 k v
-       -> mk2 k v
-       -> mk3 k v
-     )
-  ->              l mk1
-  -> LedgerTables l mk2
-  ->              l mk3
-zipOverLedgerTables f l tables2 =
-    overLedgerTables
-      (\tables1 -> zipLedgerTables f tables1 tables2)
-      l
-
-overLedgerTablesTicked ::
-     (HasTickedLedgerTables l, IsMapKind mk1, IsMapKind mk2)
-  => (LedgerTables l mk1 -> LedgerTables l mk2)
-  -> Ticked1 l mk1
-  -> Ticked1 l mk2
-overLedgerTablesTicked f l =
-    withLedgerTables l $ castLedgerTables $ f $ castLedgerTables $ projectLedgerTables l
-
-mapOverLedgerTablesTicked ::
-     (HasTickedLedgerTables l, IsMapKind mk1, IsMapKind mk2)
-  => (forall k v.
-         (Ord k, Eq v)
-      => mk1 k v
-      -> mk2 k v
-     )
-  -> Ticked1 l mk1
-  -> Ticked1 l mk2
-mapOverLedgerTablesTicked f = overLedgerTablesTicked $ mapLedgerTables f
-
-zipOverLedgerTablesTicked ::
-     (HasTickedLedgerTables l, IsMapKind mk1, IsMapKind mk3)
-  => (forall k v.
-         (Ord k, Eq v)
-      => mk1 k v
-      -> mk2 k v
-      -> mk3 k v
-     )
-  -> Ticked1      l mk1
-  -> LedgerTables l mk2
-  -> Ticked1      l mk3
-zipOverLedgerTablesTicked f l tables2 =
-    overLedgerTablesTicked
-      (\tables1 -> zipLedgerTables f tables1 tables2)
-      l
+ltprj :: (HasLedgerTables l, Castable l l', IsMapKind mk) => l mk -> LedgerTables l' mk
+ltprj = castLedgerTables . projectLedgerTables
 
 {-------------------------------------------------------------------------------
-  Utils aliases
+  Utils aliases: tables
 -------------------------------------------------------------------------------}
 
 -- | When applying a block that is not on an era transition, ticking won't
 -- generate new values, so this function can be used to wrap the call to the
 -- ledger rules that perform the tick.
 noNewTickingDiffs :: HasTickedLedgerTables l
-                   => l any
-                   -> l DiffMK
+                  => l any
+                  -> l DiffMK
 noNewTickingDiffs l = withLedgerTables l emptyLedgerTables
-
--- | Empty values for every table
-emptyLedgerTables :: forall mk l. (HasLedgerTables l, IsMapKind mk) => LedgerTables l mk
-emptyLedgerTables = pureLedgerTables emptyMK
-
--- Forget all
 
 forgetLedgerTables :: HasLedgerTables l => l mk -> l EmptyMK
 forgetLedgerTables l = withLedgerTables l emptyLedgerTables
 
--- Forget values
+-- | Empty values for every table
+emptyLedgerTables :: (IsMapKind mk, LedgerTableConstraints l) => LedgerTables l mk
+emptyLedgerTables = ltpure emptyMK
 
-rawForgetValues :: TrackingMK k v -> DiffMK k v
-rawForgetValues (TrackingMK _vs d) = DiffMK d
+--
+-- Forget parts of 'TrackingMK'
+--
 
-forgetLedgerTablesValues :: HasLedgerTables l => l TrackingMK -> l DiffMK
-forgetLedgerTablesValues = mapOverLedgerTables rawForgetValues
+rawForgetTrackingValues :: TrackingMK k v -> DiffMK k v
+rawForgetTrackingValues (TrackingMK _vs d) = DiffMK d
 
-forgetLedgerTablesValuesTicked :: HasTickedLedgerTables l => Ticked1 l TrackingMK -> Ticked1 l DiffMK
-forgetLedgerTablesValuesTicked = mapOverLedgerTablesTicked rawForgetValues
+forgetTrackingValues :: (HasLedgerTables l, LedgerTableConstraints l) => l TrackingMK -> l DiffMK
+forgetTrackingValues l = over l $ ltmap rawForgetTrackingValues (ltprj l)
 
+--
 -- Forget diffs
+--
 
-rawForgetDiffs :: TrackingMK k v -> ValuesMK k v
-rawForgetDiffs (TrackingMK vs _ds) = ValuesMK vs
+rawForgetTrackingDiffs :: TrackingMK k v -> ValuesMK k v
+rawForgetTrackingDiffs (TrackingMK vs _ds) = ValuesMK vs
 
-forgetLedgerTablesDiffs       ::       HasLedgerTables l =>         l TrackingMK ->         l ValuesMK
-forgetLedgerTablesDiffsTicked :: HasTickedLedgerTables l => Ticked1 l TrackingMK -> Ticked1 l ValuesMK
-forgetLedgerTablesDiffs       = mapOverLedgerTables rawForgetDiffs
-forgetLedgerTablesDiffsTicked = mapOverLedgerTablesTicked rawForgetDiffs
+forgetTrackingDiffs :: (LedgerTableConstraints l, HasLedgerTables l) => l TrackingMK -> l ValuesMK
+forgetTrackingDiffs l = over l $ ltmap rawForgetTrackingDiffs (ltprj l)
 
+--
 -- Prepend diffs
+--
 
 rawPrependDiffs ::
      Ord k
@@ -176,16 +113,23 @@ rawPrependDiffs ::
   -> DiffMK k v
 rawPrependDiffs (DiffMK d1) (DiffMK d2) = DiffMK (d1 <> d2)
 
-prependLedgerTablesDiffsRaw        ::       HasLedgerTables l => LedgerTables l DiffMK ->         l DiffMK ->         l DiffMK
-prependLedgerTablesDiffs           ::       HasLedgerTables l =>              l DiffMK ->         l DiffMK ->         l DiffMK
-prependLedgerTablesDiffsFromTicked :: HasTickedLedgerTables l => Ticked1      l DiffMK ->         l DiffMK ->         l DiffMK
-prependLedgerTablesDiffsTicked     :: HasTickedLedgerTables l =>              l DiffMK -> Ticked1 l DiffMK -> Ticked1 l DiffMK
-prependLedgerTablesDiffsRaw        = flip (zipOverLedgerTables rawPrependDiffs)
-prependLedgerTablesDiffs           = prependLedgerTablesDiffsRaw . projectLedgerTables
-prependLedgerTablesDiffsFromTicked = prependLedgerTablesDiffsRaw . castLedgerTables . projectLedgerTables
-prependLedgerTablesDiffsTicked     = flip (zipOverLedgerTablesTicked rawPrependDiffs) . projectLedgerTables
+-- | Prepend diffs from the first ledger state to the diffs from the second
+-- ledger state. Returns ledger tables.
+prependDiffs' ::
+     (Castable l l'', Castable l' l'', HasLedgerTables l, HasLedgerTables l')
+  => l DiffMK -> l' DiffMK -> LedgerTables l'' DiffMK
+prependDiffs' l1 l2 = ltliftA2 rawPrependDiffs (ltprj l1) (ltprj l2)
 
+-- | Like 'prependDiffs'', but puts the ledger tables inside the second ledger
+-- state.
+prependDiffs ::
+     (Castable l l', HasLedgerTables l, HasLedgerTables l')
+  => l DiffMK -> l' DiffMK -> l' DiffMK
+prependDiffs l1 l2 = over l2 $ prependDiffs' l1 l2
+
+--
 -- Apply diffs
+--
 
 rawApplyDiffs ::
      Ord k
@@ -194,16 +138,23 @@ rawApplyDiffs ::
   -> ValuesMK k v
 rawApplyDiffs (ValuesMK vals) (DiffMK diffs) = ValuesMK (applyDiff vals diffs)
 
-applyLedgerTablesDiffs           ::       HasLedgerTables l =>              l ValuesMK ->         l DiffMK ->         l ValuesMK
-applyLedgerTablesDiffsTicked     :: HasTickedLedgerTables l =>              l ValuesMK -> Ticked1 l DiffMK -> Ticked1 l ValuesMK
-applyLedgerTablesDiffsTicked'    :: HasTickedLedgerTables l => LedgerTables l ValuesMK -> Ticked1 l DiffMK -> Ticked1 l ValuesMK
-applyLedgerTablesDiffsFromTicked :: HasTickedLedgerTables l => Ticked1      l ValuesMK ->         l DiffMK ->         l ValuesMK
-applyLedgerTablesDiffs           = flip (zipOverLedgerTables       $ flip rawApplyDiffs) . projectLedgerTables
-applyLedgerTablesDiffsTicked     = flip (zipOverLedgerTablesTicked $ flip rawApplyDiffs) . projectLedgerTables
-applyLedgerTablesDiffsTicked'    = flip (zipOverLedgerTablesTicked $ flip rawApplyDiffs)
-applyLedgerTablesDiffsFromTicked = flip (zipOverLedgerTables       $ flip rawApplyDiffs) . castLedgerTables . projectLedgerTables
+-- | Apply diffs from the second ledger state to the values of the first ledger
+-- state. Returns ledger tables.
+applyDiffs' ::
+     (Castable l l'', Castable l' l'', HasLedgerTables l, HasLedgerTables l')
+  => l ValuesMK -> l' DiffMK -> LedgerTables l'' ValuesMK
+applyDiffs' l1 l2 = ltliftA2 rawApplyDiffs (ltprj l1) (ltprj l2)
 
+-- | Like 'applyDiffs'', but puts the ledger tables inside the second ledger
+-- state.
+applyDiffs ::
+     (Castable l l', HasLedgerTables l, HasLedgerTables l')
+  => l ValuesMK -> l' DiffMK -> l' ValuesMK
+applyDiffs l1 l2 = over l2 $ applyDiffs' l1 l2
+
+--
 -- Calculate differences
+--
 
 rawCalculateDifference ::
      (Ord k, Eq v)
@@ -212,12 +163,29 @@ rawCalculateDifference ::
   -> TrackingMK k v
 rawCalculateDifference (ValuesMK before) (ValuesMK after) = TrackingMK after (diff before after)
 
-calculateAdditions        ::       HasLedgerTables l =>         l ValuesMK ->                               l TrackingMK
-calculateDifference       :: HasTickedLedgerTables l => Ticked1 l ValuesMK ->         l ValuesMK ->         l TrackingMK
-calculateDifferenceTicked :: HasTickedLedgerTables l => Ticked1 l ValuesMK -> Ticked1 l ValuesMK -> Ticked1 l TrackingMK
-calculateAdditions               after = zipOverLedgerTables       (flip rawCalculateDifference) after emptyLedgerTables
-calculateDifference       before after = zipOverLedgerTables       (flip rawCalculateDifference) after (castLedgerTables $ projectLedgerTables before)
-calculateDifferenceTicked before after = zipOverLedgerTablesTicked (flip rawCalculateDifference) after (castLedgerTables $ projectLedgerTables before)
+calculateAdditions ::
+     (LedgerTableConstraints l, HasLedgerTables l)
+  => l ValuesMK -> l TrackingMK
+calculateAdditions l = over l $ ltliftA (rawCalculateDifference emptyMK) (ltprj l)
+
+-- | Calculate the differences between two ledger states. The first ledger state
+-- is considered /before/, the second ledger state is considered /after/.
+-- Returns ledger tables.
+calculateDifference' ::
+     (Castable l l'', Castable l' l'', HasLedgerTables l, HasLedgerTables l')
+  => l ValuesMK -> l' ValuesMK -> LedgerTables l'' TrackingMK
+calculateDifference' l1 l2 = ltliftA2 rawCalculateDifference (ltprj l1) (ltprj l2)
+
+-- | Like 'calculcateDifference'', but puts the ledger tables inside the second
+-- leger state.
+calculateDifference ::
+     (Castable l l', HasLedgerTables l, HasLedgerTables l')
+  => l ValuesMK -> l' ValuesMK -> l' TrackingMK
+calculateDifference l1 l2 = over l2 $ calculateDifference' l1 l2
+
+--
+-- Attaching and/or applying diffs
+--
 
 rawAttachAndApplyDiffs ::
      Ord k
@@ -226,43 +194,52 @@ rawAttachAndApplyDiffs ::
   -> TrackingMK k v
 rawAttachAndApplyDiffs (DiffMK d) (ValuesMK v) = TrackingMK (applyDiff v d) d
 
--- | Replace the tables in the first parameter with the tables of the second
--- parameter after applying the differences in the first parameter to them
-attachAndApplyDiffsTicked ::
-     HasTickedLedgerTables l
-  => Ticked1 l DiffMK
-  ->         l ValuesMK
-  -> Ticked1 l TrackingMK
-attachAndApplyDiffsTicked after before =
-    zipOverLedgerTablesTicked rawAttachAndApplyDiffs after
-  $ projectLedgerTables before
-attachAndApplyDiffsTickedToTables ::
-     HasTickedLedgerTables l
-  => Ticked1 l DiffMK
-  -> LedgerTables l ValuesMK
-  -> Ticked1 l TrackingMK
-attachAndApplyDiffsTickedToTables =
-    zipOverLedgerTablesTicked rawAttachAndApplyDiffs
+-- | Apply the differences from the first ledger state to the values of the
+-- second ledger state, and returns the resulting values together with the
+-- applied diff.
+attachAndApplyDiffs' ::
+     (Castable l l'', Castable l' l'', HasLedgerTables l, HasLedgerTables l')
+  => l DiffMK -> l' ValuesMK -> LedgerTables l'' TrackingMK
+attachAndApplyDiffs' l1 l2 = ltliftA2 rawAttachAndApplyDiffs (ltprj l1) (ltprj l2)
+
+-- | Like 'attachAndApplyDiffs'', but puts the ledger tables inside the first
+-- leger state.
+attachAndApplyDiffs ::
+     (Castable l l', HasLedgerTables l, HasLedgerTables l')
+  => l DiffMK -> l' ValuesMK -> l TrackingMK
+attachAndApplyDiffs l1 l2 = over l1 $ attachAndApplyDiffs' l1 l2
+
+rawAttachEmptyDiffs :: Ord k => ValuesMK k v -> TrackingMK k v
+rawAttachEmptyDiffs (ValuesMK v) = TrackingMK v mempty
+
+-- | Make a 'TrackingMK' with empty diffs.
+attachEmptyDiffs :: HasLedgerTables l => l ValuesMK -> l TrackingMK
+attachEmptyDiffs l1 = over l1 $ ltmap rawAttachEmptyDiffs (ltprj l1)
+
+--
+-- Prepend tracking diffs
+--
 
 rawPrependTrackingDiffs ::
       Ord k
    => TrackingMK k v
    -> TrackingMK k v
    -> TrackingMK k v
-rawPrependTrackingDiffs (TrackingMK v d2) (TrackingMK _v d1) =
+rawPrependTrackingDiffs (TrackingMK _ d1) (TrackingMK v d2) =
   TrackingMK v (d1 <> d2)
 
--- | Mappend the differences in the ledger tables. Keep the ledger state of the
--- first one.
-prependLedgerTablesTrackingDiffs ::
-     HasTickedLedgerTables l
-  => Ticked1 l TrackingMK
-  -> Ticked1 l TrackingMK
-  -> Ticked1 l TrackingMK
-prependLedgerTablesTrackingDiffs after before =
-    zipOverLedgerTablesTicked rawPrependTrackingDiffs after
-  $ castLedgerTables
-  $ projectLedgerTables before
+
+prependTrackingDiffs' ::
+     (Castable l l'', Castable l' l'', HasLedgerTables l, HasLedgerTables l')
+  => l TrackingMK -> l' TrackingMK -> LedgerTables l'' TrackingMK
+prependTrackingDiffs' l1 l2 = ltliftA2 rawPrependTrackingDiffs (ltprj l1) (ltprj l2)
+
+prependTrackingDiffs ::
+     (Castable l l', HasLedgerTables l, HasLedgerTables l')
+  => l TrackingMK -> l' TrackingMK -> l' TrackingMK
+prependTrackingDiffs l1 l2 = over l2 $ prependTrackingDiffs' l1 l2
+
+-- Reapply tracking diffs
 
 rawReapplyTracking ::
      Ord k
@@ -273,14 +250,10 @@ rawReapplyTracking (TrackingMK _v d) (ValuesMK v) = TrackingMK (applyDiff v d) d
 
 -- | Replace the tables in the first parameter with the tables of the second
 -- parameter after applying the differences in the first parameter to them
-reapplyTrackingTicked ::
-     HasTickedLedgerTables l
-  => Ticked1 l TrackingMK
-  ->         l ValuesMK
-  -> Ticked1 l TrackingMK
-reapplyTrackingTicked after before =
-    zipOverLedgerTablesTicked rawReapplyTracking after
-  $ projectLedgerTables before
+reapplyTracking :: LedgerTableConstraints l => LedgerTables l TrackingMK -> LedgerTables l ValuesMK -> LedgerTables l TrackingMK
+reapplyTracking = ltliftA2 rawReapplyTracking
+
+-- Restrict values
 
 rawRestrictValues ::
      Ord k
@@ -290,8 +263,6 @@ rawRestrictValues ::
 rawRestrictValues (ValuesMK v) (KeysMK k) = ValuesMK $ v `Map.restrictKeys` k
 
 restrictValues ::
-     HasLedgerTables l
-  => l ValuesMK
-  -> LedgerTables l KeysMK
-  -> LedgerTables l ValuesMK
-restrictValues st = zipLedgerTables rawRestrictValues (projectLedgerTables st)
+     (Castable l l'', Castable l' l'', HasLedgerTables l, HasLedgerTables l')
+  => l ValuesMK -> l' KeysMK -> LedgerTables l'' ValuesMK
+restrictValues l1 l2 = ltliftA2 rawRestrictValues (ltprj l1) (ltprj l2)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Tables/Utils.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Tables/Utils.hs
@@ -220,6 +220,12 @@ attachEmptyDiffs l1 = over l1 $ ltmap rawAttachEmptyDiffs (ltprj l1)
 -- Prepend tracking diffs
 --
 
+-- | Prepend the former tracking diffs to the latter tracking diffs. Keep the
+-- second tracking values.
+--
+-- PRECONDITION: Given that the first argument is @TrackingMK v1 d1@, and the
+-- second argument is @TrackingMK v2 d2@, it should be the case that @applyDiff
+-- v1 d2 == v2@.
 rawPrependTrackingDiffs ::
       Ord k
    => TrackingMK k v
@@ -228,12 +234,18 @@ rawPrependTrackingDiffs ::
 rawPrependTrackingDiffs (TrackingMK _ d1) (TrackingMK v d2) =
   TrackingMK v (d1 <> d2)
 
-
+-- | Prepend tracking diffs from the first ledger state to the tracking diffs
+-- from the second ledger state. Keep the tracking values of the second ledger
+-- state.
+--
+-- PRECONDITION:  See 'rawPrependTrackingDiffs'.
 prependTrackingDiffs' ::
      (Castable l l'', Castable l' l'', HasLedgerTables l, HasLedgerTables l')
   => l TrackingMK -> l' TrackingMK -> LedgerTables l'' TrackingMK
 prependTrackingDiffs' l1 l2 = ltliftA2 rawPrependTrackingDiffs (ltprj l1) (ltprj l2)
 
+-- | Like 'prependTrackingDiffs'', but puts the ledger tables inside the second
+-- leger state.
 prependTrackingDiffs ::
      (Castable l l', HasLedgerTables l, HasLedgerTables l')
   => l TrackingMK -> l' TrackingMK -> l' TrackingMK

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/StateMachine.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/StateMachine.hs
@@ -457,7 +457,7 @@ foldTxs cfg nextTk remainingCap initialState  =
             go ( MempoolTxAdded vtx:acc
                , succ tk
                , if txInBlockSize tx > cap then 0 else cap - txInBlockSize tx
-               , forgetLedgerTablesDiffsTicked st'
+               , forgetTrackingDiffs st'
                )
                next
 
@@ -468,11 +468,7 @@ tick ::
   => LedgerConfig blk
   -> LedgerState blk ValuesMK
   -> TickedLedgerState blk ValuesMK
-tick cfg st =
-  zipOverLedgerTablesTicked
-    (flip rawApplyDiffs)
-    ticked
-    (projectLedgerTables st)
+tick cfg st = applyDiffs st ticked
   where
     ticked = snd
            . tickLedgerState cfg

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/HD/BackingStore.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/HD/BackingStore.hs
@@ -40,7 +40,6 @@ import qualified Ouroboros.Consensus.Storage.LedgerDB.BackingStore as BS
 import qualified Ouroboros.Consensus.Storage.LedgerDB.BackingStore.Init as BS
 import qualified Ouroboros.Consensus.Storage.LedgerDB.BackingStore.InMemory as BS
 import qualified Ouroboros.Consensus.Storage.LedgerDB.BackingStore.LMDB as LMDB
-import           Ouroboros.Consensus.Util ((.:))
 import           Ouroboros.Consensus.Util.IOLike hiding (MonadMask (..))
 import qualified System.Directory as Dir
 import           System.FS.API hiding (Handle)
@@ -226,7 +225,7 @@ instance Mock.EmptyValues V where
   emptyValues = emptyLedgerTables
 
 instance Mock.ApplyDiff V D where
-  applyDiff = zipLedgerTables rawApplyDiffs
+  applyDiff = applyDiffs'
 
 instance Mock.LookupKeysRange K V where
   lookupKeysRange = \prev n vs ->
@@ -271,7 +270,7 @@ instance Mock.ValuesLength V where
     Map.size m
 
 instance Mock.MakeDiff V D where
-  diff t1 t2 = zipLedgerTables (rawForgetValues .: rawCalculateDifference) t1 t2
+  diff t1 t2 = forgetTrackingValues $ calculateDifference t1 t2
 
 instance Mock.DiffSize D where
   diffSize (LedgerTables (DiffMK (Diff.Diff m))) = Map.size m

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
@@ -830,7 +830,7 @@ runMock cmd initMock =
     push b = do
         ls <- State.get
         l' <- State.lift $ tickThenApply (ledgerDbCfg cfg) b (cur ls)
-        State.put ((b, applyLedgerTablesDiffs (cur ls) l'):ls)
+        State.put ((b, applyDiffs (cur ls) l'):ls)
 
     switch :: Word64
            -> [TestBlock]


### PR DESCRIPTION
# Description

With the changes of #158, we can now unify a lot of the definitions in the `Tables.Utils` modules by using casting/coercing.