### PR TITLE
Add a multi-repl-enabled cabal to shell

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -6,6 +6,7 @@ in
 hsPkgs.shellFor {
   nativeBuildInputs = [
     pkgs.cabal
+    pkgs.cabal-multi-repl
     pkgs.fd
     pkgs.nixpkgs-fmt
     pkgs.stylish-haskell

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -13,6 +13,28 @@ in
 
   cabal = tool "cabal" "latest" { };
 
+  cabal-multi-repl = (final.haskell-nix.cabalProject {
+    # cabal master commit containing https://github.com/haskell/cabal/pull/8726
+    src = final.fetchFromGitHub {
+      owner = "haskell";
+      repo = "cabal";
+      rev = "249374d16b328736a01a4c7e84fa42fbad7422e7";
+      hash = "sha256-KQm3NwQAvsii+6o7MRRL4emCEBUT77foywTBHfq1pxg=";
+    };
+    index-state = tool-index-state;
+    inherit (final.hsPkgs.args) compiler-nix-name;
+    cabalProject = ''
+      packages: Cabal-syntax Cabal cabal-install-solver cabal-install
+    '';
+    configureArgs = "--disable-benchmarks --disable-tests";
+    modules = [{
+      packages.cabal-install.components.exes.cabal.postInstall = ''
+        mv $out/bin/cabal $out/bin/cabal-multi-repl
+        wrapProgram $out/bin/cabal-multi-repl --add-flags --enable-multi-repl
+      '';
+    }];
+  }).cabal-install.components.exes.cabal;
+
   stylish-haskell = tool "stylish-haskell" "0.14.4.0" { };
 
   cabal-fmt = tool "cabal-fmt" "0.1.6" { };


### PR DESCRIPTION
This adds a multi-repl-enabled (see https://github.com/haskell/cabal/pull/8726) cabal (using a recent commit from `master`) to the shell.

When using GHC >=9.4, one can then run e.g.
```console
cabal-multi-repl repl ouroboros-consensus ouroboros-consensus-diffusion
```
to get a REPL with all components in `ouroboros-consensus` and `ouroboros-consensus-diffusion` :tada: 
`ghcid` also works, e.g.
```console
ghcid -c 'cabal-multi-repl repl ...'
```

Beware that this feature is still somewhat experimental, e.g. `cabal-multi-repl repl ouroboros-consensus-cardano` (or also `-protocol`) are stalling for me, and selecting individual components involving sublibraries fails with this message:
```console
 $ cabal-multi-repl repl ouroboros-consensus:consensus-testlib ouroboros-consensus:consensus-test
Error:
    Dependency on unbuildable library 'consensus-testlib' from ouroboros-consensus
```

Still, this might already be useful, and should not have any risks/maintenance burden.