### PR TITLE
bump ouroboros-consensus-protocol's ouroboros-consensus lower bound to 0.8, as StrictSVar is required

### DIFF
--- a/ouroboros-consensus-protocol/ouroboros-consensus-protocol.cabal
+++ b/ouroboros-consensus-protocol/ouroboros-consensus-protocol.cabal
@@ -53,7 +53,7 @@ library
     , containers
     , mtl
     , nothunks
-    , ouroboros-consensus      >=0.5  && <0.9
+    , ouroboros-consensus      >=0.8  && <0.9
     , serialise
     , text
 


### PR DESCRIPTION
# Description

- bump ouroboros-consensus-protocol's ouroboros-consensus lower bound to 0.8, as StrictSVar is required
