### PR TITLE
Add golden transactions test to the local transaction submission server

### DIFF
--- a/ouroboros-consensus-cardano/changelog.d/20230718_150203_joris_137_add_golden_txs_test_for_localTxSubmissionServer.md
+++ b/ouroboros-consensus-cardano/changelog.d/20230718_150203_joris_137_add_golden_txs_test_for_localTxSubmissionServer.md
@@ -1,0 +1,23 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->
+### Non-Breaking
+
+- Add new `ProtocolInfo` module to `cardano-testlib`, containing utilities for
+  creating Cardano `ProtocolInfo`s for testing purposes.
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -427,7 +427,6 @@ test-suite cardano-test
     , cardano-crypto-class
     , cardano-ledger-alonzo
     , cardano-ledger-byron
-    , cardano-ledger-conway
     , cardano-ledger-core
     , cardano-ledger-shelley
     , cardano-protocol-tpraos

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -414,6 +414,8 @@ test-suite cardano-test
   other-modules:
     Test.Consensus.Cardano.ByronCompatibility
     Test.Consensus.Cardano.Golden
+    Test.Consensus.Cardano.MiniProtocol.LocalTxSubmission.ByteStringTxParser
+    Test.Consensus.Cardano.MiniProtocol.LocalTxSubmission.Server
     Test.Consensus.Cardano.Serialisation
     Test.ThreadNet.AllegraMary
     Test.ThreadNet.Cardano
@@ -422,6 +424,7 @@ test-suite cardano-test
 
   build-depends:
     , base
+    , base16-bytestring
     , byron-testlib
     , bytestring
     , cardano-crypto-class
@@ -434,18 +437,23 @@ test-suite cardano-test
     , cardano-testlib
     , cborg
     , containers
+    , contra-tracer
     , filepath
     , microlens
-    , ouroboros-consensus-cardano
+    , ouroboros-consensus-cardano:{ouroboros-consensus-cardano, cardano-testlib}
     , ouroboros-consensus-diffusion:diffusion-testlib
     , ouroboros-consensus-protocol
-    , ouroboros-consensus:{ouroboros-consensus, consensus-testlib}
+    , ouroboros-consensus:{ouroboros-consensus, consensus-testlib, mempool-test-utils}
     , ouroboros-network-api
+    , ouroboros-network-protocols:{ouroboros-network-protocols, testlib}
+    , pretty-simple
     , QuickCheck
     , shelley-testlib
     , sop-core
     , tasty
+    , tasty-hunit
     , tasty-quickcheck
+    , typed-protocols
 
 library cardano-tools
   import:          common-lib

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -372,6 +372,7 @@ library cardano-testlib
     Test.Consensus.Cardano.Examples
     Test.Consensus.Cardano.Generators
     Test.Consensus.Cardano.MockCrypto
+    Test.Consensus.Cardano.ProtocolInfo
     Test.ThreadNet.Infra.ShelleyBasedHardFork
     Test.ThreadNet.Infra.TwoEras
     Test.ThreadNet.TxGen.Allegra
@@ -387,6 +388,7 @@ library cardano-testlib
     , cardano-crypto-wrapper
     , cardano-ledger-alonzo-test
     , cardano-ledger-byron
+    , cardano-ledger-conway
     , cardano-ledger-conway-test                                                        ^>=1.2.0.1
     , cardano-ledger-core:{cardano-ledger-core, testlib}
     , cardano-ledger-shelley                                                            ^>=1.4.0

--- a/ouroboros-consensus-cardano/src/cardano-testlib/Test/Consensus/Cardano/ProtocolInfo.hs
+++ b/ouroboros-consensus-cardano/src/cardano-testlib/Test/Consensus/Cardano/ProtocolInfo.hs
@@ -137,6 +137,8 @@ stayInByron =
 versionZero :: SL.Version
 versionZero = SL.natVersion @0
 
+-- TODO: could be simplified once we implement something like
+-- ouroboros-network#4115.
 hardForkInto :: Era -> HardForkSpec
 hardForkInto Byron   = stayInByron
 hardForkInto Shelley =
