### PR TITLE
Fix 9.6 compilation and update Nix infra

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -232,11 +232,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1686041216,
-        "narHash": "sha256-RP0i9YtZbUkPtPVRz3GuBt9bwfoWCKcJ8888vocTiyg=",
+        "lastModified": 1688518296,
+        "narHash": "sha256-8c6I2aRGg1mHVHHWj49sbcdbkxoXbL5d6fWcHsvwCw4=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "bc3f8b660a3b40f52139f59213652e083e6d2418",
+        "rev": "0f0cbc1c42adc9dfa017ce5836abd87d652efdfb",
         "type": "github"
       },
       "original": {
@@ -328,11 +328,11 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1684223806,
-        "narHash": "sha256-IyLoP+zhuyygLtr83XXsrvKyqqLQ8FHXTiySFf4FJOI=",
+        "lastModified": 1687951625,
+        "narHash": "sha256-jwUD9tyGAvcuIl4TZYc+qGFTCEwIMriim+whXO+fiE4=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "86421fdd89b3af43fa716ccd07638f96c6ecd1e4",
+        "rev": "7bb42e5de0c1318e57017eedbe206751d58b78b3",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -48,23 +48,25 @@
           inherit system;
           inherit (inputs.haskellNix) config;
           overlays = [
-            inputs.haskellNix.overlay
             inputs.iohkNix.overlays.crypto
+            inputs.haskellNix.overlay
+            inputs.iohkNix.overlays.haskell-nix-crypto
             (import ./nix/tools.nix inputs)
             (import ./nix/haskell.nix inputs)
             (import ./nix/pdfs.nix)
           ];
         };
-        devShell = import ./nix/shell.nix pkgs;
+        hydraJobs = import ./nix/ci.nix pkgs;
       in
       {
         devShells = {
-          default = devShell;
+          default = hydraJobs.native.haskell.devShell;
+          ghc96 = hydraJobs.native.haskell96.devShell;
           website = pkgs.mkShell {
             packages = [ pkgs.nodejs pkgs.yarn ];
           };
         };
-        hydraJobs = import ./nix/ci.nix { inherit inputs pkgs devShell; };
+        inherit hydraJobs;
         legacyPackages = pkgs;
       }
     );

--- a/nix/ci.nix
+++ b/nix/ci.nix
@@ -1,4 +1,4 @@
-{ inputs, pkgs, devShell }:
+pkgs:
 
 let
   inherit (pkgs) lib haskell-nix;
@@ -6,7 +6,10 @@ let
   buildSystem = pkgs.buildPlatform.system;
 
   mkHaskellJobsFor = hsPkgs:
-    let projectHsPkgs = haskellLib.selectProjectPackages hsPkgs; in
+    let
+      projectHsPkgs = haskellLib.selectProjectPackages hsPkgs.hsPkgs;
+      noCross = buildSystem == hsPkgs.pkgs.stdenv.hostPlatform.system;
+    in
     {
       libs =
         haskellLib.collectComponents' "library" projectHsPkgs;
@@ -18,34 +21,40 @@ let
         haskellLib.collectComponents' "tests" projectHsPkgs;
       checks =
         haskellLib.collectChecks' projectHsPkgs;
+    } // lib.optionalAttrs noCross {
+      devShell =
+        import ./shell.nix { inherit pkgs hsPkgs; };
     };
