### PR TITLE
Add top-level module for Cardano legacy block

### DIFF
--- a/ouroboros-consensus-cardano-legacy-block/ouroboros-consensus-cardano-legacy-block.cabal
+++ b/ouroboros-consensus-cardano-legacy-block/ouroboros-consensus-cardano-legacy-block.cabal
@@ -47,8 +47,10 @@ library
   exposed-modules:
     DBSync
     Legacy.Byron.Ledger
+    Legacy.Cardano
     Legacy.Cardano.Block
     Legacy.Cardano.CanHardFork
+    Legacy.Cardano.Ledger
     Legacy.Convert
     Legacy.LegacyBlock
     Legacy.Shelley.Ledger

--- a/ouroboros-consensus-cardano-legacy-block/src/DBSync.hs
+++ b/ouroboros-consensus-cardano-legacy-block/src/DBSync.hs
@@ -6,6 +6,7 @@ module DBSync (
   , reapplyBlock
   ) where
 
+import           Legacy.Cardano ()
 import           Legacy.Cardano.Block
 import           Legacy.Cardano.CanHardFork
 import           Ouroboros.Consensus.Cardano.Block

--- a/ouroboros-consensus-cardano-legacy-block/src/Legacy/Cardano.hs
+++ b/ouroboros-consensus-cardano-legacy-block/src/Legacy/Cardano.hs
@@ -1,0 +1,12 @@
+module Legacy.Cardano (
+    LegacyCardanoBlock
+  , LegacyCardanoEras
+  , LegacyCardanoHardForkConstraints
+  , LegacyCardanoShelleyEras
+  ) where
+
+import           Legacy.Byron.Ledger ()
+import           Legacy.Cardano.Block
+import           Legacy.Cardano.CanHardFork
+import           Legacy.Cardano.Ledger ()
+import           Legacy.Shelley.Ledger ()