@@ -280,8 +282,6 @@ mkTestProtocolInfo
     protocolInfoCardano
         ProtocolParamsByron {
             byronGenesis                = genesisByron
-            -- Trivialize the PBFT signature window so that the forks induced by
-            -- the network partition are as deep as possible.
           , byronPbftSignatureThreshold = aByronPbftSignatureThreshold
           , byronProtocolVersion        = aByronProtocolVersion
           , byronSoftwareVersion        = softVerByron

--- a/ouroboros-consensus-cardano/src/cardano-testlib/Test/Consensus/Cardano/ProtocolInfo.hs
+++ b/ouroboros-consensus-cardano/src/cardano-testlib/Test/Consensus/Cardano/ProtocolInfo.hs
@@ -1,0 +1,358 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+
+-- | Utility functions to elaborate a Cardano 'ProtocolInfo' from certain parameters.
+module Test.Consensus.Cardano.ProtocolInfo (
+    -- * ProtocolInfo elaboration parameter types
+    ByronSlotLengthInSeconds (..)
+  , NumCoreNodes (..)
+  , ShelleySlotLengthInSeconds (..)
+    -- ** Hard-fork specification
+  , Era (..)
+  , HardForkSpec (..)
+  , hardForkInto
+  , stayInByron
+    -- * ProtocolInfo elaboration
+  , mkSimpleTestProtocolInfo
+  , mkTestProtocolInfo
+  ) where
+
+import qualified Cardano.Chain.Genesis as CC.Genesis
+import qualified Cardano.Chain.Update as CC.Update
+import qualified Cardano.Ledger.BaseTypes as SL
+import qualified Cardano.Ledger.Conway.Genesis as SL
+import qualified Cardano.Ledger.Shelley.API as SL
+import qualified Cardano.Ledger.Shelley.Translation as SL
+import qualified Cardano.Protocol.TPraos.OCert as SL
+import qualified Cardano.Slotting.Time as Time
+import           Data.Proxy (Proxy (..))
+import           Data.Word (Word64)
+import           Ouroboros.Consensus.Block.Forging (BlockForging)
+import           Ouroboros.Consensus.BlockchainTime (SlotLength)
+import           Ouroboros.Consensus.Byron.Node (ByronLeaderCredentials,
+                     ProtocolParamsByron (..), byronGenesis,
+                     byronMaxTxCapacityOverrides, byronPbftSignatureThreshold,
+                     byronSoftwareVersion)
+import           Ouroboros.Consensus.Cardano.Block (CardanoBlock)
+import           Ouroboros.Consensus.Cardano.Node (CardanoHardForkConstraints,
+                     ProtocolTransitionParamsShelleyBased (..),
+                     TriggerHardFork (TriggerHardForkAtEpoch, TriggerHardForkNever),
+                     protocolInfoCardano, transitionTranslationContext,
+                     transitionTrigger)
+import           Ouroboros.Consensus.Config.SecurityParam (SecurityParam (..))
+import qualified Ouroboros.Consensus.Mempool as Mempool
+import           Ouroboros.Consensus.Node.ProtocolInfo (NumCoreNodes (..),
+                     ProtocolInfo)
+import           Ouroboros.Consensus.NodeId (CoreNodeId (..))
+import           Ouroboros.Consensus.Protocol.PBFT (PBftParams,
+                     PBftSignatureThreshold (..))
+import           Ouroboros.Consensus.Shelley.Node (ProtocolParamsAllegra (..),
+                     ProtocolParamsAlonzo (..), ProtocolParamsMary (..),
+                     ProtocolParamsShelley (..),
+                     ProtocolParamsShelleyBased (..), ShelleyGenesis,
+                     ShelleyLeaderCredentials, allegraMaxTxCapacityOverrides,
+                     allegraProtVer, alonzoMaxTxCapacityOverrides,
+                     alonzoProtVer, maryMaxTxCapacityOverrides, maryProtVer,
+                     sgGenDelegs, shelleyBasedGenesis, shelleyBasedInitialNonce,
+                     shelleyBasedLeaderCredentials,
+                     shelleyMaxTxCapacityOverrides, shelleyProtVer)
+import           Ouroboros.Consensus.Shelley.Node.Praos
+                     (ProtocolParamsBabbage (..), ProtocolParamsConway (..))
+import           Ouroboros.Consensus.Util.IOLike (IOLike)
+import qualified Test.ThreadNet.Infra.Alonzo as Alonzo
+import qualified Test.ThreadNet.Infra.Byron as Byron
+import qualified Test.ThreadNet.Infra.Shelley as Shelley
+import           Test.ThreadNet.Util.Seed (Seed (Seed), runGen)
+import           Test.Util.Slots (NumSlots (..))
+
+{-------------------------------------------------------------------------------
+  ProtocolInfo elaboration parameter types
+-------------------------------------------------------------------------------}
+
+newtype ByronSlotLengthInSeconds = ByronSlotLengthInSeconds Word64
+
+newtype ShelleySlotLengthInSeconds = ShelleySlotLengthInSeconds Word64
+
+class ToSlotLength a where
+  toSlotLength :: a -> SlotLength
+
+instance ToSlotLength ByronSlotLengthInSeconds where
+  toSlotLength (ByronSlotLengthInSeconds n) = Time.slotLengthFromSec $ fromIntegral n
+
+instance ToSlotLength ShelleySlotLengthInSeconds where
+  toSlotLength (ShelleySlotLengthInSeconds n) = Time.slotLengthFromSec $ fromIntegral n
+
+-- | This data structure is used to specify if and when hardforks should take
+-- place, and the version used at each era. See 'stayInByron' and 'hardForkInto'
+-- for examples.
+data HardForkSpec =
+    HardForkSpec {
+      shelleyHardForkSpec :: (SL.ProtVer, TriggerHardFork)
+    , allegraHardForkSpec :: (SL.ProtVer, TriggerHardFork)
+    , maryHardForkSpec    :: (SL.ProtVer, TriggerHardFork)
+    , alonzoHardForkSpec  :: (SL.ProtVer, TriggerHardFork)
+    , babbageHardForkSpec :: (SL.ProtVer, TriggerHardFork)
+    , conwayHardForkSpec  :: (SL.ProtVer, TriggerHardFork)
+    }
+
+data Era = Shelley
+         | Allegra
+         | Mary
+         | Alonzo
+         | Babbage
+         | Conway
+  deriving (Show, Eq, Ord, Enum)
+
+selectEra :: Era -> HardForkSpec -> (SL.ProtVer, TriggerHardFork)
+selectEra Shelley HardForkSpec { shelleyHardForkSpec } = shelleyHardForkSpec
+selectEra Allegra HardForkSpec { allegraHardForkSpec } = allegraHardForkSpec
+selectEra Mary    HardForkSpec { maryHardForkSpec    } = maryHardForkSpec
+selectEra Alonzo  HardForkSpec { alonzoHardForkSpec  } = alonzoHardForkSpec
+selectEra Babbage HardForkSpec { babbageHardForkSpec } = babbageHardForkSpec
+selectEra Conway  HardForkSpec { conwayHardForkSpec  } = conwayHardForkSpec
+
+hfSpecProtVer :: Era -> HardForkSpec -> SL.ProtVer
+hfSpecProtVer era = fst . selectEra era
+
+hfSpecTransitionTrigger :: Era -> HardForkSpec -> TriggerHardFork
+hfSpecTransitionTrigger era = snd . selectEra era
+
+stayInByron :: HardForkSpec
+stayInByron =
+    HardForkSpec {
+      shelleyHardForkSpec = (SL.ProtVer versionZero 0, TriggerHardForkNever)
+    , allegraHardForkSpec = (SL.ProtVer versionZero 0, TriggerHardForkNever)
+    , maryHardForkSpec    = (SL.ProtVer versionZero 0, TriggerHardForkNever)
+    , alonzoHardForkSpec  = (SL.ProtVer versionZero 0, TriggerHardForkNever)
+    , babbageHardForkSpec = (SL.ProtVer versionZero 0, TriggerHardForkNever)
+    , conwayHardForkSpec  = (SL.ProtVer versionZero 0, TriggerHardForkNever)
+    }
+
+versionZero :: SL.Version
+versionZero = SL.natVersion @0
+
+hardForkInto :: Era -> HardForkSpec
+hardForkInto Shelley =
+    stayInByron
+      { shelleyHardForkSpec = (SL.ProtVer versionZero 0, TriggerHardForkAtEpoch 0) }
+hardForkInto Allegra =
+    (hardForkInto Shelley)
+      { allegraHardForkSpec = (SL.ProtVer versionZero 0, TriggerHardForkAtEpoch 0) }
+hardForkInto Mary    =
+    (hardForkInto Allegra)
+      { maryHardForkSpec    = (SL.ProtVer versionZero 0, TriggerHardForkAtEpoch 0) }
+hardForkInto Alonzo  =
+    (hardForkInto Mary)
+      { alonzoHardForkSpec  = (SL.ProtVer versionZero 0, TriggerHardForkAtEpoch 0) }
+hardForkInto Babbage =
+    (hardForkInto Alonzo)
+      { babbageHardForkSpec  = (SL.ProtVer versionZero 0, TriggerHardForkAtEpoch 0) }
+hardForkInto Conway =
+    (hardForkInto Babbage)
+      { conwayHardForkSpec  = (SL.ProtVer versionZero 0, TriggerHardForkAtEpoch 0) }
+
+{-------------------------------------------------------------------------------
+ ProtocolInfo elaboration
+-------------------------------------------------------------------------------}
+
+-- | Create a Cardano protocol info for testing purposes, using some predifined
+-- settings (see below). For a more general version see 'mkTestProtocolInfo'.
+--
+-- The resulting 'ProtocolInfo' will use a randomly generated core node. This
+-- generation will use a fixed seed. See 'mkTestProtocolInfo' for a function
+-- that takes a core node as parameter.
+--
+-- The resulting 'ProtocolInfo' will:
+--
+-- - Use a 'NeutralNonce'.
+-- - Use a fixed number of slots per KES evolution.
+-- - Have version 0 0 0 as Byron protocol version.
+-- - Use 1 as 'PbftSignatureThreshold'
+--
+-- If you want to tweak the resulting protocol info further see
+-- 'mkTestProtocolInfo'.
+--
+-- The resulting 'ProtocolInfo' contains a ledger state. The 'HardForkSpec'
+-- parameter will determine to which era this ledger state belongs. See
+-- 'HardForkSpec' for more details on how to specify a value of this type.
+--
+mkSimpleTestProtocolInfo ::
+     forall c
+   . CardanoHardForkConstraints c
+  => Shelley.DecentralizationParam
+  -- ^ Network decentralization parameter.
+  -> SecurityParam
+  -> ByronSlotLengthInSeconds
+  -> ShelleySlotLengthInSeconds
+  -> HardForkSpec
+  -> ProtocolInfo (CardanoBlock c)
+mkSimpleTestProtocolInfo
+    decentralizationParam
+    securityParam
+    byronSlotLenghtInSeconds
+    shelleySlotLengthInSeconds
+    hardForkSpec
+  = fst
+  $ mkTestProtocolInfo @IO
+      (CoreNodeId 0, coreNodeShelley)
+      shelleyGenesis
+      byronProtocolVersion
+      SL.NeutralNonce
+      genesisByron
+      generatedSecretsByron
+      (Just $ PBftSignatureThreshold 1)
+      hardForkSpec
+  where
+    byronProtocolVersion =
+        CC.Update.ProtocolVersion 0 0 0
+
+    coreNodeShelley = runGen initSeed $ Shelley.genCoreNode initialKESPeriod
+      where
+        initSeed :: Seed
+        initSeed = Seed 0
+
+        initialKESPeriod :: SL.KESPeriod
+        initialKESPeriod = SL.KESPeriod 0
+
+    pbftParams :: PBftParams
+    pbftParams = Byron.byronPBftParams securityParam (NumCoreNodes 1)
+
+    generatedSecretsByron :: CC.Genesis.GeneratedSecrets
+    (genesisByron, generatedSecretsByron) =
+        Byron.generateGenesisConfig (toSlotLength byronSlotLenghtInSeconds) pbftParams
+
+    shelleyGenesis :: ShelleyGenesis c
+    shelleyGenesis =
+        Shelley.mkGenesisConfig
+          (hfSpecProtVer Shelley hardForkSpec)
+          securityParam
+          activeSlotCoeff
+          decentralizationParam
+          maxLovelaceSupply
+          (toSlotLength shelleySlotLengthInSeconds)
+          (Shelley.mkKesConfig (Proxy @c) numSlots)
+          [coreNodeShelley]
+      where
+        maxLovelaceSupply :: Word64
+        maxLovelaceSupply = 45000000000000000
+
+        activeSlotCoeff :: Rational
+        activeSlotCoeff = 0.2   -- c.f. mainnet is more conservative, using 0.05
+
+        numSlots = NumSlots 100
+
+-- | A more generalized version of 'mkSimpleTestProtocolInfo'.
+--
+mkTestProtocolInfo ::
+     forall m c
+   . (CardanoHardForkConstraints c, IOLike m)
+  => (CoreNodeId, Shelley.CoreNode c)
+  -- ^ Id of the node for which the protocol info will be elaborated.
+  -> ShelleyGenesis c
+  -- ^ These nodes will be part of the initial delegation mapping, and funds
+  --   will be allocated to these nodes.
+  -> CC.Update.ProtocolVersion
+  -- ^ Protocol version of the Byron era proposal.
+  -> SL.Nonce
+  -> CC.Genesis.Config
+  -> CC.Genesis.GeneratedSecrets
+  -> Maybe PBftSignatureThreshold
+  -> HardForkSpec
+  -- ^ Specification of the era to which the initial state should hard-fork to.
+  -> (ProtocolInfo (CardanoBlock c), m [BlockForging m (CardanoBlock c)])
+mkTestProtocolInfo
+    (coreNodeId, coreNode)
+    shelleyGenesis
+    aByronProtocolVersion
+    initialNonce
+    genesisByron
+    generatedSecretsByron
+    aByronPbftSignatureThreshold
+    hardForkSpec
+  =
+    protocolInfoCardano
+        ProtocolParamsByron {
+            byronGenesis                = genesisByron
+            -- Trivialize the PBFT signature window so that the forks induced by
+            -- the network partition are as deep as possible.
+          , byronPbftSignatureThreshold = aByronPbftSignatureThreshold
+          , byronProtocolVersion        = aByronProtocolVersion
+          , byronSoftwareVersion        = softVerByron
+          , byronLeaderCredentials      = Just leaderCredentialsByron
+          , byronMaxTxCapacityOverrides = Mempool.mkOverrides Mempool.noOverridesMeasure
+          }
+        ProtocolParamsShelleyBased {
+            shelleyBasedGenesis           = shelleyGenesis
+          , shelleyBasedInitialNonce      = initialNonce
+          , shelleyBasedLeaderCredentials = [leaderCredentialsShelley]
+          }
+        ProtocolParamsShelley {
+            shelleyProtVer                = hfSpecProtVer Shelley hardForkSpec
+          , shelleyMaxTxCapacityOverrides = Mempool.mkOverrides Mempool.noOverridesMeasure
+          }
+        ProtocolParamsAllegra {
+            allegraProtVer                = hfSpecProtVer Allegra hardForkSpec
+          , allegraMaxTxCapacityOverrides = Mempool.mkOverrides Mempool.noOverridesMeasure
+          }
+        ProtocolParamsMary {
+            maryProtVer                   = hfSpecProtVer Mary hardForkSpec
+          , maryMaxTxCapacityOverrides    = Mempool.mkOverrides Mempool.noOverridesMeasure
+          }
+        ProtocolParamsAlonzo {
+            alonzoProtVer                 = hfSpecProtVer Alonzo hardForkSpec
+          , alonzoMaxTxCapacityOverrides  = Mempool.mkOverrides Mempool.noOverridesMeasure
+          }
+        ProtocolParamsBabbage {
+            babbageProtVer                = hfSpecProtVer Babbage hardForkSpec
+          , babbageMaxTxCapacityOverrides = Mempool.mkOverrides Mempool.noOverridesMeasure
+          }
+        ProtocolParamsConway {
+            conwayProtVer                 = hfSpecProtVer Conway hardForkSpec
+          , conwayMaxTxCapacityOverrides  = Mempool.mkOverrides Mempool.noOverridesMeasure
+          }
+        ProtocolTransitionParamsShelleyBased {
+          transitionTranslationContext = SL.toFromByronTranslationContext shelleyGenesis
+        , transitionTrigger            = hfSpecTransitionTrigger Shelley hardForkSpec
+        }
+        ProtocolTransitionParamsShelleyBased {
+            transitionTranslationContext = ()
+          , transitionTrigger            = hfSpecTransitionTrigger Allegra hardForkSpec
+          }
+        ProtocolTransitionParamsShelleyBased {
+            transitionTranslationContext = ()
+          , transitionTrigger            = hfSpecTransitionTrigger Mary hardForkSpec
+          }
+        ProtocolTransitionParamsShelleyBased {
+            transitionTranslationContext = Alonzo.degenerateAlonzoGenesis
+          , transitionTrigger            = hfSpecTransitionTrigger Alonzo hardForkSpec
+          }
+        ProtocolTransitionParamsShelleyBased {
+            transitionTranslationContext = ()
+          , transitionTrigger            = hfSpecTransitionTrigger Babbage hardForkSpec
+          }
+        ProtocolTransitionParamsShelleyBased {
+            transitionTranslationContext =
+              -- Note that this is effectively a no-op, which is fine for
+              -- testing, at least for now.
+              SL.ConwayGenesis $ SL.GenDelegs $ sgGenDelegs shelleyGenesis
+          , transitionTrigger            = hfSpecTransitionTrigger Conway hardForkSpec
+          }
+
+  where
+    leaderCredentialsByron :: ByronLeaderCredentials
+    leaderCredentialsByron =
+        Byron.mkLeaderCredentials
+          genesisByron
+          generatedSecretsByron
+          coreNodeId
+
+    -- This sets a vestigial header field which is not actually used for anything.
+    softVerByron :: CC.Update.SoftwareVersion
+    softVerByron = Byron.theProposedSoftwareVersion
+
+    leaderCredentialsShelley :: ShelleyLeaderCredentials c
+    leaderCredentialsShelley = Shelley.mkLeaderCredentials coreNode

--- a/ouroboros-consensus-cardano/src/cardano-testlib/Test/Consensus/Cardano/ProtocolInfo.hs
+++ b/ouroboros-consensus-cardano/src/cardano-testlib/Test/Consensus/Cardano/ProtocolInfo.hs
@@ -99,7 +99,8 @@ data HardForkSpec =
     , conwayHardForkSpec  :: (SL.ProtVer, TriggerHardFork)
     }
 
