### PR TITLE
Cleanup of old `HasLedgerTables` combinators

### DIFF
--- a/ouroboros-consensus-cardano-legacy-block/src/Legacy/LegacyBlock.hs
+++ b/ouroboros-consensus-cardano-legacy-block/src/Legacy/LegacyBlock.hs
@@ -72,7 +72,6 @@ import           Ouroboros.Consensus.Storage.ImmutableDB.Chunks (ChunkInfo)
 import           Ouroboros.Consensus.Storage.Serialisation (PrefixLen,
                      ReconstructNestedCtxt (..), SizeInBytes)
 import           Ouroboros.Consensus.Ticked (Ticked1)
-import           Ouroboros.Consensus.Util
 import           Ouroboros.Consensus.Util.IOLike (IOLike)
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus-cardano-legacy-block/src/Legacy/Shelley/Ledger.hs
+++ b/ouroboros-consensus-cardano-legacy-block/src/Legacy/Shelley/Ledger.hs
@@ -31,7 +31,6 @@ import           Ouroboros.Consensus.Ledger.Tables.Utils
 import           Ouroboros.Consensus.Protocol.Ledger.Util (isNewEpoch)
 import           Ouroboros.Consensus.Shelley.Ledger
 import           Ouroboros.Consensus.Shelley.Protocol.Abstract (mkHeaderView)
