### PR TITLE
Nix shell: enable Hoogle

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -25,5 +25,5 @@ pkgs.hsPkgs.shellFor {
     export LOCALE_ARCHIVE="${pkgs.glibcLocales}/lib/locale/locale-archive"
   '';
 
-  withHoogle = false;
+  withHoogle = true;
 }


### PR DESCRIPTION
This might be useful occasionally, and should not have a high cost.

Thanks to @dnadales for the idea!