-data Era = Shelley
+data Era = Byron
+         | Shelley
          | Allegra
          | Mary
          | Alonzo
@@ -108,6 +109,7 @@ data Era = Shelley
   deriving (Show, Eq, Ord, Enum)
 
 selectEra :: Era -> HardForkSpec -> (SL.ProtVer, TriggerHardFork)
+selectEra Byron   _                                    = error "Byron is the first era, therefore there is no hard fork spec."
 selectEra Shelley HardForkSpec { shelleyHardForkSpec } = shelleyHardForkSpec
 selectEra Allegra HardForkSpec { allegraHardForkSpec } = allegraHardForkSpec
 selectEra Mary    HardForkSpec { maryHardForkSpec    } = maryHardForkSpec
@@ -136,6 +138,7 @@ versionZero :: SL.Version
 versionZero = SL.natVersion @0
 
 hardForkInto :: Era -> HardForkSpec
+hardForkInto Byron   = stayInByron
 hardForkInto Shelley =
     stayInByron
       { shelleyHardForkSpec = (SL.ProtVer versionZero 0, TriggerHardForkAtEpoch 0) }

--- a/ouroboros-consensus-cardano/test/cardano-test/Main.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Main.hs
@@ -2,14 +2,15 @@ module Main (main) where
 
 import           System.IO (BufferMode (LineBuffering), hSetBuffering,
                      hSetEncoding, stdout, utf8)