-import           Ouroboros.Consensus.Util ((..:))
 
 {-------------------------------------------------------------------------------
   Ticking

--- a/ouroboros-consensus-cardano/src/byron-testlib/Ouroboros/Consensus/ByronDual/Node.hs
+++ b/ouroboros-consensus-cardano/src/byron-testlib/Ouroboros/Consensus/ByronDual/Node.hs
@@ -44,7 +44,7 @@ import           Ouroboros.Consensus.NodeId
 import           Ouroboros.Consensus.Protocol.PBFT
 import qualified Ouroboros.Consensus.Protocol.PBFT.State as S
 import           Ouroboros.Consensus.Storage.ChainDB.Init (InitChainDB (..))
-import           Ouroboros.Consensus.Util ((.....:), (.:))
+import           Ouroboros.Consensus.Util ((.....:))
 import qualified Test.Cardano.Chain.Elaboration.Block as Spec.Test
 import qualified Test.Cardano.Chain.Elaboration.Delegation as Spec.Test
 import qualified Test.Cardano.Chain.Elaboration.Keys as Spec.Test

--- a/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
+++ b/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
@@ -83,7 +83,7 @@ import           Ouroboros.Consensus.Ledger.Query
 import           Ouroboros.Consensus.Ledger.SupportsPeerSelection
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Ledger.Tables.Utils
-import           Ouroboros.Consensus.Util (ShowProxy (..), (..:))
+import           Ouroboros.Consensus.Util (ShowProxy (..))
 
 {-------------------------------------------------------------------------------
   LedgerState

--- a/ouroboros-consensus-cardano/src/byronspec/Ouroboros/Consensus/ByronSpec/Ledger/Ledger.hs
+++ b/ouroboros-consensus-cardano/src/byronspec/Ouroboros/Consensus/ByronSpec/Ledger/Ledger.hs
@@ -38,7 +38,6 @@ import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.CommonProtocolParams
 import           Ouroboros.Consensus.Ledger.Tables.Utils
 import           Ouroboros.Consensus.Ticked
-import           Ouroboros.Consensus.Util ((..:))
 
 {-------------------------------------------------------------------------------
   State

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
@@ -97,7 +97,6 @@ import           Ouroboros.Consensus.Shelley.Ledger.Config
 import           Ouroboros.Consensus.Shelley.Ledger.Protocol ()
 import           Ouroboros.Consensus.Shelley.Protocol.Abstract
                      (EnvelopeCheckError, envelopeChecks, mkHeaderView)
-import           Ouroboros.Consensus.Util ((..:))
 import           Ouroboros.Consensus.Util.CBOR (decodeWithOrigin,
                      encodeWithOrigin)
 import           Ouroboros.Consensus.Util.Versioned

--- a/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBAnalyser/Analysis.hs
+++ b/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBAnalyser/Analysis.hs
@@ -700,7 +700,7 @@ reproMempoolForge numBlks env = do
           Mempool.getCurrentLedgerState = ledgerState . DbChangelog.current . DbChangelog.anchorlessChangelog <$> IOLike.readTVar ref
         , Mempool.getLedgerTablesAtFor = \pt txs -> do
             let keys = castLedgerTables
-                  $ foldl' (ltliftA2 (<>)) emptyLedgerTables
+                  $ foldl' (<>) emptyLedgerTables
                   $ map getTransactionKeySets txs
             let f = do
                   lgrDb <- anchorlessChangelog <$> IOLike.atomically (IOLike.readTVar ref)

--- a/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBAnalyser/Analysis.hs
+++ b/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBAnalyser/Analysis.hs
@@ -700,7 +700,7 @@ reproMempoolForge numBlks env = do
           Mempool.getCurrentLedgerState = ledgerState . DbChangelog.current . DbChangelog.anchorlessChangelog <$> IOLike.readTVar ref
         , Mempool.getLedgerTablesAtFor = \pt txs -> do
             let keys = castLedgerTables
-                  $ foldl' (zipLedgerTables (<>)) emptyLedgerTables
+                  $ foldl' (ltliftA2 (<>)) emptyLedgerTables
                   $ map getTransactionKeySets txs
             let f = do
                   lgrDb <- anchorlessChangelog <$> IOLike.atomically (IOLike.readTVar ref)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/A.hs
@@ -81,7 +81,7 @@ import           Ouroboros.Consensus.Node.Serialisation
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Storage.ImmutableDB (simpleChunkInfo)
 import           Ouroboros.Consensus.Storage.Serialisation
-import           Ouroboros.Consensus.Util (repeatedlyM, (..:), (.:))
+import           Ouroboros.Consensus.Util (repeatedlyM)
 import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Consensus.Util.Orphans ()
 import           Ouroboros.Network.Block (Serialised, unwrapCBORinCBOR,

--- a/ouroboros-consensus/src/mock-block/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus/src/mock-block/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -98,8 +98,7 @@ import           Ouroboros.Consensus.Mock.Ledger.Address
 import           Ouroboros.Consensus.Mock.Ledger.State
 import qualified Ouroboros.Consensus.Mock.Ledger.UTxO as Mock
 import           Ouroboros.Consensus.Storage.Common (BinaryBlockInfo (..))
-import           Ouroboros.Consensus.Util (ShowProxy (..), hashFromBytesShortE,
-                     (..:))
+import           Ouroboros.Consensus.Util (ShowProxy (..), hashFromBytesShortE)
 import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Consensus.Util.Orphans ()
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Embed/Nary.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Embed/Nary.hs
@@ -39,7 +39,6 @@ import           Ouroboros.Consensus.Ledger.Extended (ExtLedgerState (..))
 import           Ouroboros.Consensus.Ledger.Tables.Utils
 import           Ouroboros.Consensus.Storage.Serialisation
 import           Ouroboros.Consensus.TypeFamilyWrappers
-import           Ouroboros.Consensus.Util ((.:))
 
 {-------------------------------------------------------------------------------
   Injection for a single block into a HardForkBlock

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Forging.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Forging.hs
@@ -38,7 +38,6 @@ import           Ouroboros.Consensus.HardFork.Combinator.Protocol
 import qualified Ouroboros.Consensus.HardFork.Combinator.State as State
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.TypeFamilyWrappers
-import           Ouroboros.Consensus.Util ((.:))
 
 -- | If we cannot forge, it's because the current era could not forge
 type HardForkCannotForge xs = OneEraCannotForge xs

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseDisk.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseDisk.hs
@@ -21,7 +21,6 @@ import           Ouroboros.Consensus.Ledger.Basics
 import           Ouroboros.Consensus.Storage.ChainDB
 import           Ouroboros.Consensus.Storage.Serialisation
 import           Ouroboros.Consensus.TypeFamilyWrappers
-import           Ouroboros.Consensus.Util ((.:))
 
 instance SerialiseHFC xs => SerialiseDiskConstraints  (HardForkBlock xs)
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/State.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/State.hs
@@ -51,7 +51,6 @@ import           Ouroboros.Consensus.HardFork.Combinator.Translation
 import qualified Ouroboros.Consensus.HardFork.History as History
 import           Ouroboros.Consensus.Ledger.Abstract hiding (getTip)
 import           Ouroboros.Consensus.Ledger.Tables.Utils
-import           Ouroboros.Consensus.Util ((.:))
 import           Prelude hiding (sequence)
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Abstract.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Abstract.hs
@@ -40,7 +40,7 @@ import           Ouroboros.Consensus.Block.Abstract
 import           Ouroboros.Consensus.Ledger.Basics
 import           Ouroboros.Consensus.Ledger.Tables.Utils
 import           Ouroboros.Consensus.Ticked
-import           Ouroboros.Consensus.Util (repeatedly, repeatedlyM, (..:))
+import           Ouroboros.Consensus.Util (repeatedly, repeatedlyM)
 
 -- | " Validated " transaction or block
 --

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Basics.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Basics.hs
@@ -40,7 +40,6 @@ import           NoThunks.Class (NoThunks)
 import           Ouroboros.Consensus.Block.Abstract
 import           Ouroboros.Consensus.Ledger.Tables
 import           Ouroboros.Consensus.Ticked
-import           Ouroboros.Consensus.Util ((..:))
 
 {-------------------------------------------------------------------------------
   Tip

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Tables.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Tables.hs
@@ -353,7 +353,6 @@ valuesMKDecoder = do
   Special classes of ledger states
 -------------------------------------------------------------------------------}
 
--- | TODO: make this a type synonym.
 type LedgerTablesAreTrivial :: LedgerStateKind -> Constraint
 -- | For some ledger states we won't be defining 'LedgerTables' and instead the
 -- ledger state will be fully stored in memory, as before UTxO-HD. The ledger

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Tables.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Tables.hs
@@ -24,16 +24,6 @@ module Ouroboros.Consensus.Ledger.Tables (
   , CanStowLedgerTables (..)
   , HasLedgerTables (..)
   , HasTickedLedgerTables
-    -- * TODO: To be removed
-  , foldLedgerTables
-  , foldLedgerTables2
-  , mapLedgerTables
-  , pureLedgerTables
-  , traverseLedgerTables
-  , zipLedgerTables
-  , zipLedgerTables3
-  , zipLedgerTables3A
-  , zipLedgerTablesA
     -- * @MapKind@s
     -- ** Interface
   , IsMapKind (..)
@@ -69,7 +59,6 @@ import           Data.Kind (Constraint, Type)
 import           Data.Map.Diff.Strict (Diff)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Monoid (Sum (..))
 import           Data.Set (Set)
 import           Data.Void (Void)
 import           GHC.Generics
@@ -79,7 +68,6 @@ import           Ouroboros.Consensus.Ledger.Tables.Common
 import           Ouroboros.Consensus.Ledger.Tables.DiffSeq (DiffSeq, empty,
                      mapDiffSeq)
 import           Ouroboros.Consensus.Ticked
-import           Ouroboros.Consensus.Util ((..:), (.:))
 
 {-------------------------------------------------------------------------------
   Basic LedgerState classes
@@ -171,111 +159,6 @@ class CanStowLedgerTables l where
     -> l ValuesMK
   unstowLedgerTables = convertMapKind
 
-{-------------------------------------------------------------------------------
-  To be removed
--------------------------------------------------------------------------------}
-
-pureLedgerTables ::
-     HasLedgerTables l
-  => (forall k v.
-          (Ord k, Eq v)
-       => mk k v
-     )
-  -> LedgerTables l mk
-pureLedgerTables = ltpure
-
-mapLedgerTables ::
-     HasLedgerTables l
-  => (forall k v.
-          (Ord k, Eq v)
-       => mk1 k v
-       -> mk2 k v
-     )
-  -> LedgerTables l mk1
-  -> LedgerTables l mk2
-mapLedgerTables = ltmap
-
-traverseLedgerTables ::
-      (Applicative f, HasLedgerTables l)
-  => (forall k v .
-          (Ord k, Eq v)
-       =>    mk1 k v
-       -> f (mk2 k v)
-     )
-  ->    LedgerTables l mk1
-  -> f (LedgerTables l mk2)
-traverseLedgerTables = lttraverse
-
-zipLedgerTables ::
-     HasLedgerTables l
-  => (forall k v.
-          (Ord k, Eq v)
-       => mk1 k v
-       -> mk2 k v
-       -> mk3 k v
-     )
-  -> LedgerTables l mk1
-  -> LedgerTables l mk2
-  -> LedgerTables l mk3
-zipLedgerTables = ltliftA2
-
-zipLedgerTables3 ::
-     HasLedgerTables l
-  => (forall k v.
-          (Ord k, Eq v)
-       => mk1 k v
-       -> mk2 k v
-       -> mk3 k v
-       -> mk4 k v
-     )
-  -> LedgerTables l mk1
-  -> LedgerTables l mk2
-  -> LedgerTables l mk3
-  -> LedgerTables l mk4
-zipLedgerTables3 = ltliftA3
-
-zipLedgerTablesA ::
-     (Applicative f, HasLedgerTables l)
-  => (forall k v.
-          (Ord k, Eq v)
-       => mk1 k v
-       -> mk2 k v
-       -> f (mk3 k v)
-     )
-  -> LedgerTables l mk1
-  -> LedgerTables l mk2
-  -> f (LedgerTables l mk3)
-zipLedgerTablesA f = ltsequence .: ltliftA2 (Comp2 .: f)
-
-zipLedgerTables3A ::
-     (Applicative f, HasLedgerTables l)
-  => (forall k v.
-          (Ord k, Eq v)
-       => mk1 k v
-       -> mk2 k v
-       -> mk3 k v
-       -> f (mk4 k v)
-     )
-  -> LedgerTables l mk1
-  -> LedgerTables l mk2
-  -> LedgerTables l mk3
-  -> f (LedgerTables l mk4)
-zipLedgerTables3A f = ltsequence ..: ltliftA3 (Comp2 ..: f)
-
-foldLedgerTables ::
-      HasLedgerTables l
-  => (forall k v. (Ord k, Eq v) => mk k v -> m)
-  -> LedgerTables l mk
-  -> m
-foldLedgerTables f = ltcollapse . ltliftA (K2 . f)
-
-foldLedgerTables2 ::
-     HasLedgerTables l
-  => (forall k v. (Ord k, Eq v) => mk1 k v -> mk2 k v -> m)
-  -> LedgerTables l mk1
-  -> LedgerTables l mk2
-  -> m
-foldLedgerTables2 f = ltcollapse .: ltliftA2 (K2 .: f)
 
 {-------------------------------------------------------------------------------
   @MapKind@s
@@ -432,8 +315,8 @@ valuesMKEncoder ::
   => LedgerTables l ValuesMK
   -> CBOR.Encoding
 valuesMKEncoder tables =
-       CBOR.encodeListLen (getSum (foldLedgerTables (\_ -> Sum 1) tables))
-    <> foldLedgerTables2 go codecLedgerTables tables
+       CBOR.encodeListLen (ltcollapse $ ltmap (K2 . const 1) tables)
+    <> ltcollapse (ltliftA2 (K2 .: go) codecLedgerTables tables)
   where
     go :: CodecMK k v -> ValuesMK k v -> CBOR.Encoding
     go (CodecMK encK encV _decK _decV) (ValuesMK m) =
@@ -451,11 +334,11 @@ valuesMKDecoder = do
     numTables <- CBOR.decodeListLen
     if numTables == 0
       then
-        return $ pureLedgerTables emptyMK
+        return $ ltpure emptyMK
       else do
         mapLen <- CBOR.decodeMapLen
-        ret    <- traverseLedgerTables (go mapLen) codecLedgerTables
-        Exn.assert (getSum (foldLedgerTables (\_ -> Sum 1) ret) == numTables)
+        ret    <- lttraverse (go mapLen) codecLedgerTables
+        Exn.assert (ltcollapse (ltmap (K2 . const 1) ret) == numTables)
           $ return ret
  where
   go :: Ord k

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Tables/Combinators.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Tables/Combinators.hs
@@ -44,6 +44,8 @@ module Ouroboros.Consensus.Ledger.Tables.Combinators (
   , ltliftA2
   , ltliftA3
   , ltliftA4
+    -- * Applicative and Traversable
+  , ltzipWith3A
     -- * Collapsing
   , ltcollapse
     -- * Lifted functions
@@ -52,6 +54,10 @@ module Ouroboros.Consensus.Ledger.Tables.Combinators (
   , fn2_3
   , fn2_4
   , type (-..->) (..)
+    -- ** Re-exports of utils
+  , (...:)
+  , (..:)
+  , (.:)
     -- * Basic bifunctors
   , K2 (..)
   , type (:..:) (..)
@@ -61,6 +67,7 @@ import           Data.Bifunctor
 import           Data.Kind
 import           Data.SOP.Functors
 import           Ouroboros.Consensus.Ledger.Tables.Common
+import           Ouroboros.Consensus.Util ((...:), (..:), (.:))
 
 {-------------------------------------------------------------------------------
   Common constraints
@@ -165,6 +172,19 @@ ltliftA4 ::
   -> LedgerTables l mk5
 ltliftA4 f x x' x'' x''' =
   ltpure (fn2_4 f) `ltap` x `ltap` x' `ltap` x'' `ltap` x'''
+
+{-------------------------------------------------------------------------------
+  Applicative and Traversable
+-------------------------------------------------------------------------------}
+
+ltzipWith3A ::
+     (Applicative f, LedgerTableConstraints l)
+  => (forall k v. (Ord k, Eq v) => mk1 k v -> mk2 k v -> mk3 k v -> f (mk4 k v))
+  -> LedgerTables l mk1
+  -> LedgerTables l mk2
+  -> LedgerTables l mk3
+  -> f (LedgerTables l mk4)
+ltzipWith3A f = ltsequence ..: ltliftA3 (Comp2 ..: f)
 
 {-------------------------------------------------------------------------------
   Collapsing

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/API.hs
@@ -82,7 +82,6 @@ import qualified Ouroboros.Consensus.Storage.LedgerDB.DbChangelog.Update as Ledg
 import           Ouroboros.Consensus.Storage.LedgerDB.ReadsKeySets
                      (PointNotFound)
 import           Ouroboros.Consensus.Storage.Serialisation
-import           Ouroboros.Consensus.Util ((..:))
 import           Ouroboros.Consensus.Util.CallStack
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/BackingStore/Init.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/BackingStore/Init.hs
@@ -75,15 +75,15 @@ newBackingStoreInitialiser trcr bss =
         limits
     InMemoryBackingStore -> InMemory.newTVarBackingStoreInitialiser
       (InMemoryTrace >$< trcr)
-      (zipLedgerTables lookup_)
+      (ltliftA2 lookup_)
       (\rq values -> case rqPrev rq of
           Nothing   ->
-            mapLedgerTables (rangeRead0_ (rqCount rq))      values
+            ltmap (rangeRead0_ (rqCount rq))      values
           Just keys ->
-            zipLedgerTables (rangeRead_  (rqCount rq)) keys values
+            ltliftA2 (rangeRead_  (rqCount rq)) keys values
       )
-      (zipLedgerTables applyDiff_)
-      (getSum . foldLedgerTables count_)
+      (ltliftA2 applyDiff_)
+      (getSum . ltcollapse . ltmap (K2 . count_))
       valuesMKEncoder
       valuesMKDecoder
   where

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/DbChangelog.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/DbChangelog.hs
@@ -222,7 +222,7 @@ empty theAnchor =
         changelogLastFlushedState = theAnchor
         , anchorlessChangelog     = AnchorlessDbChangelog {
               adcLastFlushedSlot = pointSlot $ getTip theAnchor
-            , adcDiffs           = pureLedgerTables (SeqDiffMK DS.empty)
+            , adcDiffs           = ltpure (SeqDiffMK DS.empty)
             , adcStates          = AS.Empty theAnchor
             }
       }

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/DbChangelog/Query.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/DbChangelog/Query.hs
@@ -99,7 +99,7 @@ rollbackToPoint pt dblog = do
         ((== pt) . getTip . either id id)
         adcStates
     let ndropped = AS.length adcStates - AS.length vol'
-        diffs'   = mapLedgerTables (trunc ndropped) adcDiffs
+        diffs'   = ltmap (trunc ndropped) adcDiffs
     Exn.assert (ndropped >= 0) $ pure AnchorlessDbChangelog {
           adcLastFlushedSlot
         , adcDiffs  = diffs'
@@ -130,7 +130,7 @@ rollbackToAnchor dblog =
 
     ndropped = AS.length vol
     diffs'   =
-      mapLedgerTables (trunc ndropped) adcDiffs
+      ltmap (trunc ndropped) adcDiffs
 
 trunc ::
      (Ord k, Eq v)
@@ -169,7 +169,8 @@ immutableTipSlot =
 flushableLength :: (HasLedgerTables l, GetTip l) => AnchorlessDbChangelog l -> Word64
 flushableLength chlog =
     (\(Sum x) -> x - fromIntegral (AS.length (adcStates chlog)))
-  . foldLedgerTables f
+  . ltcollapse
+  . ltmap (K2 . f)
   $ adcDiffs chlog
  where
    f :: (Ord k, Eq v)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Query.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Query.hs
@@ -132,8 +132,10 @@ getStatistics (LedgerDBView lbsvh dblog _) = do
     seqNo = adcLastFlushedSlot dblog
 
     nInserts = getSum
-            $ foldLedgerTables (numInserts . getSeqDiffMK)
+            $ ltcollapse
+            $ ltmap (K2 . numInserts . getSeqDiffMK)
               diffs
     nDeletes = getSum
-            $ foldLedgerTables (numDeletes . getSeqDiffMK)
+            $ ltcollapse
+            $ ltmap (K2 . numDeletes . getSeqDiffMK)
               diffs

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/ReadsKeySets.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/ReadsKeySets.hs
@@ -161,7 +161,7 @@ forwardTableKeySets' ::
 forwardTableKeySets' seqNo chdiffs = \(UnforwardedReadSets seqNo' values keys) ->
     if seqNo /= seqNo'
     then Left $ RewindReadFwdError seqNo' seqNo
-    else Right $ zipLedgerTables3 forward values keys chdiffs
+    else Right $ ltliftA3 forward values keys chdiffs
   where
     forward ::
          (Ord k, Eq v)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Update.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Update.hs
@@ -62,7 +62,7 @@ setCurrent v dblog =
               adcLastFlushedSlot = adcLastFlushedSlot $ anchorlessChangelog pruned
             , adcStates          = adcStates dblog
             , adcDiffs           =
-                zipLedgerTables (f s) (adcDiffs $ anchorlessChangelog pruned) (adcDiffs dblog)
+                ltliftA2 (f s) (adcDiffs $ anchorlessChangelog pruned) (adcDiffs dblog)
             }
         })
   where

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool.hs
@@ -612,11 +612,11 @@ withTestMempool setup@TestSetup {..} prop =
       let ledgerInterface = LedgerInterface
             { getCurrentLedgerState = forgetLedgerTables <$> readTVar varCurrentLedgerState
             , getLedgerTablesAtFor = \pt txs -> do
-                let keys = foldl' (zipLedgerTables (<>)) emptyLedgerTables
+                let keys = foldl' (ltliftA2 (<>)) emptyLedgerTables
                       $ map getTransactionKeySets txs
                 st <- atomically $ readTVar varCurrentLedgerState
                 if castPoint (getTip st) == pt
-                  then pure $ Right $ zipLedgerTables f
+                  then pure $ Right $ ltliftA2 f
                                                       (projectLedgerTables st)
                                                       keys
                   else pure $ Left $ PointNotFound pt

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool.hs
@@ -612,7 +612,7 @@ withTestMempool setup@TestSetup {..} prop =
       let ledgerInterface = LedgerInterface
             { getCurrentLedgerState = forgetLedgerTables <$> readTVar varCurrentLedgerState
             , getLedgerTablesAtFor = \pt txs -> do
-                let keys = foldl' (ltliftA2 (<>)) emptyLedgerTables
+                let keys = foldl' (<>) emptyLedgerTables
                       $ map getTransactionKeySets txs
                 st <- atomically $ readTVar varCurrentLedgerState
                 if castPoint (getTip st) == pt

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/StateMachine.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/StateMachine.hs
@@ -519,13 +519,13 @@ newLedgerInterface initialLedger = do
   pure (LedgerInterface {
       getCurrentLedgerState = forgetLedgerTables . ldbTip <$> readTVar t
     , getLedgerTablesAtFor  = \pt txs -> do
-        let keys = foldl' (zipLedgerTables (<>)) emptyLedgerTables
+        let keys = foldl' (ltliftA2 (<>)) emptyLedgerTables
                  $ map getTransactionKeySets txs
         MockedLedgerDB ti oldReachableTips _ <- atomically $ readTVar t
         if pt == castPoint (getTip ti) -- if asking for tables at the tip of the
                                        -- ledger db
         then
-          let tbs = zipLedgerTables f keys $ projectLedgerTables ti
+          let tbs = ltliftA2 f keys $ projectLedgerTables ti
           in  pure $ Right tbs
         else case find ((castPoint pt ==). getTip) oldReachableTips of
            Nothing -> pure $ Left $ PointNotFound pt
@@ -533,7 +533,7 @@ newLedgerInterface initialLedger = do
              if pt == castPoint (getTip mtip)
              -- if asking for tables at some still reachable state
              then
-               let tbs = zipLedgerTables f keys $ projectLedgerTables mtip
+               let tbs = ltliftA2 f keys $ projectLedgerTables mtip
                in  pure $ Right tbs
              else
                -- if asking for tables at other point or at the mempool tip but

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/StateMachine.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/StateMachine.hs
@@ -519,7 +519,7 @@ newLedgerInterface initialLedger = do
   pure (LedgerInterface {
       getCurrentLedgerState = forgetLedgerTables . ldbTip <$> readTVar t
     , getLedgerTablesAtFor  = \pt txs -> do
-        let keys = foldl' (ltliftA2 (<>)) emptyLedgerTables
+        let keys = foldl' (<>) emptyLedgerTables
                  $ map getTransactionKeySets txs
         MockedLedgerDB ti oldReachableTips _ <- atomically $ readTVar t
         if pt == castPoint (getTip ti) -- if asking for tables at the tip of the

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/HD/BackingStore.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/HD/BackingStore.hs
@@ -231,9 +231,9 @@ instance Mock.LookupKeysRange K V where
   lookupKeysRange = \prev n vs ->
       case prev of
         Nothing ->
-          mapLedgerTables (rangeRead n) vs
+          ltmap (rangeRead n) vs
         Just ks ->
-          zipLedgerTables (rangeRead' n) ks vs
+          ltliftA2 (rangeRead' n) ks vs
     where
       rangeRead :: Int -> ValuesMK k v -> ValuesMK k v
       rangeRead n (ValuesMK vs) =
@@ -255,7 +255,7 @@ instance Mock.LookupKeysRange K V where
           ValuesMK vs = vsmk
 
 instance Mock.LookupKeys K V where
-  lookupKeys = zipLedgerTables readKeys
+  lookupKeys = ltliftA2 readKeys
     where
       readKeys ::
           Ord k

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
@@ -1321,7 +1321,7 @@ generator cd secParam (Model mock hs) =
                [ (5, do
                      -- existing point, subset of keys
                      (blk, st) <- QC.elements (mockLedger mock)
-                     keys <- traverseLedgerTables f (projectLedgerTables st)
+                     keys <- lttraverse f (projectLedgerTables st)
                      pure $ GetTablesAtFor (blockPoint blk) keys)
                , (1, do
                      -- existing point, random keys


### PR DESCRIPTION
# Description

#173 left behind some old `HasLedgerTables` combinators, with the goal to reduce the size of the diff. This PR replaces the old combinators by the new ones. Example: `mapLedgerTables` becomes `mapLedgerTables`.