+
+  hsPkgsForGhc = ghcVer:
+    pkgs.hsPkgs.appendModule { compiler-nix-name = lib.mkForce ghcVer; };
 
   jobs = lib.filterAttrsRecursive (n: v: n != "recurseForDerivations") ({
     native = {
       haskell = mkHaskellJobsFor pkgs.hsPkgs;
-      formatting = import ./formatting.nix pkgs;
-      inherit devShell;
     } // lib.optionalAttrs (buildSystem == "x86_64-linux") {
+      formatting = import ./formatting.nix pkgs;
       inherit (pkgs) consensus-pdfs;
+
       # ensure we can still build on 8.10, can be removed soon
-      haskell8107 = builtins.removeAttrs
-        (mkHaskellJobsFor (
-          (pkgs.hsPkgs.appendModule {
-            compiler-nix-name = lib.mkForce "ghc8107";
-          }).hsPkgs
-        )) [ "checks" ];
+      haskell810 = builtins.removeAttrs
+        (mkHaskellJobsFor (hsPkgsForGhc "ghc8107"))
+        [ "checks" "devShell" ];
+
+      # ensure we can already build with 9.6, but do not yet run tests to reduce CI load
+      haskell96 = builtins.removeAttrs
+        (mkHaskellJobsFor (hsPkgsForGhc "ghc962"))
+        [ "checks" ];
     };
   } // lib.optionalAttrs (buildSystem == "x86_64-linux") {
     windows = {
-      haskell = mkHaskellJobsFor pkgs.hsPkgs.projectCross.mingwW64.hsPkgs;
+      haskell = mkHaskellJobsFor pkgs.hsPkgs.projectCross.mingwW64;
     };
   });
 
   require = jobs: pkgs.releaseTools.aggregate {
     name = "required-consensus";
-    constituents = lib.collect lib.isDerivation jobs
-      # force rebuild on every commit
-      ++ [ (pkgs.writeText "rebuild-trigger" (inputs.self.rev or "dirty")) ];
+    constituents = lib.collect lib.isDerivation jobs;
   };
 in
 jobs // {

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,22 +1,27 @@
-pkgs:
+{ pkgs, hsPkgs }:
 
 let
   inherit (pkgs) lib;
 in
-pkgs.hsPkgs.shellFor {
+hsPkgs.shellFor {
   nativeBuildInputs = [
     pkgs.cabal
     pkgs.fd
     pkgs.nixpkgs-fmt
     pkgs.stylish-haskell
     pkgs.cabal-fmt
-    pkgs.haskell-language-server
     pkgs.ghcid
 
     # release management
     pkgs.scriv
     (pkgs.python3.withPackages (p: [ p.beautifulsoup4 p.html5lib ]))
   ];
+
+  # This is the place for tools that are required to be built with the same GHC
+  # version as used in hsPkgs.
+  tools = lib.mapAttrs (_: t: t // { index-state = pkgs.tool-index-state; }) {
+    haskell-language-server = { version = "2.0.0.1"; };
+  };
 
   shellHook = ''
     export LANG="en_US.UTF-8"

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -1,20 +1,21 @@
 inputs: final: prev:
 
 let
+  tool-index-state = "2023-07-05T00:00:00Z";
   tool = name: version: other:
     final.haskell-nix.tool final.hsPkgs.args.compiler-nix-name name ({
       version = version;
-      index-state = "2023-05-30T00:00:00Z";
+      index-state = tool-index-state;
     } // other);
 in
 {
+  inherit tool-index-state;
+
   cabal = tool "cabal" "latest" { };
 
   stylish-haskell = tool "stylish-haskell" "0.14.4.0" { };
 
   cabal-fmt = tool "cabal-fmt" "0.1.6" { };
-
-  haskell-language-server = tool "haskell-language-server" "2.0.0.0" { };
 
   scriv = prev.scriv.overrideAttrs (_: {
     version = "1.2.0-custom-iog";

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -606,7 +606,8 @@ executable beacon
     , vector
     , vector-algorithms
 
-  if os(windows)
+  -- Chart does not compile on 9.6 right now: https://github.com/timbod7/haskell-chart/issues/248
+  if (os(windows) || impl(ghc >=9.6))
     buildable: False
 
 test-suite tools-test


### PR DESCRIPTION
 - Fix compilation for 9.6 by disabling the beacon exe on 9.6 for now.
 - Various minor Nix/Hydra tweaks:
    - Remove now-unnecessary workaround for Hydra job reporting
    - Also compile with 9.6 on Nix CI
    - Minor refactoring to allow for GHC-specific dev shells
    - Adapt to iohk-nix changes
    - Only check formatting on one platform