### PR TITLE
bump chaps index-state and relax upper bound on cardano-ledger-core

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -16,7 +16,7 @@ index-state:
   -- Bump this if you need newer packages from Hackage
   , hackage.haskell.org 2023-06-21T21:42:02Z
   -- Bump this if you need newer packages from CHaP
-  , cardano-haskell-packages 2023-06-20T22:19:21Z
+  , cardano-haskell-packages 2023-07-05T12:27:25Z
 
 packages:
   ./ouroboros-consensus

--- a/ouroboros-consensus-cardano/changelog.d/20230706_095651_fraser.murray_bump_chaps_index_state_ledger_core.md
+++ b/ouroboros-consensus-cardano/changelog.d/20230706_095651_fraser.murray_bump_chaps_index_state_ledger_core.md
@@ -1,0 +1,24 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->
+
+### Non-Breaking
+
+- Relax upper bounds on `cardano-ledger-core` (`^>=1.3` to `>=1.3 && <1.5`)
+
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -128,7 +128,7 @@ library
     , cardano-ledger-binary
     , cardano-ledger-byron
     , cardano-ledger-conway
-    , cardano-ledger-core           ^>=1.3.1
+    , cardano-ledger-core           >=1.3 && < 1.5
     , cardano-ledger-mary
     , cardano-ledger-shelley
     , cardano-prelude


### PR DESCRIPTION
# Description

- bump CHaPs index-state to `2023-07-05T12:27:25Z` to include new `cardano-ledger` packages
- relax upper bounds on `cardano-ledger-core` in `ouroboros-consensus-cardano` (to accept 1.4.x)