-import qualified Test.Consensus.Cardano.ByronCompatibility (tests)
-import qualified Test.Consensus.Cardano.Golden (tests)
-import qualified Test.Consensus.Cardano.Serialisation (tests)
+import qualified Test.Consensus.Cardano.ByronCompatibility
+import qualified Test.Consensus.Cardano.Golden
+import qualified Test.Consensus.Cardano.MiniProtocol.LocalTxSubmission.Server
+import qualified Test.Consensus.Cardano.Serialisation
 import           Test.Tasty
-import qualified Test.ThreadNet.AllegraMary (tests)
-import qualified Test.ThreadNet.Cardano (tests)
-import qualified Test.ThreadNet.MaryAlonzo (tests)
-import qualified Test.ThreadNet.ShelleyAllegra (tests)
+import qualified Test.ThreadNet.AllegraMary
+import qualified Test.ThreadNet.Cardano
+import qualified Test.ThreadNet.MaryAlonzo
+import qualified Test.ThreadNet.ShelleyAllegra
 import           Test.Util.TestEnv (defaultMainWithTestEnv,
                      defaultTestEnvConfig)
 
@@ -29,4 +30,5 @@ tests =
   , Test.ThreadNet.Cardano.tests
   , Test.ThreadNet.MaryAlonzo.tests
   , Test.ThreadNet.ShelleyAllegra.tests