--- a/ouroboros-consensus-cardano-legacy-block/src/Legacy/Cardano/Block.hs
+++ b/ouroboros-consensus-cardano-legacy-block/src/Legacy/Cardano/Block.hs
@@ -1,20 +1,6 @@
 {-# LANGUAGE DataKinds                #-}
-{-# LANGUAGE DeriveAnyClass           #-}
-{-# LANGUAGE DeriveGeneric            #-}
-{-# LANGUAGE DisambiguateRecordFields #-}
-{-# LANGUAGE FlexibleContexts         #-}
-{-# LANGUAGE FlexibleInstances        #-}
-{-# LANGUAGE InstanceSigs             #-}
-{-# LANGUAGE MultiParamTypeClasses    #-}
-{-# LANGUAGE RankNTypes               #-}
-{-# LANGUAGE ScopedTypeVariables      #-}
 {-# LANGUAGE StandaloneKindSignatures #-}
-{-# LANGUAGE TypeApplications         #-}
-{-# LANGUAGE TypeFamilies             #-}
 {-# LANGUAGE TypeOperators            #-}
-{-# LANGUAGE UndecidableInstances     #-}
-
-{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Legacy.Cardano.Block (
     LegacyCardanoBlock
@@ -22,22 +8,10 @@ module Legacy.Cardano.Block (
   , LegacyCardanoShelleyEras
   ) where
 
-import           Control.Monad.Except
 import           Data.Kind
-import           Data.Proxy
-import           Data.SOP.Functors (Flip (..))
-import           Data.SOP.Strict hiding (shape, tl)
-import           Data.Void (Void)
-import           GHC.Stack (HasCallStack)
 import           Legacy.LegacyBlock
-import           Ouroboros.Consensus.Block
-import           Ouroboros.Consensus.Byron.Ledger
+import           Ouroboros.Consensus.Byron.Ledger.Block
 import           Ouroboros.Consensus.Cardano.Block
-import           Ouroboros.Consensus.HardFork.Combinator.Abstract
-import           Ouroboros.Consensus.HardFork.Combinator.Basics
-import           Ouroboros.Consensus.HardFork.Combinator.Ledger
-import           Ouroboros.Consensus.Ledger.Abstract
-import           Ouroboros.Consensus.Ledger.Tables.Utils
 import           Ouroboros.Consensus.Protocol.Praos
 import           Ouroboros.Consensus.Protocol.TPraos
 import           Ouroboros.Consensus.Shelley.Ledger
@@ -57,168 +31,3 @@ type LegacyCardanoShelleyEras c =
    ]
 
 type LegacyCardanoBlock c = LegacyBlock (HardForkBlock (LegacyCardanoEras c))
-
-{-------------------------------------------------------------------------------
-  Ticking
--------------------------------------------------------------------------------}
-
-instance CanHardFork (LegacyCardanoEras c)
-      => IsLedger (LedgerState (LegacyCardanoBlock c)) where
-  type LedgerErr (LedgerState (LegacyCardanoBlock c)) =
-         LedgerErr (LedgerState (HardForkBlock (LegacyCardanoEras c)))
-
-  type AuxLedgerEvent (LedgerState (LegacyCardanoBlock c)) =
-         AuxLedgerEvent (LedgerState (HardForkBlock (LegacyCardanoEras c)))
-
-  applyChainTickLedgerResult ::
-       LedgerCfg (LedgerState (LegacyCardanoBlock c))
-    -> SlotNo
-    -> LedgerState (LegacyCardanoBlock c) EmptyMK
-    -> LedgerResult
-         (LedgerState (LegacyCardanoBlock c))
-         (Ticked1 (LedgerState (LegacyCardanoBlock c)) DiffMK)
-  applyChainTickLedgerResult cfg slot st0 =
-        fmap castTickedLedgerState . castLedgerResult $ inner
-    where
-      st :: LedgerState (HardForkBlock (LegacyCardanoEras c)) EmptyMK
-      st = getLegacyLedgerState st0
-
-      inner :: LedgerResult
-                 (LedgerState (HardForkBlock (LegacyCardanoEras c)))
-                 (Ticked1 (LedgerState (HardForkBlock (LegacyCardanoEras c))) DiffMK)
-      inner = applyChainTickLedgerResult cfg slot st
-
-      castTickedLedgerState ::
-           Ticked1 (LedgerState (HardForkBlock (LegacyCardanoEras c))) DiffMK
-        -> Ticked1 (LedgerState (LegacyCardanoBlock c)) DiffMK
-      castTickedLedgerState = TickedLegacyLedgerState
-                            . flip withLedgerTables emptyLedgerTables
-
-{-------------------------------------------------------------------------------
-  ApplyBlock
--------------------------------------------------------------------------------}
-
-instance CanHardFork (LegacyCardanoEras c)
-      => ApplyBlock (LedgerState (LegacyCardanoBlock c)) (LegacyCardanoBlock c) where
-  applyBlockLedgerResult ::
-       HasCallStack
-    => LedgerCfg (LedgerState (LegacyCardanoBlock c))
-    -> LegacyCardanoBlock c
-    -> Ticked1 (LedgerState (LegacyCardanoBlock c)) ValuesMK
-    -> Except
-         (LedgerErr (LedgerState (LegacyCardanoBlock c)))
-         (LedgerResult
-           (LedgerState (LegacyCardanoBlock c))
-           (LedgerState (LegacyCardanoBlock c) DiffMK)
-         )
-  applyBlockLedgerResult cfg blk0 tst0 =
-      fmap castLedgerState . castLedgerResult <$> inner
-    where
-      blk :: HardForkBlock (LegacyCardanoEras c)
-      blk = getLegacyBlock blk0
-
-      tst :: Ticked1 (LedgerState (HardForkBlock (LegacyCardanoEras c))) ValuesMK
-      tst = flip withLedgerTables emptyLedgerTables
-          $ getTickedLegacyLedgerState tst0
-
-      inner :: Except
-                 (LedgerErr (LedgerState (HardForkBlock (LegacyCardanoEras c))))
-                 (LedgerResult
-                   (LedgerState (HardForkBlock (LegacyCardanoEras c)))
-                   (LedgerState (HardForkBlock (LegacyCardanoEras c)) DiffMK)
-                 )
-      inner = applyBlockLedgerResult cfg blk tst
-
-      castLedgerState ::
-           LedgerState (HardForkBlock (LegacyCardanoEras c)) DiffMK
-        -> LedgerState (LegacyCardanoBlock c) DiffMK
-      castLedgerState = LegacyLedgerState
-                      . flip withLedgerTables emptyLedgerTables
-
-  reapplyBlockLedgerResult ::
-       HasCallStack
-    => LedgerCfg (LedgerState (LegacyCardanoBlock c))
-    -> LegacyCardanoBlock c
-    -> Ticked1 (LedgerState (LegacyCardanoBlock c)) ValuesMK
-    -> LedgerResult
-         (LedgerState (LegacyCardanoBlock c))
-         (LedgerState (LegacyCardanoBlock c) DiffMK)
-  reapplyBlockLedgerResult cfg blk0 tst0 =
-      fmap castLedgerState . castLedgerResult $ inner
-    where
-      blk :: HardForkBlock (LegacyCardanoEras c)
-      blk = getLegacyBlock blk0
-
-      tst :: Ticked1 (LedgerState (HardForkBlock (LegacyCardanoEras c))) ValuesMK
-      tst = flip withLedgerTables emptyLedgerTables
-          $ getTickedLegacyLedgerState tst0
-
-      inner :: LedgerResult
-                 (LedgerState (HardForkBlock (LegacyCardanoEras c)))
-                 (LedgerState (HardForkBlock (LegacyCardanoEras c)) DiffMK)
-      inner = reapplyBlockLedgerResult cfg blk tst
-
-      castLedgerState ::
-           LedgerState (HardForkBlock (LegacyCardanoEras c)) DiffMK
-        -> LedgerState (LegacyCardanoBlock c) DiffMK
-      castLedgerState = LegacyLedgerState
-                      . flip withLedgerTables emptyLedgerTables
-
-  getBlockKeySets ::
-        LegacyCardanoBlock c
-    -> LedgerTables (LedgerState (LegacyCardanoBlock c)) KeysMK
-  getBlockKeySets = const trivialLedgerTables
-
-{-------------------------------------------------------------------------------
-  Ledger tables
--------------------------------------------------------------------------------}
-
-type instance Key   (LedgerState (HardForkBlock (LegacyCardanoEras c))) = Void
-type instance Value (LedgerState (HardForkBlock (LegacyCardanoEras c))) = Void
-
-instance HasLedgerTables (LedgerState (HardForkBlock (LegacyCardanoEras c))) where
-instance HasLedgerTables (Ticked1 (LedgerState (HardForkBlock (LegacyCardanoEras c)))) where
-instance HasTickedLedgerTables (LedgerState (HardForkBlock (LegacyCardanoEras c))) where
-
-instance LedgerTablesAreTrivial (LedgerState (HardForkBlock (LegacyCardanoEras c))) where
-  convertMapKind (HardForkLedgerState x) = HardForkLedgerState $
-      hcmap
-        (Proxy @(Compose LedgerTablesAreTrivial LedgerState))
-        (Flip . convertMapKind . unFlip) x
-
-instance All (Compose LedgerTablesAreTrivial (ComposeWithTicked1 LedgerState)) (LegacyCardanoEras c)
-      => LedgerTablesAreTrivial (Ticked1 (LedgerState (HardForkBlock (LegacyCardanoEras c)))) where
-  convertMapKind (TickedHardForkLedgerState x st) =
-      TickedHardForkLedgerState x $
-        hcmap
-          (Proxy @(Compose LedgerTablesAreTrivial (ComposeWithTicked1 LedgerState)))
-          ( FlipTickedLedgerState
-          . unComposeWithTicked1
-          . convertMapKind
-          . ComposeWithTicked1
-          . getFlipTickedLedgerState
-          )
-          st
-
-instance CanSerializeLedgerTables (LedgerState (HardForkBlock (LegacyCardanoEras c)))
-
-{-------------------------------------------------------------------------------
-  LedgerTablesCanHardFork
--------------------------------------------------------------------------------}
-
-instance LedgerTablesCanHardFork (LegacyCardanoEras c) where
-  hardForkInjectLedgerTables =
-         injLegacyLedgerTables
-      :* injLegacyLedgerTables
-      :* injLegacyLedgerTables
-      :* injLegacyLedgerTables
-      :* injLegacyLedgerTables
-      :* injLegacyLedgerTables
-      :* injLegacyLedgerTables
-      :* Nil
-    where
-      injLegacyLedgerTables :: InjectLedgerTables (LegacyCardanoEras c) (LegacyBlock blk)
-      injLegacyLedgerTables = InjectLedgerTables {
-          applyInjectLedgerTables  = const emptyLedgerTables
-        , applyDistribLedgerTables = const trivialLedgerTables
-        }

--- a/ouroboros-consensus-cardano-legacy-block/src/Legacy/Cardano/Ledger.hs
+++ b/ouroboros-consensus-cardano-legacy-block/src/Legacy/Cardano/Ledger.hs
@@ -1,0 +1,193 @@
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE InstanceSigs          #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE UndecidableInstances  #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Legacy.Cardano.Ledger () where
+
+import           Control.Monad.Except
+import           Data.Proxy
+import           Data.SOP.Functors (Flip (..))
+import           Data.SOP.Strict hiding (shape, tl)
+import           Data.Void (Void)
+import           GHC.Stack (HasCallStack)
+import           Legacy.Cardano.Block
+import           Legacy.LegacyBlock
+import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.Cardano.Block
+import           Ouroboros.Consensus.HardFork.Combinator.Abstract
+import           Ouroboros.Consensus.HardFork.Combinator.Basics
+import           Ouroboros.Consensus.HardFork.Combinator.Ledger
+import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.Tables.Utils
+
+{-------------------------------------------------------------------------------
+  Ticking
+-------------------------------------------------------------------------------}
+
+instance CanHardFork (LegacyCardanoEras c)
+      => IsLedger (LedgerState (LegacyCardanoBlock c)) where
+  type LedgerErr (LedgerState (LegacyCardanoBlock c)) =
+         LedgerErr (LedgerState (HardForkBlock (LegacyCardanoEras c)))
+
+  type AuxLedgerEvent (LedgerState (LegacyCardanoBlock c)) =
+         AuxLedgerEvent (LedgerState (HardForkBlock (LegacyCardanoEras c)))
+
+  applyChainTickLedgerResult ::
+       LedgerCfg (LedgerState (LegacyCardanoBlock c))
+    -> SlotNo
+    -> LedgerState (LegacyCardanoBlock c) EmptyMK
+    -> LedgerResult
+         (LedgerState (LegacyCardanoBlock c))
+         (Ticked1 (LedgerState (LegacyCardanoBlock c)) DiffMK)
+  applyChainTickLedgerResult cfg slot st0 =
+        fmap castTickedLedgerState . castLedgerResult $ inner
+    where
+      st :: LedgerState (HardForkBlock (LegacyCardanoEras c)) EmptyMK
+      st = getLegacyLedgerState st0
+
+      inner :: LedgerResult
+                 (LedgerState (HardForkBlock (LegacyCardanoEras c)))
+                 (Ticked1 (LedgerState (HardForkBlock (LegacyCardanoEras c))) DiffMK)
+      inner = applyChainTickLedgerResult cfg slot st
+
+      castTickedLedgerState ::
+           Ticked1 (LedgerState (HardForkBlock (LegacyCardanoEras c))) DiffMK
+        -> Ticked1 (LedgerState (LegacyCardanoBlock c)) DiffMK
+      castTickedLedgerState = TickedLegacyLedgerState
+                            . flip withLedgerTables emptyLedgerTables
+
+{-------------------------------------------------------------------------------
+  ApplyBlock
+-------------------------------------------------------------------------------}
+
+instance CanHardFork (LegacyCardanoEras c)
+      => ApplyBlock (LedgerState (LegacyCardanoBlock c)) (LegacyCardanoBlock c) where
+  applyBlockLedgerResult ::
+       HasCallStack
+    => LedgerCfg (LedgerState (LegacyCardanoBlock c))
+    -> LegacyCardanoBlock c
+    -> Ticked1 (LedgerState (LegacyCardanoBlock c)) ValuesMK
+    -> Except
+         (LedgerErr (LedgerState (LegacyCardanoBlock c)))
+         (LedgerResult
+           (LedgerState (LegacyCardanoBlock c))
+           (LedgerState (LegacyCardanoBlock c) DiffMK)
+         )
+  applyBlockLedgerResult cfg blk0 tst0 =
+      fmap castLedgerState . castLedgerResult <$> inner
+    where
+      blk :: HardForkBlock (LegacyCardanoEras c)
+      blk = getLegacyBlock blk0
+
+      tst :: Ticked1 (LedgerState (HardForkBlock (LegacyCardanoEras c))) ValuesMK
+      tst = flip withLedgerTables emptyLedgerTables
+          $ getTickedLegacyLedgerState tst0
+
+      inner :: Except
+                 (LedgerErr (LedgerState (HardForkBlock (LegacyCardanoEras c))))
+                 (LedgerResult
+                   (LedgerState (HardForkBlock (LegacyCardanoEras c)))
+                   (LedgerState (HardForkBlock (LegacyCardanoEras c)) DiffMK)
+                 )
+      inner = applyBlockLedgerResult cfg blk tst
+
+      castLedgerState ::
+           LedgerState (HardForkBlock (LegacyCardanoEras c)) DiffMK
+        -> LedgerState (LegacyCardanoBlock c) DiffMK
+      castLedgerState = LegacyLedgerState
+                      . flip withLedgerTables emptyLedgerTables
+
+  reapplyBlockLedgerResult ::
+       HasCallStack
+    => LedgerCfg (LedgerState (LegacyCardanoBlock c))
+    -> LegacyCardanoBlock c
+    -> Ticked1 (LedgerState (LegacyCardanoBlock c)) ValuesMK
+    -> LedgerResult
+         (LedgerState (LegacyCardanoBlock c))
+         (LedgerState (LegacyCardanoBlock c) DiffMK)
+  reapplyBlockLedgerResult cfg blk0 tst0 =
+      fmap castLedgerState . castLedgerResult $ inner
+    where
+      blk :: HardForkBlock (LegacyCardanoEras c)
+      blk = getLegacyBlock blk0
+
+      tst :: Ticked1 (LedgerState (HardForkBlock (LegacyCardanoEras c))) ValuesMK
+      tst = flip withLedgerTables emptyLedgerTables
+          $ getTickedLegacyLedgerState tst0
+
+      inner :: LedgerResult
+                 (LedgerState (HardForkBlock (LegacyCardanoEras c)))
+                 (LedgerState (HardForkBlock (LegacyCardanoEras c)) DiffMK)
+      inner = reapplyBlockLedgerResult cfg blk tst
+
+      castLedgerState ::
+           LedgerState (HardForkBlock (LegacyCardanoEras c)) DiffMK
+        -> LedgerState (LegacyCardanoBlock c) DiffMK
+      castLedgerState = LegacyLedgerState
+                      . flip withLedgerTables emptyLedgerTables
+
+  getBlockKeySets ::
+        LegacyCardanoBlock c
+    -> LedgerTables (LedgerState (LegacyCardanoBlock c)) KeysMK
+  getBlockKeySets = const trivialLedgerTables
+
+{-------------------------------------------------------------------------------
+  Ledger tables
+-------------------------------------------------------------------------------}
+
+type instance Key   (LedgerState (HardForkBlock (LegacyCardanoEras c))) = Void
+type instance Value (LedgerState (HardForkBlock (LegacyCardanoEras c))) = Void
+
+instance HasLedgerTables (LedgerState (HardForkBlock (LegacyCardanoEras c))) where
+instance HasLedgerTables (Ticked1 (LedgerState (HardForkBlock (LegacyCardanoEras c)))) where
+instance HasTickedLedgerTables (LedgerState (HardForkBlock (LegacyCardanoEras c))) where
+
+instance LedgerTablesAreTrivial (LedgerState (HardForkBlock (LegacyCardanoEras c))) where
+  convertMapKind (HardForkLedgerState x) = HardForkLedgerState $
+      hcmap
+        (Proxy @(Compose LedgerTablesAreTrivial LedgerState))
+        (Flip . convertMapKind . unFlip) x
+
+instance All (Compose LedgerTablesAreTrivial (ComposeWithTicked1 LedgerState)) (LegacyCardanoEras c)
+      => LedgerTablesAreTrivial (Ticked1 (LedgerState (HardForkBlock (LegacyCardanoEras c)))) where
+  convertMapKind (TickedHardForkLedgerState x st) =
+      TickedHardForkLedgerState x $
+        hcmap
+          (Proxy @(Compose LedgerTablesAreTrivial (ComposeWithTicked1 LedgerState)))
+          ( FlipTickedLedgerState
+          . unComposeWithTicked1
+          . convertMapKind
+          . ComposeWithTicked1
+          . getFlipTickedLedgerState
+          )
+          st
+
+instance CanSerializeLedgerTables (LedgerState (HardForkBlock (LegacyCardanoEras c)))
+
+{-------------------------------------------------------------------------------
+  LedgerTablesCanHardFork
+-------------------------------------------------------------------------------}
+
+instance LedgerTablesCanHardFork (LegacyCardanoEras c) where
+  hardForkInjectLedgerTables =
+         injLegacyLedgerTables
+      :* injLegacyLedgerTables
+      :* injLegacyLedgerTables
+      :* injLegacyLedgerTables
+      :* injLegacyLedgerTables
+      :* injLegacyLedgerTables
+      :* injLegacyLedgerTables
+      :* Nil
+    where
+      injLegacyLedgerTables :: InjectLedgerTables (LegacyCardanoEras c) (LegacyBlock blk)
+      injLegacyLedgerTables = InjectLedgerTables {
+          applyInjectLedgerTables  = const emptyLedgerTables
+        , applyDistribLedgerTables = const trivialLedgerTables
+        }

--- a/ouroboros-consensus-cardano-legacy-block/src/Legacy/Convert.hs
+++ b/ouroboros-consensus-cardano-legacy-block/src/Legacy/Convert.hs
@@ -59,10 +59,8 @@ import           Data.SOP.Counting
 import           Data.SOP.Functors
 import           Data.SOP.Match
 import           Data.SOP.Strict
-import           Legacy.Byron.Ledger ()
-import           Legacy.Cardano.Block
+import           Legacy.Cardano
 import           Legacy.LegacyBlock
-import           Legacy.Shelley.Ledger ()
 import           Ouroboros.Consensus.Block.Abstract
 import           Ouroboros.Consensus.Cardano.Block
 import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras


### PR DESCRIPTION
# Description

* Move `Ledger`-related functions for the Cardano legacy block to a separate module.
* Add a top-level Cardano legacy block module that exports the legacy cardano block and all related orphan class instances.