### PR TITLE
Bump bimap upper bound to <0.6

### DIFF
--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -178,7 +178,7 @@ library byronspec
 
   build-depends:
     , base                       >=4.14  && <4.19
-    , bimap                      >=0.4   && <0.5
+    , bimap                      >=0.4   && <0.6
     , byron-spec-chain
     , byron-spec-ledger
     , cardano-ledger-binary

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -292,7 +292,7 @@ library
   build-depends:
     , base                         >=4.14     && <4.19
     , base16-bytestring
-    , bimap                        >=0.4      && <0.5
+    , bimap                        >=0.4      && <0.6
     , binary                       >=0.8      && <0.11
     , bytestring                   >=0.10     && <0.12
     , cardano-binary


### PR DESCRIPTION
# Description
Prerequisite of: https://github.com/input-output-hk/cardano-api/pull/80