+  , Test.Consensus.Cardano.MiniProtocol.LocalTxSubmission.Server.tests
   ]

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/Consensus/Cardano/MiniProtocol/LocalTxSubmission/ByteStringTxParser.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/Consensus/Cardano/MiniProtocol/LocalTxSubmission/ByteStringTxParser.hs
@@ -1,0 +1,54 @@
+{-# LANGUAGE OverloadedStrings #-}
+-- | Utility functions to deserialize the hexadecimal representation of a CBOR
+-- encoded Cardano transaction.
+--
+-- To use from the repl run:
+--
+-- > cabal repl ouroboros-consensus-cardano:test:cardano-test
+-- > import Test.Consensus.Cardano.MiniProtocol.LocalTxSubmission.ByteStringTxParser
+--
+module Test.Consensus.Cardano.MiniProtocol.LocalTxSubmission.ByteStringTxParser (
+    cardanoCodecCfg
+  , deserialiseTx
+  , printDeserializedTx
+  ) where
+
+
+import           Cardano.Chain.Slotting (EpochSlots (..))
+import           Codec.CBOR.Read (DeserialiseFailure, deserialiseFromBytes)
+import           Data.ByteString.Base16.Lazy (decodeLenient)
+import qualified Data.ByteString.Lazy as BL
+import           Ouroboros.Consensus.Byron.Ledger
+import           Ouroboros.Consensus.Cardano.Block
+import           Ouroboros.Consensus.Cardano.Node
+import           Ouroboros.Consensus.Node.Serialisation
+                     (SerialiseNodeToClient (decodeNodeToClient))
+import           Ouroboros.Consensus.Protocol.Praos.Translate ()
+import           Ouroboros.Consensus.Shelley.Ledger
+                     (CodecConfig (ShelleyCodecConfig))
+import           Ouroboros.Consensus.Shelley.Ledger.SupportsProtocol ()
+import           Text.Pretty.Simple (pPrint)
+
+cardanoCodecCfg :: CodecConfig (CardanoBlock StandardCrypto)
+cardanoCodecCfg =
+  CardanoCodecConfig
+            (ByronCodecConfig (EpochSlots 21600))
+            ShelleyCodecConfig
+            ShelleyCodecConfig
+            ShelleyCodecConfig
+            ShelleyCodecConfig
+            ShelleyCodecConfig
+            ShelleyCodecConfig
+
+deserialiseTx ::
+     BL.ByteString
+  -> Either DeserialiseFailure (BL.ByteString, GenTx (CardanoBlock StandardCrypto))
+deserialiseTx = deserialiseFromBytes cborDecoder . decodeLenient
+  where
+    cborDecoder = decodeNodeToClient cardanoCodecCfg CardanoNodeToClientVersion11
+
+printDeserializedTx :: BL.ByteString -> IO ()
+printDeserializedTx bs =
+  case deserialiseTx bs of
+    Left  err             -> pPrint err
+    Right (_rest, result) -> pPrint result

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/Consensus/Cardano/MiniProtocol/LocalTxSubmission/Server.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/Consensus/Cardano/MiniProtocol/LocalTxSubmission/Server.hs
@@ -1,0 +1,135 @@
+{-# LANGUAGE FlexibleContexts   #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings  #-}
+
+-- TODO: remove once we find out why GHC is reporting 'Redundant constraint: Show (LedgerSupportsMempool.ApplyTxErr blk)' in 'should_process_and_return'
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
+-- | Test that we can submit transactions to the mempool using the local
+-- submission server, in different Cardano eras.
+--
+module Test.Consensus.Cardano.MiniProtocol.LocalTxSubmission.Server (tests) where
+
+import           Control.Monad (void)
+import           Control.Tracer (Tracer, nullTracer, stdoutTracer)
+import           Data.Functor.Contravariant ((>$<))
+import           Data.SOP.Strict (index_NS)
+import qualified Data.SOP.Telescope as Telescope
+import           Network.TypedProtocol.Proofs (connect)
+import           Ouroboros.Consensus.Cardano.Block
+import           Ouroboros.Consensus.Config (topLevelConfigLedger)
+import qualified Ouroboros.Consensus.Config as Consensus
+import           Ouroboros.Consensus.HardFork.Combinator (getHardForkState,
+                     hardForkLedgerStatePerEra)
+import           Ouroboros.Consensus.Ledger.Extended (ledgerState)
+import qualified Ouroboros.Consensus.Ledger.SupportsMempool as Ledger
+import qualified Ouroboros.Consensus.Ledger.SupportsMempool as LedgerSupportsMempool
+import qualified Ouroboros.Consensus.Mempool.Capacity as Mempool
+import           Ouroboros.Consensus.MiniProtocol.LocalTxSubmission.Server
+                     (TraceLocalTxSubmissionServerEvent,
+                     localTxSubmissionServer)
+import           Ouroboros.Consensus.Node.ProtocolInfo
+import           Ouroboros.Network.Protocol.LocalTxSubmission.Client
+                     (SubmitResult, localTxSubmissionClientPeer)
+import           Ouroboros.Network.Protocol.LocalTxSubmission.Examples
+                     (localTxSubmissionClient)
+import           Ouroboros.Network.Protocol.LocalTxSubmission.Server
+                     (localTxSubmissionServerPeer)
+import           Test.Consensus.Cardano.MiniProtocol.LocalTxSubmission.ByteStringTxParser
+                     (deserialiseTx)
+import           Test.Consensus.Cardano.ProtocolInfo
+                     (ByronSlotLengthInSeconds (..), Era (..),
+                     ShelleySlotLengthInSeconds (..), hardForkInto,
+                     mkSimpleTestProtocolInfo, stayInByron)
+import qualified Test.Consensus.Mempool.Mocked as Mocked
+import           Test.Consensus.Mempool.Mocked (MockedMempool)
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.HUnit (testCase, (@=?))
+import qualified Test.ThreadNet.Infra.Shelley as Shelley
+
+tests :: TestTree
+tests =
+    testGroup "LocalTxSubmissionServer"
+      $  [ localServerPassesRegressionTests (stayInByron         , 0) ]
+      <> fmap localServerPassesRegressionTests [(hardForkInto era, fromEnum era + 1) | era <- [Shelley ..]]
+      -- fromEnum Shelley == 0, hence the '+ 1' to account for the Byron era
+  where
+    eraName 0 = "Byron"
+    eraName 1 = "Shelley"
+    eraName 2 = "Allegra"
+    eraName 3 = "Mary"
+    eraName 4 = "Alonzo"
+    eraName 5 = "Babbage"
+    eraName 6 = "Conway"
+    eraName i = error $ "Unknown era index: " ++ show i
+
+    localServerPassesRegressionTests (hardForkSpec, i) =
+        testCase ("Passes the regression tests (" ++ eraName i ++ ")") $ do
+          let
+            pInfo :: ProtocolInfo (CardanoBlock StandardCrypto)
+            pInfo = mkSimpleTestProtocolInfo
+                        (Shelley.DecentralizationParam 1)
+                        (Consensus.SecurityParam 10)
+                        (ByronSlotLengthInSeconds 1)
+                        (ShelleySlotLengthInSeconds 1)
+                        hardForkSpec
+            eraIndex = index_NS
+                     . Telescope.tip
+                     . getHardForkState
+                     . hardForkLedgerStatePerEra
+                     . ledgerState
+                     $ pInfoInitLedger pInfo
+
+          eraIndex @=? i
+
+          mempool <- Mocked.openMockedMempool (Mempool.mkCapacityBytesOverride 100_000) -- We don't want the mempool to fill up during these tests.
+                                              nullTracer                                -- Use 'show >$< stdoutTracer' for debugging.
+                                              LedgerSupportsMempool.txInBlockSize
+                                              Mocked.MempoolAndModelParams {
+                                                  Mocked.immpInitialState = ledgerState $ pInfoInitLedger pInfo
+                                                , Mocked.immpLedgerConfig = topLevelConfigLedger $ pInfoConfig pInfo
+                                              }
+
+          mempool `should_process` [ _137 ]
+      where
+        -- Reported in https://github.com/input-output-hk/ouroboros-consensus/issues/137
+        _137 :: GenTx (CardanoBlock StandardCrypto)
+        _137 = either (error . show) snd (deserialiseTx _137_bs)
+          where
+            _137_bs =  "8205d818590210" <> "84a400828258203a79a6a834e7779c67b0b3cbd3b7271883bbbeac15b1a89d78f057edc25e000b008258203a79a6a834e7779c67b0b3cbd3b7271883bbbeac15b1a89d78f057edc25e000b010182825839007d5a2560d23c3443b98d84c57b0c491311da4b3098de1945c7bcfc4c63ea8c5404f9ed9ae80d95b5544857b2011e3f26b63ddc3be1abd42d1a001e84808258390009ecea977429fa7a4993bc045ea618f3697e6b8eac9d5ea68bba7e4b63ea8c5404f9ed9ae80d95b5544857b2011e3f26b63ddc3be1abd42d821a560ea01ca4581c47be64fcc8a7fe5321b976282ce4e43e4d29015f6613cfabcea28eaba244546573741a3b97c0aa51576f52456d706972654c696368303037391a3443f4a0581c4cd2ea369880853541c5f446725f3e4ecaf141635f0c56c43104923ba14574464c41431b0de0b6b346d4b018581c85ef026c7da6a91f7acc1e662c50301bcce79eb401a3217690aa7044a14574464c41431b000000022eaca140581c92bd3be92d6a6eadd7c01ce9ff485809f3f2eb36845cd7a25c9177bfa14b546f20746865206d6f6f6e01021a0002b9b5031a05a18ef7a100818258202726733baa5c15d8d856c8d94e7d83bcfc7f5661ec7f952f052f311a2443feb258405f9d3d8a703baf700a3015994a3e8702fd7fe2e25d640487944b32ea999f36b314be9674be09b8b8f2c678976ecf994c83086180e854120d81243476c2b89e05f5f6"
+
+-- | Check that the given transactions can be processed, irrespective of whether
+-- they were sucessfully validated.
+should_process :: MockedMempool IO blk -> [Ledger.GenTx blk] -> IO ()
+should_process mockedMempool txs = do
+    void $ processTxs nullTracer mockedMempool txs
+
+processTxs ::
+     Tracer IO (TraceLocalTxSubmissionServerEvent blk)
+  -> MockedMempool IO blk
+  -> [Ledger.GenTx blk]
+  -> IO [(GenTx blk, SubmitResult (LedgerSupportsMempool.ApplyTxErr blk))]
+processTxs tracer mockedMempool txs =
+    (\(a, _, _) -> a) <$>
+      connect (localTxSubmissionClientPeer client) (localTxSubmissionServerPeer mServer)
+  where
+    mServer = pure $ localTxSubmissionServer tracer
+                                             (Mocked.getMempool mockedMempool)
+    client  = localTxSubmissionClient txs
+
+-- TODO: this function is unused at the moment. We will use it once we add tests
+-- for Cardano transactions that are supposed to succeed.
+_should_process_and_return ::
+     ( Show (Ledger.GenTx blk)
+     , Eq   (Ledger.ApplyTxErr blk)
+     , Show (Ledger.ApplyTxErr blk)
+     , Show (SubmitResult (LedgerSupportsMempool.ApplyTxErr blk))
+     )
+  => MockedMempool IO blk -> [(Ledger.GenTx blk, SubmitResult (LedgerSupportsMempool.ApplyTxErr blk))] -> IO ()
+_should_process_and_return mockedMempool txs_ress = do
+    processResult <- processTxs (show >$< stdoutTracer) mockedMempool (fmap fst txs_ress)
+    let
+      actualResults   = fmap snd processResult
+      expectedResults = fmap snd txs_ress
+    length actualResults  @=? length expectedResults
+    mapM_ (uncurry (@=?)) $ zip expectedResults actualResults
+    pure ()

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/Consensus/Cardano/MiniProtocol/LocalTxSubmission/Server.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/Consensus/Cardano/MiniProtocol/LocalTxSubmission/Server.hs
@@ -71,13 +71,23 @@ tests =
 
           eraIndex @=? fromEnum era
 
-          mempool <- Mocked.openMockedMempool (Mempool.mkCapacityBytesOverride 100_000) -- We don't want the mempool to fill up during these tests.
-                                              nullTracer                                -- Use 'show >$< stdoutTracer' for debugging.
-                                              LedgerSupportsMempool.txInBlockSize
-                                              Mocked.MempoolAndModelParams {
-                                                  Mocked.immpInitialState = ledgerState $ pInfoInitLedger pInfo
-                                                , Mocked.immpLedgerConfig = topLevelConfigLedger $ pInfoConfig pInfo
-                                              }
+          let
+            -- We don't want the mempool to fill up during these tests.
+            capcityBytesOverride = Mempool.mkCapacityBytesOverride 100_000
+            -- Use 'show >$< stdoutTracer' for debugging.
+            tracer               = nullTracer
+            mempoolParams        = Mocked.MempoolAndModelParams {
+                Mocked.immpInitialState =
+                  ledgerState $ pInfoInitLedger pInfo
+              , Mocked.immpLedgerConfig =
+                  topLevelConfigLedger $ pInfoConfig pInfo
+              }
+
+          mempool <- Mocked.openMockedMempool
+                      capcityBytesOverride
+                      tracer
+                      LedgerSupportsMempool.txInBlockSize
+                      mempoolParams
 
           mempool `should_process` [ _137 ]
       where

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/Cardano.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/Cardano.hs
@@ -486,7 +486,10 @@ mkProtocolCardanoAndHardForkTxs
         initialNonce
         genesisByron
         generatedSecretsByron
-        (Just $ PBftSignatureThreshold 1) -- Trivialize the PBFT signature window so that the forks induced by the network partition are as deep as possible.
+        (Just $ PBftSignatureThreshold 1) -- Trivialize the PBFT signature
+                                          -- window so that the forks induced by
+                                          -- the network partition are as deep
+                                          -- as possible.
         HardForkSpec {
             shelleyHardForkSpec =
               ( SL.ProtVer shelleyMajorVersion 0

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/Cardano.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/Cardano.hs
@@ -14,10 +14,8 @@ import           Cardano.Chain.ProtocolConstants (kEpochSlots)
 import           Cardano.Chain.Slotting (unEpochSlots)
 import qualified Cardano.Chain.Update as CC.Update
 import qualified Cardano.Ledger.BaseTypes as SL
-import qualified Cardano.Ledger.Conway.Genesis as SL
 import qualified Cardano.Ledger.Shelley.API as SL
 import qualified Cardano.Ledger.Shelley.Core as SL
-import qualified Cardano.Ledger.Shelley.Translation as SL
 import qualified Cardano.Protocol.TPraos.OCert as SL
 import           Cardano.Slotting.Slot (EpochSize (..), SlotNo (..))
 import           Control.Exception (assert)
@@ -41,8 +39,6 @@ import           Ouroboros.Consensus.Config.SecurityParam
 import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.Common
                      (isHardForkNodeToNodeEnabled)
 import           Ouroboros.Consensus.Ledger.SupportsMempool (extractTxs)
-import qualified Ouroboros.Consensus.Mempool as Mempool
-import qualified Ouroboros.Consensus.Mempool as TxLimits
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.NodeId
@@ -50,15 +46,14 @@ import           Ouroboros.Consensus.Protocol.PBFT
 import           Ouroboros.Consensus.Protocol.Praos.Translate ()
 import           Ouroboros.Consensus.Shelley.Ledger.SupportsProtocol ()
 import           Ouroboros.Consensus.Shelley.Node
-import           Ouroboros.Consensus.Shelley.Node.Praos
-                     (ProtocolParamsBabbage (..), ProtocolParamsConway (..))
 import           Ouroboros.Consensus.Util.IOLike (IOLike)
 import           Test.Consensus.Cardano.MockCrypto (MockCryptoCompatByron)
+import           Test.Consensus.Cardano.ProtocolInfo (HardForkSpec (..),
+                     mkTestProtocolInfo)
 import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 import           Test.ThreadNet.General
-import qualified Test.ThreadNet.Infra.Alonzo as Alonzo
 import qualified Test.ThreadNet.Infra.Byron as Byron
 import qualified Test.ThreadNet.Infra.Shelley as Shelley
 import           Test.ThreadNet.Infra.TwoEras
@@ -262,11 +257,6 @@ prop_simple_cardano_convergence TestSetup
                   genesisShelley
                   setupInitialNonce
                   (coreNodes !! fromIntegral nid)
-                  ProtocolTransitionParamsShelleyBased {
-                      transitionTranslationContext = SL.toFromByronTranslationContext genesisShelley
-                    , transitionTrigger            =
-                        TriggerHardForkAtVersion $ SL.getVersion shelleyMajorVersion
-                    }
             , mkRekeyM = Nothing
             }
 
@@ -460,13 +450,11 @@ mkProtocolCardanoAndHardForkTxs
   -> ShelleyGenesis c
   -> SL.Nonce
   -> Shelley.CoreNode c
-     -- HardForks
-  -> ProtocolTransitionParamsShelleyBased (ShelleyEra c)
   -> TestNodeInitialization m (CardanoBlock c)
 mkProtocolCardanoAndHardForkTxs
     pbftParams coreNodeId genesisByron generatedSecretsByron propPV
     genesisShelley initialNonce coreNodeShelley
-    protocolParamsByronShelley =
+  =
     TestNodeInitialization
       { tniCrucialTxs   = crucialTxs
       , tniProtocolInfo = protocolInfo
@@ -490,148 +478,41 @@ mkProtocolCardanoAndHardForkTxs
 
     protocolInfo :: ProtocolInfo (CardanoBlock c)
     blockForging :: m [BlockForging m (CardanoBlock c)]
-    (protocolInfo, blockForging) = protocolInfoCardano
-              paramsByron
-              paramsShelleyBased
-              paramsShelley
-              paramsAllegra
-              paramsMary
-              paramsAlonzo
-              paramsBabbage
-              paramsConway
-              transitionShelley
-              transitionAllegra
-              transitionMary
-              transitionAlonzo
-              transitionBabbage
-              transitionConway
-
-    paramsByron :: ProtocolParamsByron
-    paramsByron =
-        ProtocolParamsByron {
-            byronGenesis                = genesisByron
-            -- Trivialize the PBFT signature window so that the forks induced by
-            -- the network partition are as deep as possible.
-          , byronPbftSignatureThreshold = Just $ PBftSignatureThreshold 1
-          , byronProtocolVersion        = propPV
-          , byronSoftwareVersion        = softVerByron
-          , byronLeaderCredentials      = Just leaderCredentialsByron
-          , byronMaxTxCapacityOverrides = TxLimits.mkOverrides TxLimits.noOverridesMeasure
-          }
-
-    paramsShelleyBased :: ProtocolParamsShelleyBased (ShelleyEra c)
-    paramsShelleyBased =
-        ProtocolParamsShelleyBased {
-            shelleyBasedGenesis           = genesisShelley
-          , shelleyBasedInitialNonce      = initialNonce
-          , shelleyBasedLeaderCredentials = [leaderCredentialsShelley]
-          }
-
-    paramsShelley :: ProtocolParamsShelley c
-    paramsShelley =
-        ProtocolParamsShelley {
-            shelleyProtVer                = SL.ProtVer shelleyMajorVersion 0
-          , shelleyMaxTxCapacityOverrides = TxLimits.mkOverrides TxLimits.noOverridesMeasure
-          }
-
-    paramsAllegra :: ProtocolParamsAllegra c
-    paramsAllegra =
-        ProtocolParamsAllegra {
-            allegraProtVer                = SL.ProtVer allegraMajorVersion 0
-          , allegraMaxTxCapacityOverrides = TxLimits.mkOverrides TxLimits.noOverridesMeasure
-          }
-
-    paramsMary :: ProtocolParamsMary c
-    paramsMary =
-        ProtocolParamsMary {
-            maryProtVer                   = SL.ProtVer maryMajorVersion    0
-          , maryMaxTxCapacityOverrides    = TxLimits.mkOverrides TxLimits.noOverridesMeasure
-          }
-
-    paramsAlonzo :: ProtocolParamsAlonzo c
-    paramsAlonzo =
-        ProtocolParamsAlonzo {
-            alonzoProtVer                 = SL.ProtVer alonzoMajorVersion  0
-          , alonzoMaxTxCapacityOverrides  = TxLimits.mkOverrides TxLimits.noOverridesMeasure
-          }
-
-    paramsBabbage :: ProtocolParamsBabbage c
-    paramsBabbage =
-        ProtocolParamsBabbage {
-            babbageProtVer                = SL.ProtVer babbageMajorVersion  0
-          , babbageMaxTxCapacityOverrides  = TxLimits.mkOverrides TxLimits.noOverridesMeasure
-          }
-
-    paramsConway :: ProtocolParamsConway c
-    paramsConway =
-      ProtocolParamsConway {
-            conwayProtVer                 = SL.ProtVer conwayMajorVersion  0
-          , conwayMaxTxCapacityOverrides  = Mempool.mkOverrides Mempool.noOverridesMeasure
-          }
-
-    transitionShelley :: ProtocolTransitionParamsShelleyBased (ShelleyEra c)
-    transitionShelley = protocolParamsByronShelley
-
-    transitionAllegra :: ProtocolTransitionParamsShelleyBased (AllegraEra c)
-    transitionAllegra =
-        ProtocolTransitionParamsShelleyBased {
-            transitionTranslationContext = ()
-          , transitionTrigger            =
-              TriggerHardForkAtVersion $ SL.getVersion allegraMajorVersion
-          }
-
-    transitionMary :: ProtocolTransitionParamsShelleyBased (MaryEra c)
-    transitionMary =
-        ProtocolTransitionParamsShelleyBased {
-            transitionTranslationContext = ()
-          , transitionTrigger            =
-              TriggerHardForkAtVersion $ SL.getVersion maryMajorVersion
-          }
-
-    transitionAlonzo :: ProtocolTransitionParamsShelleyBased (AlonzoEra c)
-    transitionAlonzo =
-        ProtocolTransitionParamsShelleyBased {
-            transitionTranslationContext = Alonzo.degenerateAlonzoGenesis
-          , transitionTrigger            =
-              TriggerHardForkAtVersion $ SL.getVersion alonzoMajorVersion
-          }
-
-    transitionBabbage :: ProtocolTransitionParamsShelleyBased (BabbageEra c)
-    transitionBabbage =
-        ProtocolTransitionParamsShelleyBased {
-            transitionTranslationContext = ()
-          , transitionTrigger            =
-              TriggerHardForkAtVersion $ SL.getVersion babbageMajorVersion
-          }
-
-    transitionConway :: ProtocolTransitionParamsShelleyBased (ConwayEra c)
-    transitionConway =
-      ProtocolTransitionParamsShelleyBased {
-            transitionTranslationContext =
-              -- Note that this is effectively a no-op, which is fine for
-              -- testing, at least for now.
-              SL.ConwayGenesis $ SL.GenDelegs $ sgGenDelegs genesisShelley
-          , transitionTrigger            =
-              TriggerHardForkAtVersion $ SL.getVersion conwayMajorVersion
-          }
-
-    -- Byron
-
-    leaderCredentialsByron :: ByronLeaderCredentials
-    leaderCredentialsByron =
-        Byron.mkLeaderCredentials
-          genesisByron
-          generatedSecretsByron
-          coreNodeId
-
-    -- this sets a vestigial header field which is not actually used for anything
-    softVerByron :: CC.Update.SoftwareVersion
-    softVerByron = Byron.theProposedSoftwareVersion
-
-    -- Shelley
-
-    leaderCredentialsShelley :: ShelleyLeaderCredentials c
-    leaderCredentialsShelley = Shelley.mkLeaderCredentials coreNodeShelley
+    (protocolInfo, blockForging) =
+      mkTestProtocolInfo
+        (coreNodeId, coreNodeShelley)
+        genesisShelley
+        propPV
+        initialNonce
+        genesisByron
+        generatedSecretsByron
+        (Just $ PBftSignatureThreshold 1) -- Trivialize the PBFT signature window so that the forks induced by the network partition are as deep as possible.
+        HardForkSpec {
+            shelleyHardForkSpec =
+              ( SL.ProtVer shelleyMajorVersion 0
+              , TriggerHardForkAtVersion $ SL.getVersion shelleyMajorVersion
+              )
+          , allegraHardForkSpec =
+              ( SL.ProtVer allegraMajorVersion 0
+              , TriggerHardForkAtVersion $ SL.getVersion allegraMajorVersion
+              )
+          , maryHardForkSpec =
+              ( SL.ProtVer maryMajorVersion    0
+              , TriggerHardForkAtVersion $ SL.getVersion maryMajorVersion
+              )
+          , alonzoHardForkSpec =
+              ( SL.ProtVer alonzoMajorVersion  0
+              , TriggerHardForkAtVersion $ SL.getVersion alonzoMajorVersion
+              )
+          , babbageHardForkSpec =
+              ( SL.ProtVer babbageMajorVersion  0
+              , TriggerHardForkAtVersion $ SL.getVersion babbageMajorVersion
+              )
+          , conwayHardForkSpec =
+              ( SL.ProtVer conwayMajorVersion  0
+              , TriggerHardForkAtVersion $ SL.getVersion conwayMajorVersion
+              )
+        }
 
 {-------------------------------------------------------------------------------
   Constants

--- a/ouroboros-consensus/bench/mempool-bench/Bench/Consensus/Mempool.hs
+++ b/ouroboros-consensus/bench/mempool-bench/Bench/Consensus/Mempool.hs
@@ -20,8 +20,6 @@ module Bench.Consensus.Mempool (
   ) where
 
 import           Bench.Consensus.Mempool.TestBlock ()
-import           Bench.Consensus.MempoolWithMockedLedgerItf
-                     (MempoolWithMockedLedgerItf, addTx)
 import           Control.DeepSeq (NFData)
 import           Control.Monad (void)
 import           Data.Foldable (traverse_)
@@ -29,6 +27,8 @@ import           Data.Maybe (mapMaybe)
 import           GHC.Generics (Generic)
 import qualified Ouroboros.Consensus.Ledger.SupportsMempool as Ledger
 import           Ouroboros.Consensus.Mempool.API (AddTxOnBehalfOf (..))
+import qualified Test.Consensus.Mempool.Mocked as Mocked
+import           Test.Consensus.Mempool.Mocked (MockedMempool)
 
 {-------------------------------------------------------------------------------
   Commands
@@ -70,11 +70,11 @@ getCmdsTxIds = mapMaybe getCmdTxId
 -- and tested by state-mathine tests.
 run ::
      Monad m
-  => MempoolWithMockedLedgerItf m blk -> [MempoolCmd blk] -> m ()
+  => MockedMempool m blk -> [MempoolCmd blk] -> m ()
 run mempool = traverse_ (runCmd mempool)
 
 runCmd ::
      Monad m
-  => MempoolWithMockedLedgerItf m blk -> MempoolCmd blk -> m ()
+  => MockedMempool m blk -> MempoolCmd blk -> m ()
 runCmd mempool = \case
-    AddTx tx -> void $ addTx mempool AddTxForRemotePeer tx -- TODO: we might want to benchmark the 'Intervene' case
+    AddTx tx -> void $ Mocked.addTx mempool AddTxForRemotePeer tx -- TODO: we might want to benchmark the 'Intervene' case

--- a/ouroboros-consensus/bench/mempool-bench/Bench/Consensus/Mempool/TestBlock.hs
+++ b/ouroboros-consensus/bench/mempool-bench/Bench/Consensus/Mempool/TestBlock.hs
@@ -14,7 +14,6 @@ module Bench.Consensus.Mempool.TestBlock (
     -- * Initial parameters
   , initialLedgerState
   , sampleLedgerConfig
-  , sampleMempoolAndModelParams
     -- * Transactions
   , Token (Token)
   , Tx (Tx)
@@ -22,7 +21,6 @@ module Bench.Consensus.Mempool.TestBlock (
   , txSize
   ) where
 
-import           Bench.Consensus.MempoolWithMockedLedgerItf
 import qualified Cardano.Slotting.Time as Time
 import           Codec.Serialise (Serialise)
 import           Control.DeepSeq (NFData)
@@ -76,12 +74,6 @@ initialLedgerState = TestLedger {
 sampleLedgerConfig :: Ledger.LedgerConfig TestBlock
 sampleLedgerConfig =
   HardFork.defaultEraParams (Consensus.SecurityParam 10) (Time.slotLengthFromSec 2)
-
-sampleMempoolAndModelParams :: InitialMempoolAndModelParams TestBlock
-sampleMempoolAndModelParams = MempoolAndModelParams {
-      immpInitialState = initialLedgerState
-    , immpLedgerConfig = sampleLedgerConfig
-    }
 
 {-------------------------------------------------------------------------------
   Payload semantics

--- a/ouroboros-consensus/bench/mempool-bench/Main.hs
+++ b/ouroboros-consensus/bench/mempool-bench/Main.hs
@@ -10,7 +10,6 @@ module Main (main) where
 import           Bench.Consensus.Mempool
 import           Bench.Consensus.Mempool.TestBlock (TestBlock)
 import qualified Bench.Consensus.Mempool.TestBlock as TestBlock
-import           Bench.Consensus.MempoolWithMockedLedgerItf
 import           Control.Arrow (first)
 import           Control.Monad (unless, void)
 import qualified Control.Tracer as Tracer
@@ -23,6 +22,8 @@ import qualified Data.Text as Text
 import qualified Data.Text.Read as Text.Read
 import qualified Ouroboros.Consensus.Mempool.Capacity as Mempool
 import           System.Exit (die, exitFailure)
+import qualified Test.Consensus.Mempool.Mocked as Mocked
+import           Test.Consensus.Mempool.Mocked (MockedMempool)
 import           Test.Tasty (withResource)
 import           Test.Tasty.Bench (CsvPath (CsvPath), bench, benchIngredients,
                      bgroup, nfIO)
@@ -59,7 +60,7 @@ main = do
                             (mempool, txs) <- getAcquiredRes
                             void $ act mempool txs
                             -- TODO: consider adding a 'reset' command to the mempool to make sure its state is not tainted.
-                            removeTxs mempool $ getCmdsTxIds txs
+                            Mocked.removeTxs mempool $ getCmdsTxIds txs
                       bgroup (show n <> " transactions") [
                           bench "benchmark" $ nfIO $ withAcquiredMempool $ \mempool txs -> do
                             run mempool txs
@@ -72,7 +73,7 @@ main = do
               where
                 testAddTxs mempool txs = do
                     run mempool txs
-                    mempoolTxs <- getTxs mempool
+                    mempoolTxs <- Mocked.getTxs mempool
                     mempoolTxs @?= getCmdsTxs txs
 
     parseBenchmarkResults csvFilePath = do
@@ -124,12 +125,15 @@ main = do
   Adding TestBlock transactions to a mempool
 -------------------------------------------------------------------------------}
 
-openMempoolWithCapacityFor :: [MempoolCmd TestBlock] ->  IO (MempoolWithMockedLedgerItf IO TestBlock)
+openMempoolWithCapacityFor :: [MempoolCmd TestBlock] ->  IO (MockedMempool IO TestBlock)
 openMempoolWithCapacityFor cmds =
-    openMempoolWithMockedLedgerItf capacityRequiredByCmds
-                                   Tracer.nullTracer
-                                   TestBlock.txSize
-                                   TestBlock.sampleMempoolAndModelParams
+    Mocked.openMockedMempool capacityRequiredByCmds
+                             Tracer.nullTracer
+                             TestBlock.txSize
+                             Mocked.MempoolAndModelParams {
+                                 Mocked.immpInitialState = TestBlock.initialLedgerState
+                               , Mocked.immpLedgerConfig = TestBlock.sampleLedgerConfig
+                             }
   where
     capacityRequiredByCmds = Mempool.mkCapacityBytesOverride totalTxsSize
       where totalTxsSize = sum $ fmap TestBlock.txSize $ getCmdsTxs cmds

--- a/ouroboros-consensus/changelog.d/20230718_150039_joris_137_add_golden_txs_test_for_localTxSubmissionServer.md
+++ b/ouroboros-consensus/changelog.d/20230718_150039_joris_137_add_golden_txs_test_for_localTxSubmissionServer.md
@@ -1,0 +1,23 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->
+### Non-Breaking
+
+- Add new `mempool-test-utils` public library containing utilities for opening a
+  mocked mempool.
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -454,6 +454,18 @@ library mock-block
     , serialise
     , time
 
+library mempool-test-utils
+  import:          common-lib
+  visibility:      public
+  hs-source-dirs:  src/mempool-test-utils
+  exposed-modules: Test.Consensus.Mempool.Mocked
+  build-depends:
+    , base
+    , contra-tracer
+    , deepseq
+    , ouroboros-consensus
+    , strict-stm
+
 library tutorials
   import:         common-lib
 
@@ -632,7 +644,6 @@ benchmark mempool-bench
   other-modules:
     Bench.Consensus.Mempool
     Bench.Consensus.Mempool.TestBlock
-    Bench.Consensus.MempoolWithMockedLedgerItf
 
   build-depends:
     , aeson
@@ -644,10 +655,10 @@ benchmark mempool-bench
     , containers
     , contra-tracer
     , deepseq
+    , mempool-test-utils
     , nothunks
     , ouroboros-consensus
     , serialise
-    , strict-stm
     , tasty
     , tasty-bench
     , tasty-hunit

--- a/ouroboros-consensus/src/mempool-test-utils/Test/Consensus/Mempool/Mocked.hs
+++ b/ouroboros-consensus/src/mempool-test-utils/Test/Consensus/Mempool/Mocked.hs
@@ -2,11 +2,11 @@
 {-# LANGUAGE NamedFieldPuns   #-}
 
 -- | Mempool with a mocked ledger interface
-module Bench.Consensus.MempoolWithMockedLedgerItf (
+module Test.Consensus.Mempool.Mocked (
     InitialMempoolAndModelParams (..)
     -- * Mempool with a mocked LedgerDB interface
-  , MempoolWithMockedLedgerItf (getMempool)
-  , openMempoolWithMockedLedgerItf
+  , MockedMempool (getMempool)
+  , openMockedMempool
   , setLedgerState
     -- * Mempool API functions
   , addTx
@@ -27,29 +27,31 @@ import qualified Ouroboros.Consensus.Mempool as Mempool
 import           Ouroboros.Consensus.Mempool.API (AddTxOnBehalfOf,
                      MempoolAddTxResult)
 
-data MempoolWithMockedLedgerItf m blk = MempoolWithMockedLedgerItf {
+data MockedMempool m blk = MockedMempool {
       getLedgerInterface :: !(Mempool.LedgerInterface m blk)
     , getLedgerStateTVar :: !(StrictTVar m (LedgerState blk))
     , getMempool         :: !(Mempool m blk)
     }
 
-instance NFData (MempoolWithMockedLedgerItf m blk) where
+instance NFData (MockedMempool m blk) where
   -- TODO: check we're OK with skipping the evaluation of the
-  -- MempoolWithMockedLedgerItf. The only data we could force here is the
+  -- MockedMempool. The only data we could force here is the
   -- 'LedgerState' inside 'getLedgerStateTVar', but that would require adding a
   -- 'NFData' constraint and perform unsafe IO. Since we only require this
   -- instance to be able to use
   -- [env](<https://hackage.haskell.org/package/tasty-bench-0.3.3/docs/Test-Tasty-Bench.html#v:env),
   -- and we only care about initializing the mempool before running the
   -- benchmarks, maybe this definition is enough.
-  rnf MempoolWithMockedLedgerItf {} = ()
+  rnf MockedMempool {} = ()
 
 data InitialMempoolAndModelParams blk = MempoolAndModelParams {
+      -- | Initial ledger state for the mocked Ledger DB interface.
       immpInitialState :: !(Ledger.LedgerState blk)
+      -- | Ledger configuration, which is needed to open the mempool.
     , immpLedgerConfig :: !(Ledger.LedgerConfig blk)
     }
 
-openMempoolWithMockedLedgerItf ::
+openMockedMempool ::
      ( Ledger.LedgerSupportsMempool blk
      , Ledger.HasTxId (Ledger.GenTx blk)
      , Header.ValidateEnvelope blk
@@ -58,48 +60,47 @@ openMempoolWithMockedLedgerItf ::
   -> Tracer IO (Mempool.TraceEventMempool blk)
   -> (Ledger.GenTx blk -> Mempool.TxSizeInBytes)
   -> InitialMempoolAndModelParams blk
-    -- ^ Initial ledger state for the mocked Ledger DB interface.
-  -> IO (MempoolWithMockedLedgerItf IO blk)
-openMempoolWithMockedLedgerItf capacityOverride tracer txSizeImpl params = do
-    currentLedgerStateTVar <- newTVarIO (immpInitialState params)
+  -> IO (MockedMempool IO blk)
+openMockedMempool capacityOverride tracer txSizeImpl initialParams = do
+    currentLedgerStateTVar <- newTVarIO (immpInitialState initialParams)
     let ledgerItf = Mempool.LedgerInterface {
             Mempool.getCurrentLedgerState = readTVar currentLedgerStateTVar
         }
     mempool <- Mempool.openMempoolWithoutSyncThread
                    ledgerItf
-                   (immpLedgerConfig params)
+                   (immpLedgerConfig initialParams)
                    capacityOverride
                    tracer
                    txSizeImpl
-    pure MempoolWithMockedLedgerItf {
+    pure MockedMempool {
         getLedgerInterface = ledgerItf
       , getLedgerStateTVar = currentLedgerStateTVar
       , getMempool         = mempool
     }
 
 setLedgerState ::
-     MempoolWithMockedLedgerItf IO blk
+     MockedMempool IO blk
   -> LedgerState blk
   -> IO ()
-setLedgerState MempoolWithMockedLedgerItf {getLedgerStateTVar} newSt =
+setLedgerState MockedMempool {getLedgerStateTVar} newSt =
   atomically $ writeTVar getLedgerStateTVar newSt
 
 addTx ::
-     MempoolWithMockedLedgerItf m blk
+     MockedMempool m blk
   -> AddTxOnBehalfOf
   -> Ledger.GenTx blk
   -> m (MempoolAddTxResult blk)
 addTx = Mempool.addTx . getMempool
 
 removeTxs ::
-     MempoolWithMockedLedgerItf m blk
+     MockedMempool m blk
   -> [Ledger.GenTxId blk]
   -> m ()
 removeTxs = Mempool.removeTxs . getMempool
 
 getTxs ::
      (Ledger.LedgerSupportsMempool blk)
-  => MempoolWithMockedLedgerItf IO blk -> IO [Ledger.GenTx blk]
+  => MockedMempool IO blk -> IO [Ledger.GenTx blk]
 getTxs mockedMempool = do
     snapshotTxs <- fmap Mempool.snapshotTxs $ atomically
                                             $ Mempool.getSnapshot


### PR DESCRIPTION
This PR introduces a test to detect errors in the Ledger code, [like this one](https://github.com/input-output-hk/ouroboros-consensus/issues/137), early on. 

Other changes include:

- Addition of a new test library to mock a mempool.
- Addition of a module to elaborate a `ProtocolInfo` for testing purposes. This protocol info is used when opening a Cardano mempool.