### PR TITLE
Extent Legacy.convert utilities

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1689590464,
-        "narHash": "sha256-3f3lfnlxUZwZvgDxq2N+C5BECAZ3oZEN1QC/u6pZSmw=",
+        "lastModified": 1689770606,
+        "narHash": "sha256-30c/iX+enOh+5eJXExvNNm4q8DvV0VkteBgtnQw44zM=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "bea3f9603ca4febaab5a4d9e6aef3a35f81c24cb",
+        "rev": "7cc96e06f91b643725d5b4d67b1021d84ce21552",
         "type": "github"
       },
       "original": {

--- a/ouroboros-consensus-cardano-legacy-block/src/Legacy/LegacyBlock.hs
+++ b/ouroboros-consensus-cardano-legacy-block/src/Legacy/LegacyBlock.hs
@@ -17,10 +17,13 @@
 {-# LANGUAGE ViewPatterns               #-}
 
 module Legacy.LegacyBlock (
-    GenTx (..)
+    BlockConfig (..)
+  , CodecConfig (..)
+  , GenTx (..)
   , LedgerState (..)
   , LedgerTables (..)
   , LegacyBlock (..)
+  , StorageConfig (..)
   , Ticked1 (..)
   , Validated (..)
   ) where


### PR DESCRIPTION
# Description
Extends the Leagacy.convert utilities. Useful for clients like db-sync that maintain the full ExtLedgerState.