### PR TITLE
Add support for creating git tags to create-release.hs

### DIFF
--- a/scripts/release/create-release.hs
+++ b/scripts/release/create-release.hs
@@ -85,6 +85,10 @@ main = sh do
       unless skipGit do
         createGitCommit packageName next
 
+        -- note that this tags each package release with the commit that released
+        -- that package, not the commit with all of the packages released
+        createGitTag packageName next
+
 -- | Pairs of packages with a list of their dependencies. We use the
 --   dependencies to calculate which version changes should require a version
 --   bump in a package's dependencies as well.
@@ -245,6 +249,12 @@ createGitCommit package next = do
         "release " <> packageNameWithVersion package next
   liftIO $ putStrLn $ "Creating git commit: " <> show commitString
   procs "git" ["commit", "-am", commitString] mempty
+
+createGitTag :: FilePath -> Version -> Shell ()
+createGitTag package next = do
+  let tagName = packageNameWithVersion package next
+  liftIO $ putStrLn $ "Creating git tag: " <> show tagName
+  procs "git" ["tag", packageNameWithVersion]
 
 packageNameWithVersion :: FilePath -> Version -> Text
 packageNameWithVersion package v = Text.pack $

--- a/scripts/release/create-release.sh
+++ b/scripts/release/create-release.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+echo "DEPRECATED!!! USE create-release.hs INSTEAD!!!"
+
 # Updates the version for ouroboros-consensus packages depending on the entries
 # in the changelog directory
 


### PR DESCRIPTION
# Description

- Add support for creating git tags to create-release.hs
- Add a deprecation warning to create-release.sh (should it just be removed?)
