### PR TITLE
Reduce footprint of `IsMapKind` by splitting it into multiple classes.

### DIFF
--- a/ouroboros-consensus-cardano/src/byron-testlib/Test/Consensus/Byron/Generators.hs
+++ b/ouroboros-consensus-cardano/src/byron-testlib/Test/Consensus/Byron/Generators.hs
@@ -300,7 +300,7 @@ genByronLedgerState = do
         Left _  -> pure Origin
         Right _ -> At <$> arbitrary
 
-instance IsMapKind mk => Arbitrary (LedgerTables (LedgerState ByronBlock) mk) where
+instance CanEmptyMK mk => Arbitrary (LedgerTables (LedgerState ByronBlock) mk) where
   arbitrary = pure emptyLedgerTables
 
 genByronLedgerConfig :: Gen Byron.Config

--- a/ouroboros-consensus-cardano/src/byron-testlib/Test/Consensus/Byron/Generators.hs
+++ b/ouroboros-consensus-cardano/src/byron-testlib/Test/Consensus/Byron/Generators.hs
@@ -300,7 +300,7 @@ genByronLedgerState = do
         Left _  -> pure Origin
         Right _ -> At <$> arbitrary
 
-instance CanEmptyMK mk => Arbitrary (LedgerTables (LedgerState ByronBlock) mk) where
+instance ZeroableMK mk => Arbitrary (LedgerTables (LedgerState ByronBlock) mk) where
   arbitrary = pure emptyLedgerTables
 
 genByronLedgerConfig :: Gen Byron.Config

--- a/ouroboros-consensus-cardano/src/cardano-testlib/Test/Consensus/Cardano/Examples.hs
+++ b/ouroboros-consensus-cardano/src/cardano-testlib/Test/Consensus/Cardano/Examples.hs
@@ -44,8 +44,8 @@ import qualified Ouroboros.Consensus.HardFork.History as History
 import           Ouroboros.Consensus.HeaderValidation (AnnTip)
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.SupportsMempool (ApplyTxErr)
-import           Ouroboros.Consensus.Ledger.Tables (EmptyMK, IsMapKind,
-                     ValuesMK, castLedgerTables)
+import           Ouroboros.Consensus.Ledger.Tables (CanEmptyMK, CanMapMK,
+                     EmptyMK, ValuesMK, castLedgerTables)
 import           Ouroboros.Consensus.Protocol.Praos.Translate ()
 import           Ouroboros.Consensus.Protocol.TPraos (TPraos)
 import           Ouroboros.Consensus.Shelley.Ledger (ShelleyBlock)
@@ -168,7 +168,7 @@ injectWrapLedgerTables _startBounds idx (WrapLedgerTables lt) =
     WrapLedgerTables $ castLedgerTables $ injectLedgerTables (castLedgerTables lt)
   where
     injectLedgerTables ::
-         (IsMapKind mk)
+         (CanMapMK mk, CanEmptyMK mk)
       => LedgerTables (LedgerState                  x) mk
       -> LedgerTables (LedgerState (HardForkBlock xs)) mk
     injectLedgerTables = applyInjectLedgerTables

--- a/ouroboros-consensus-cardano/src/cardano-testlib/Test/Consensus/Cardano/Examples.hs
+++ b/ouroboros-consensus-cardano/src/cardano-testlib/Test/Consensus/Cardano/Examples.hs
@@ -44,8 +44,8 @@ import qualified Ouroboros.Consensus.HardFork.History as History
 import           Ouroboros.Consensus.HeaderValidation (AnnTip)
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.SupportsMempool (ApplyTxErr)
-import           Ouroboros.Consensus.Ledger.Tables (CanEmptyMK, CanMapMK,
-                     EmptyMK, ValuesMK, castLedgerTables)
+import           Ouroboros.Consensus.Ledger.Tables (CanMapMK, EmptyMK, ValuesMK,
+                     ZeroableMK, castLedgerTables)
 import           Ouroboros.Consensus.Protocol.Praos.Translate ()
 import           Ouroboros.Consensus.Protocol.TPraos (TPraos)
 import           Ouroboros.Consensus.Shelley.Ledger (ShelleyBlock)
@@ -168,7 +168,7 @@ injectWrapLedgerTables _startBounds idx (WrapLedgerTables lt) =
     WrapLedgerTables $ castLedgerTables $ injectLedgerTables (castLedgerTables lt)
   where
     injectLedgerTables ::
-         (CanMapMK mk, CanEmptyMK mk)
+         (CanMapMK mk, ZeroableMK mk)
       => LedgerTables (LedgerState                  x) mk
       -> LedgerTables (LedgerState (HardForkBlock xs)) mk
     injectLedgerTables = applyInjectLedgerTables

--- a/ouroboros-consensus-cardano/src/cardano-testlib/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
+++ b/ouroboros-consensus-cardano/src/cardano-testlib/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
@@ -275,9 +275,7 @@ instance
       :* Nil
     where
       shelley ::
-           forall era proto. ( EraCrypto era ~ ProtoCrypto proto2
-                             , Eq (Core.TxOut era)
-                             )
+           forall era proto. EraCrypto era ~ ProtoCrypto proto2
         => SOP.Index '[ era1, era2 ] era
         -> InjectLedgerTables
              (ShelleyBasedHardForkEras proto1 era1 proto2 era2)

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Tables.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Tables.hs
@@ -92,7 +92,7 @@ instance CardanoHardForkConstraints c
         }
 
       shelley ::
-           forall era proto. (EraCrypto era ~ c, Eq (Core.TxOut era))
+           forall era proto. EraCrypto era ~ c
         => Index (ShelleyBasedEras c) era
         -> InjectLedgerTables (CardanoEras c) (ShelleyBlock proto era)
       shelley idx = InjectLedgerTables {

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
@@ -213,11 +213,11 @@ data instance LedgerState (ShelleyBlock proto era) mk = ShelleyLedgerState {
     }
   deriving (Generic)
 
-deriving instance (ShelleyBasedEra era, IsMapKind mk)
+deriving instance (ShelleyBasedEra era, EqMK mk)
                => Eq       (LedgerState (ShelleyBlock proto era) mk)
-deriving instance (ShelleyBasedEra era, IsMapKind mk)
+deriving instance (ShelleyBasedEra era, NoThunksMK mk)
                => NoThunks (LedgerState (ShelleyBlock proto era) mk)
-deriving instance (ShelleyBasedEra era, IsMapKind mk)
+deriving instance (ShelleyBasedEra era, ShowMK mk)
                => Show     (LedgerState (ShelleyBlock proto era) mk)
 
 -- | Information required to determine the hard fork point from Shelley to the

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/ShelleyHFC.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/ShelleyHFC.hs
@@ -343,7 +343,7 @@ instance ( ShelleyBasedEra era
          , SL.TranslationError era SL.NewEpochState ~ Void
          , SL.TranslationError era TxOutWrapper ~ Void
          , EraCrypto (SL.PreviousEra era) ~ EraCrypto era
-         , IsMapKind mk
+         , CanMapMK mk
          ) => SL.TranslateEra era (Flip LedgerState mk :.: ShelleyBlock proto) where
   translateEra ctxt (Comp (Flip (ShelleyLedgerState tip state _transition tables))) = do
       tip'   <- mapM (SL.translateEra ctxt) tip
@@ -359,9 +359,7 @@ translateShelleyTables ::
      ( SL.TranslateEra     era TxOutWrapper
      , SL.TranslationError era TxOutWrapper ~ Void
      , EraCrypto (SL.PreviousEra era) ~ EraCrypto era
-     , Eq (SL.TxOut (SL.PreviousEra era))
-     , Eq (SL.TxOut era)
-     , IsMapKind mk
+     , CanMapMK mk
      )
   => SL.TranslationContext era
   -> LedgerTables (LedgerState (ShelleyBlock proto (SL.PreviousEra era))) mk

--- a/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBAnalyser/Analysis.hs
+++ b/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBAnalyser/Analysis.hs
@@ -454,7 +454,7 @@ checkNoThunksEvery
         pure toKeep
       else pure intermediateLedgerDB
 
-    checkNoThunks :: IsMapKind mk => BlockNo -> LedgerState blk mk -> IO ()
+    checkNoThunks :: NoThunksMK mk => BlockNo -> LedgerState blk mk -> IO ()
     checkNoThunks bn ls =
       noThunks ["--checkThunks"] ls >>= \case
         Nothing -> putStrLn $ show bn <> ": no thunks found."

--- a/ouroboros-consensus/bench/mempool-bench/Bench/Consensus/Mempool/TestBlock.hs
+++ b/ouroboros-consensus/bench/mempool-bench/Bench/Consensus/Mempool/TestBlock.hs
@@ -40,9 +40,9 @@ import qualified Ouroboros.Consensus.Block as Block
 import qualified Ouroboros.Consensus.Ledger.Basics as Ledger
 import qualified Ouroboros.Consensus.Ledger.SupportsMempool as Ledger
 import           Ouroboros.Consensus.Ledger.Tables (CanSerializeLedgerTables,
-                     CanStowLedgerTables, DiffMK (..), EmptyMK, HasLedgerTables,
-                     IsMapKind (..), Key, KeysMK (..), LedgerTables (..), Value,
-                     ValuesMK (..))
+                     CanStowLedgerTables, DiffMK (..), EmptyMK, EqMK,
+                     HasLedgerTables, Key, KeysMK (..), LedgerTables (..),
+                     NoThunksMK, ShowMK, Value, ValuesMK (..))
 import qualified Ouroboros.Consensus.Ledger.Tables.Utils as Ledger
                      (rawAttachAndApplyDiffs)
 import qualified Ouroboros.Consensus.Mempool as Mempool
@@ -128,11 +128,11 @@ instance PayloadSemantics Tx where
     where
       Tx {consumed, produced} = tx
 
-deriving stock instance (IsMapKind mk)
+deriving stock instance EqMK mk
                         => Eq (PayloadDependentState Tx mk)
-deriving stock instance (IsMapKind mk)
+deriving stock instance ShowMK mk
                         => Show (PayloadDependentState Tx mk)
-deriving anyclass instance (IsMapKind mk)
+deriving anyclass instance NoThunksMK mk
                         => NoThunks (PayloadDependentState Tx mk)
 
 instance Serialise (PayloadDependentState Tx EmptyMK) where

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -165,6 +165,7 @@ library
     Ouroboros.Consensus.Ledger.Tables.Combinators
     Ouroboros.Consensus.Ledger.Tables.Common
     Ouroboros.Consensus.Ledger.Tables.DiffSeq
+    Ouroboros.Consensus.Ledger.Tables.MapKind
     Ouroboros.Consensus.Ledger.Tables.Utils
     Ouroboros.Consensus.Mempool
     Ouroboros.Consensus.Mempool.API

--- a/ouroboros-consensus/src/consensus-testlib/Test/LedgerTables.hs
+++ b/ouroboros-consensus/src/consensus-testlib/Test/LedgerTables.hs
@@ -14,7 +14,7 @@ import           Test.QuickCheck
 (==?) ::
   ( CanMapMK mk
   , CanMapKeysMK mk
-  , CanEmptyMK mk
+  , ZeroableMK mk
   , EqMK mk
   , ShowMK mk
   , HasLedgerTables (LedgerState blk)

--- a/ouroboros-consensus/src/consensus-testlib/Test/LedgerTables.hs
+++ b/ouroboros-consensus/src/consensus-testlib/Test/LedgerTables.hs
@@ -12,7 +12,11 @@ import           Test.QuickCheck
 -- | We compare the Ledger Tables of the result because the comparison with the
 -- rest of the LedgerState takes considerably more time to run.
 (==?) ::
-  ( IsMapKind mk
+  ( CanMapMK mk
+  , CanMapKeysMK mk
+  , CanEmptyMK mk
+  , EqMK mk
+  , ShowMK mk
   , HasLedgerTables (LedgerState blk)
   )
   => LedgerState blk mk

--- a/ouroboros-consensus/src/consensus-testlib/Test/Util/LedgerStateOnlyTables.hs
+++ b/ouroboros-consensus/src/consensus-testlib/Test/Util/LedgerStateOnlyTables.hs
@@ -21,10 +21,10 @@ module Test.Util.LedgerStateOnlyTables (
 import           Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import           NoThunks.Class (NoThunks)
 import           Ouroboros.Consensus.Ledger.Basics (LedgerState)
-import           Ouroboros.Consensus.Ledger.Tables (CanSerializeLedgerTables,
-                     CanStowLedgerTables (..), HasLedgerTables (..),
-                     IsMapKind (..), Key, LedgerTables (..), MapKind, Value,
-                     ValuesMK)
+import           Ouroboros.Consensus.Ledger.Tables (CanEmptyMK (..),
+                     CanSerializeLedgerTables, CanStowLedgerTables (..),
+                     HasLedgerTables (..), Key, LedgerTables (..), MapKind,
+                     Value, ValuesMK)
 import           Ouroboros.Consensus.Ledger.Tables.Utils (emptyLedgerTables)
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/consensus-testlib/Test/Util/LedgerStateOnlyTables.hs
+++ b/ouroboros-consensus/src/consensus-testlib/Test/Util/LedgerStateOnlyTables.hs
@@ -21,10 +21,10 @@ module Test.Util.LedgerStateOnlyTables (
 import           Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import           NoThunks.Class (NoThunks)
 import           Ouroboros.Consensus.Ledger.Basics (LedgerState)
-import           Ouroboros.Consensus.Ledger.Tables (CanEmptyMK (..),
-                     CanSerializeLedgerTables, CanStowLedgerTables (..),
-                     HasLedgerTables (..), Key, LedgerTables (..), MapKind,
-                     Value, ValuesMK)
+import           Ouroboros.Consensus.Ledger.Tables (CanSerializeLedgerTables,
+                     CanStowLedgerTables (..), HasLedgerTables (..), Key,
+                     LedgerTables (..), MapKind, Value, ValuesMK,
+                     ZeroableMK (..))
 import           Ouroboros.Consensus.Ledger.Tables.Utils (emptyLedgerTables)
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/consensus-testlib/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/src/consensus-testlib/Test/Util/TestBlock.hs
@@ -326,9 +326,9 @@ class ( Typeable ptype
       , Eq       ptype
       , NoThunks ptype
 
-      , forall mk. IsMapKind mk => Eq (PayloadDependentState ptype mk)
-      , forall mk. IsMapKind mk => NoThunks  (PayloadDependentState ptype mk)
-      , forall mk. IsMapKind mk => Show (PayloadDependentState ptype mk)
+      , forall mk. EqMK mk       => Eq (PayloadDependentState ptype mk)
+      , forall mk. NoThunksMK mk => NoThunks  (PayloadDependentState ptype mk)
+      , forall mk. ShowMK mk     => Show (PayloadDependentState ptype mk)
 
       , forall mk. Generic   (PayloadDependentState ptype mk)
       ,            Serialise (PayloadDependentState ptype EmptyMK)
@@ -512,17 +512,17 @@ data instance LedgerState (TestBlockWith ptype) mk =
       , payloadDependentState :: PayloadDependentState ptype mk
       }
 
-deriving stock instance (IsMapKind mk, PayloadSemantics ptype)
+deriving stock instance (ShowMK mk, PayloadSemantics ptype)
   => Show (LedgerState (TestBlockWith ptype) mk)
 
-deriving stock instance (IsMapKind mk, Eq (PayloadDependentState ptype mk))
+deriving stock instance Eq (PayloadDependentState ptype mk)
   => Eq (LedgerState (TestBlockWith ptype) mk)
 
 deriving stock instance Generic (LedgerState (TestBlockWith ptype) mk)
 
 deriving anyclass instance PayloadSemantics ptype =>
   Serialise (LedgerState (TestBlockWith ptype) EmptyMK)
-deriving anyclass instance (IsMapKind mk, NoThunks (PayloadDependentState ptype mk)) =>
+deriving anyclass instance NoThunks (PayloadDependentState ptype mk) =>
   NoThunks  (LedgerState (TestBlockWith ptype) mk)
 
 testInitLedgerWithState ::
@@ -535,7 +535,7 @@ newtype instance Ticked1 (LedgerState (TestBlockWith ptype)) mk = TickedTestLedg
     }
 
 deriving stock instance Generic (Ticked1 (LedgerState (TestBlockWith ptype)) mk)
-deriving anyclass instance (IsMapKind mk, NoThunks (PayloadDependentState ptype mk))
+deriving anyclass instance (NoThunksMK mk, NoThunks (PayloadDependentState ptype mk))
                         => NoThunks  (Ticked1 (LedgerState (TestBlockWith ptype)) mk)
 
 testInitExtLedgerWithState ::

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Basics.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Basics.hs
@@ -92,11 +92,11 @@ class LedgerTablesCanHardFork xs where
   hardForkInjectLedgerTables :: NP (InjectLedgerTables xs) xs
 
 data InjectLedgerTables xs x = InjectLedgerTables {
-      applyInjectLedgerTables :: forall mk. (CanMapMK mk, CanEmptyMK mk) =>
+      applyInjectLedgerTables :: forall mk. (CanMapMK mk, ZeroableMK mk) =>
            LedgerTables (LedgerState                  x) mk
         -> LedgerTables (LedgerState (HardForkBlock xs)) mk
 
-      , applyDistribLedgerTables :: forall mk. (CanMapMK mk, CanEmptyMK mk) =>
+      , applyDistribLedgerTables :: forall mk. (CanMapMK mk, ZeroableMK mk) =>
            LedgerTables (LedgerState (HardForkBlock xs)) mk
         -> LedgerTables (LedgerState                  x) mk
     }

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Basics.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Basics.hs
@@ -80,11 +80,11 @@ newtype instance LedgerState (HardForkBlock xs) mk = HardForkLedgerState {
       hardForkLedgerStatePerEra :: HardForkState (Flip LedgerState mk) xs
     }
 
-deriving stock   instance (IsMapKind mk, CanHardFork xs)
+deriving stock   instance (ShowMK mk,     CanHardFork xs)
               => Show     (LedgerState (HardForkBlock xs) mk)
-deriving stock   instance (IsMapKind mk, CanHardFork xs)
+deriving stock   instance (EqMK mk,       CanHardFork xs)
               => Eq       (LedgerState (HardForkBlock xs) mk)
-deriving newtype instance (IsMapKind mk, CanHardFork xs)
+deriving newtype instance (NoThunksMK mk, CanHardFork xs)
               => NoThunks (LedgerState (HardForkBlock xs) mk)
 
 -- | How to inject each era's ledger tables into their shared ledger tables
@@ -92,11 +92,11 @@ class LedgerTablesCanHardFork xs where
   hardForkInjectLedgerTables :: NP (InjectLedgerTables xs) xs
 
 data InjectLedgerTables xs x = InjectLedgerTables {
-      applyInjectLedgerTables :: forall mk. IsMapKind mk =>
+      applyInjectLedgerTables :: forall mk. (CanMapMK mk, CanEmptyMK mk) =>
            LedgerTables (LedgerState                  x) mk
         -> LedgerTables (LedgerState (HardForkBlock xs)) mk
 
-      , applyDistribLedgerTables :: forall mk. IsMapKind mk =>
+      , applyDistribLedgerTables :: forall mk. (CanMapMK mk, CanEmptyMK mk) =>
            LedgerTables (LedgerState (HardForkBlock xs)) mk
         -> LedgerTables (LedgerState                  x) mk
     }

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Ledger.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Ledger.hs
@@ -846,7 +846,7 @@ instance ( HardForkHasLedgerTables xs
          , LedgerTablesCanHardFork xs
          ) => HasLedgerTables (LedgerState (HardForkBlock xs)) where
   projectLedgerTables ::
-       forall mk. (CanMapMK mk, CanMapKeysMK mk, CanEmptyMK mk)
+       forall mk. (CanMapMK mk, CanMapKeysMK mk, ZeroableMK mk)
     => LedgerState               (HardForkBlock xs)  mk
     -> LedgerTables (LedgerState (HardForkBlock xs)) mk
   projectLedgerTables (HardForkLedgerState st) = hcollapse $
@@ -864,7 +864,7 @@ instance ( HardForkHasLedgerTables xs
         $ unFlip l
 
   withLedgerTables ::
-       forall mk any. (CanMapMK mk, CanMapKeysMK mk, CanEmptyMK mk)
+       forall mk any. (CanMapMK mk, CanMapKeysMK mk, ZeroableMK mk)
     => LedgerState               (HardForkBlock xs)  any
     -> LedgerTables (LedgerState (HardForkBlock xs)) mk
     -> LedgerState               (HardForkBlock xs)  mk
@@ -887,7 +887,7 @@ instance ( HardForkHasLedgerTables xs
          , LedgerTablesCanHardFork xs
          ) => HasLedgerTables (Ticked1 (LedgerState (HardForkBlock xs))) where
   projectLedgerTables ::
-       forall mk. (CanMapMK mk, CanMapKeysMK mk, CanEmptyMK mk)
+       forall mk. (CanMapMK mk, CanMapKeysMK mk, ZeroableMK mk)
     => Ticked1 (LedgerState (HardForkBlock xs)) mk
     -> LedgerTables (Ticked1 (LedgerState (HardForkBlock xs))) mk
   projectLedgerTables st = hcollapse $
@@ -910,7 +910,7 @@ instance ( HardForkHasLedgerTables xs
         $ getFlipTickedLedgerState l
 
   withLedgerTables ::
-       forall mk any. (CanMapMK mk, CanMapKeysMK mk, CanEmptyMK mk)
+       forall mk any. (CanMapMK mk, CanMapKeysMK mk, ZeroableMK mk)
     => Ticked1 (LedgerState (HardForkBlock xs)) any
     -> LedgerTables (Ticked1 (LedgerState (HardForkBlock xs))) mk
     -> Ticked1 (LedgerState (HardForkBlock xs)) mk

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Ledger.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Ledger.hs
@@ -846,7 +846,7 @@ instance ( HardForkHasLedgerTables xs
          , LedgerTablesCanHardFork xs
          ) => HasLedgerTables (LedgerState (HardForkBlock xs)) where
   projectLedgerTables ::
-       forall mk. IsMapKind mk
+       forall mk. (CanMapMK mk, CanMapKeysMK mk, CanEmptyMK mk)
     => LedgerState               (HardForkBlock xs)  mk
     -> LedgerTables (LedgerState (HardForkBlock xs)) mk
   projectLedgerTables (HardForkLedgerState st) = hcollapse $
@@ -864,7 +864,7 @@ instance ( HardForkHasLedgerTables xs
         $ unFlip l
 
   withLedgerTables ::
-       forall mk any. IsMapKind mk
+       forall mk any. (CanMapMK mk, CanMapKeysMK mk, CanEmptyMK mk)
     => LedgerState               (HardForkBlock xs)  any
     -> LedgerTables (LedgerState (HardForkBlock xs)) mk
     -> LedgerState               (HardForkBlock xs)  mk
@@ -887,7 +887,7 @@ instance ( HardForkHasLedgerTables xs
          , LedgerTablesCanHardFork xs
          ) => HasLedgerTables (Ticked1 (LedgerState (HardForkBlock xs))) where
   projectLedgerTables ::
-       forall mk. IsMapKind mk
+       forall mk. (CanMapMK mk, CanMapKeysMK mk, CanEmptyMK mk)
     => Ticked1 (LedgerState (HardForkBlock xs)) mk
     -> LedgerTables (Ticked1 (LedgerState (HardForkBlock xs))) mk
   projectLedgerTables st = hcollapse $
@@ -910,7 +910,7 @@ instance ( HardForkHasLedgerTables xs
         $ getFlipTickedLedgerState l
 
   withLedgerTables ::
-       forall mk any. IsMapKind mk
+       forall mk any. (CanMapMK mk, CanMapKeysMK mk, CanEmptyMK mk)
     => Ticked1 (LedgerState (HardForkBlock xs)) any
     -> LedgerTables (Ticked1 (LedgerState (HardForkBlock xs))) mk
     -> Ticked1 (LedgerState (HardForkBlock xs)) mk

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Ledger/Query.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Ledger/Query.hs
@@ -202,7 +202,7 @@ distribDiskLedgerView dlv =
    rangeQuery' i = fmap (distribLedgerTables i) . rangeQuery . injectRangeQuery i
 
    injectLedgerTables :: forall x mk.
-        IsMapKind mk
+        (CanMapMK mk, CanEmptyMK mk)
      => Index xs x
      -> LedgerTables (ExtLedgerState x) mk
      -> LedgerTables (ExtLedgerState (HardForkBlock xs)) mk
@@ -211,14 +211,14 @@ distribDiskLedgerView dlv =
                         . castLedgerTables
 
    injectRangeQuery :: forall x mk.
-        IsMapKind mk
+        (CanMapMK mk, CanEmptyMK mk)
      => Index xs x
      -> RangeQuery (LedgerTables (ExtLedgerState x) mk)
      -> RangeQuery (LedgerTables (ExtLedgerState (HardForkBlock xs)) mk)
    injectRangeQuery i (RangeQuery ks p) = RangeQuery (fmap (injectLedgerTables i) ks) p
 
    distribLedgerTables :: forall x mk.
-        IsMapKind mk
+        (CanMapMK mk, CanEmptyMK mk)
      => Index xs x
      -> LedgerTables (ExtLedgerState (HardForkBlock xs)) mk
      -> LedgerTables (ExtLedgerState x) mk

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Ledger/Query.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Ledger/Query.hs
@@ -202,7 +202,7 @@ distribDiskLedgerView dlv =
    rangeQuery' i = fmap (distribLedgerTables i) . rangeQuery . injectRangeQuery i
 
    injectLedgerTables :: forall x mk.
-        (CanMapMK mk, CanEmptyMK mk)
+        (CanMapMK mk, ZeroableMK mk)
      => Index xs x
      -> LedgerTables (ExtLedgerState x) mk
      -> LedgerTables (ExtLedgerState (HardForkBlock xs)) mk
@@ -211,14 +211,14 @@ distribDiskLedgerView dlv =
                         . castLedgerTables
 
    injectRangeQuery :: forall x mk.
-        (CanMapMK mk, CanEmptyMK mk)
+        (CanMapMK mk, ZeroableMK mk)
      => Index xs x
      -> RangeQuery (LedgerTables (ExtLedgerState x) mk)
      -> RangeQuery (LedgerTables (ExtLedgerState (HardForkBlock xs)) mk)
    injectRangeQuery i (RangeQuery ks p) = RangeQuery (fmap (injectLedgerTables i) ks) p
 
    distribLedgerTables :: forall x mk.
-        (CanMapMK mk, CanEmptyMK mk)
+        (CanMapMK mk, ZeroableMK mk)
      => Index xs x
      -> LedgerTables (ExtLedgerState (HardForkBlock xs)) mk
      -> LedgerTables (ExtLedgerState x) mk

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Basics.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Basics.hs
@@ -108,9 +108,9 @@ type family LedgerCfg l :: Type
 
 type IsLedger :: LedgerStateKind -> Constraint
 class ( -- Requirements on the ledger state itself
-        forall mk. IsMapKind mk => Eq       (l mk)
-      , forall mk. IsMapKind mk => NoThunks (l mk)
-      , forall mk. IsMapKind mk => Show     (l mk)
+        forall mk. EqMK mk       => Eq       (l mk)
+      , forall mk. NoThunksMK mk => NoThunks (l mk)
+      , forall mk. ShowMK mk     => Show     (l mk)
         -- Requirements on 'LedgerCfg'
       , NoThunks (LedgerCfg l)
         -- Requirements on 'LedgerErr'

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Dual.hs
@@ -441,9 +441,9 @@ data instance LedgerState (DualBlock m a) mk = DualLedgerState {
 
 instance Bridge m a => UpdateLedger (DualBlock m a)
 
-deriving instance ( Bridge m a, IsMapKind mk
+deriving instance ( Bridge m a, ShowMK mk
                   ) => Show (LedgerState (DualBlock m a) mk)
-deriving instance ( Bridge m a, IsMapKind mk
+deriving instance ( Bridge m a, EqMK mk
                   ) => Eq (LedgerState (DualBlock m a) mk)
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Extended.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Extended.hs
@@ -67,16 +67,16 @@ data ExtLedgerState blk mk = ExtLedgerState {
     }
   deriving (Generic)
 
-deriving instance (IsMapKind mk, LedgerSupportsProtocol blk)
+deriving instance (EqMK mk, LedgerSupportsProtocol blk)
                => Eq (ExtLedgerState blk mk)
-deriving instance (IsMapKind mk, LedgerSupportsProtocol blk)
+deriving instance (ShowMK mk, LedgerSupportsProtocol blk)
                => Show (ExtLedgerState blk mk)
 
 -- | We override 'showTypeOf' to show the type of the block
 --
 -- This makes debugging a bit easier, as the block gets used to resolve all
 -- kinds of type families.
-instance (IsMapKind mk, LedgerSupportsProtocol blk)
+instance (NoThunksMK mk, LedgerSupportsProtocol blk)
       => NoThunks (ExtLedgerState blk mk) where
   showTypeOf _ = show $ typeRep (Proxy @(ExtLedgerState blk))
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Tables.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Tables.hs
@@ -1,42 +1,21 @@
-{-# LANGUAGE DataKinds                  #-}
-{-# LANGUAGE DefaultSignatures          #-}
-{-# LANGUAGE DeriveAnyClass             #-}
-{-# LANGUAGE DeriveFunctor              #-}
-{-# LANGUAGE DeriveGeneric              #-}
-{-# LANGUAGE DerivingStrategies         #-}
-{-# LANGUAGE FlexibleContexts           #-}
-{-# LANGUAGE FlexibleInstances          #-}
-{-# LANGUAGE GADTs                      #-}
-{-# LANGUAGE GeneralisedNewtypeDeriving #-}
-{-# LANGUAGE MultiParamTypeClasses      #-}
-{-# LANGUAGE QuantifiedConstraints      #-}
-{-# LANGUAGE Rank2Types                 #-}
-{-# LANGUAGE StandaloneKindSignatures   #-}
-{-# LANGUAGE TypeFamilies               #-}
-{-# LANGUAGE UndecidableInstances       #-}
+{-# LANGUAGE DataKinds                #-}
+{-# LANGUAGE DefaultSignatures        #-}
+{-# LANGUAGE FlexibleContexts         #-}
+{-# LANGUAGE FlexibleInstances        #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
+{-# LANGUAGE TypeFamilies             #-}
+{-# LANGUAGE UndecidableInstances     #-}
 
 -- | See @'LedgerTables'@
 module Ouroboros.Consensus.Ledger.Tables (
     -- * Re-exports
     module Ouroboros.Consensus.Ledger.Tables.Combinators
   , module Ouroboros.Consensus.Ledger.Tables.Common
+  , module Ouroboros.Consensus.Ledger.Tables.MapKind
     -- * Basic LedgerState classes
   , CanStowLedgerTables (..)
   , HasLedgerTables (..)
   , HasTickedLedgerTables
-    -- * @MapKind@s
-    -- ** Interface
-  , IsMapKind (..)
-    -- ** Concrete definitions
-  , Canonical (..)
-  , CodecMK (..)
-  , DiffMK (..)
-  , EmptyMK (..)
-  , KeysMK (..)
-  , NameMK (..)
-  , SeqDiffMK (..)
-  , TrackingMK (..)
-  , ValuesMK (..)
     -- * Serialization
   , CanSerializeLedgerTables
   , codecLedgerTables
@@ -54,17 +33,12 @@ import qualified Codec.CBOR.Encoding as CBOR
 import qualified Control.Exception as Exn
 import           Control.Monad (replicateM)
 import           Data.Kind (Constraint)
-import           Data.Map.Diff.Strict (Diff)
-import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Set (Set)
 import           Data.Void (Void)
-import           GHC.Generics
 import           NoThunks.Class (NoThunks (..))
 import           Ouroboros.Consensus.Ledger.Tables.Combinators
 import           Ouroboros.Consensus.Ledger.Tables.Common
-import           Ouroboros.Consensus.Ledger.Tables.DiffSeq (DiffSeq, empty,
-                     mapDiffSeq)
+import           Ouroboros.Consensus.Ledger.Tables.MapKind
 import           Ouroboros.Consensus.Ticked
 
 {-------------------------------------------------------------------------------
@@ -75,10 +49,7 @@ import           Ouroboros.Consensus.Ticked
 -- from a @'LedgerState'@ (which will share the same @mk@), or replacing the
 -- @'LedgerTables'@ associated to a particular in-memory @'LedgerState'@.
 type HasLedgerTables :: LedgerStateKind -> Constraint
-class ( forall mk. IsMapKind mk => Eq       (LedgerTables l mk)
-      , forall mk. IsMapKind mk => NoThunks (LedgerTables l mk)
-      , forall mk. IsMapKind mk => Show     (LedgerTables l mk)
-      , Ord (Key l)
+class ( Ord (Key l)
       , Eq (Value l)
       , Show (Key l)
       , Show (Value l)
@@ -88,11 +59,14 @@ class ( forall mk. IsMapKind mk => Eq       (LedgerTables l mk)
 
   -- | Extract the ledger tables from a ledger state
   --
-  -- This 'IsMapKind' constraint is necessary because the 'CardanoBlock'
-  -- instance uses 'mapMK'.
-  projectLedgerTables :: forall mk. IsMapKind mk => l mk -> LedgerTables l mk
+  -- The constraints on @mk@ are necessary because the 'CardanoBlock' instance
+  -- uses them.
+  projectLedgerTables ::
+       (CanMapMK mk, CanMapKeysMK mk, CanEmptyMK mk)
+    => l mk
+    -> LedgerTables l mk
   default projectLedgerTables ::
-         (IsMapKind mk, LedgerTablesAreTrivial l)
+         (CanEmptyMK mk, LedgerTablesAreTrivial l)
       => l mk
       -> LedgerTables l mk
   projectLedgerTables _ = trivialLedgerTables
@@ -105,11 +79,15 @@ class ( forall mk. IsMapKind mk => Eq       (LedgerTables l mk)
   -- tables argument should not contain any data from eras that succeed the
   -- current era of the ledger state argument.
   --
-  -- This 'IsMapKind' constraint is necessary because the 'CardanoBlock'
-  -- instance uses 'mapMK'.
-  withLedgerTables :: IsMapKind mk => l any -> LedgerTables l mk -> l mk
+  -- The constraints on @mk@ are necessary because the 'CardanoBlock' instance
+  -- uses them.
+  withLedgerTables ::
+       (CanMapMK mk, CanMapKeysMK mk, CanEmptyMK mk)
+    => l any
+    -> LedgerTables l mk
+    -> l mk
   default withLedgerTables ::
-       (IsMapKind mk, LedgerTablesAreTrivial l)
+       LedgerTablesAreTrivial l
     => l any
     -> LedgerTables l mk
     -> l mk
@@ -157,137 +135,6 @@ class CanStowLedgerTables l where
     => l EmptyMK
     -> l ValuesMK
   unstowLedgerTables = convertMapKind
-
-
-{-------------------------------------------------------------------------------
-  @MapKind@s
--------------------------------------------------------------------------------}
-
-{- $concrete-tables
-
-We provide here  the usual structures that we expect to deal with, namely:
-
-- 'ValuesMK': a map of keys to values
-
-- 'KeysMK': a set of keys
-
-- 'DiffMK': a map of keys to value differences
-
-- 'TrackingMK': the product of both 'ValuesMK' and 'DiffMK'
-
-- 'SeqDiffMK': an efficient sequence of differences
-
-- 'CodecMK': @CBOR@ encoder and decoder for the key and value
-
--}
-
--- | A general interface to mapkinds.
---
--- In some cases where @mk@ is not specialised to a concrete mapkind like
--- @'ValuesMK'@, there are often still a number of operations that we can
--- perform for this @mk@ that make sense regardless of the concrete mapkind. For
--- example, we should always be able to map over a mapkind to change the type of
--- values that it contains. This class is an interface to mapkinds that provides
--- such common functions.
-type IsMapKind :: MapKind -> Constraint
-class ( forall k v. (Eq       k, Eq       v) => Eq       (mk k v)
-      , forall k v. (NoThunks k, NoThunks v) => NoThunks (mk k v)
-      , forall k v. (Show     k, Show     v) => Show     (mk k v)
-      ) => IsMapKind mk where
-  emptyMK :: forall k v. (Ord k, Eq v) => mk k v
-  default emptyMK :: forall k v. Monoid (mk k v) => mk k v
-  emptyMK = mempty
-
-  mapMK :: forall k v v'. (Ord k, Eq v, Eq v') => (v -> v') -> mk k v -> mk k v'
-  default mapMK :: forall k v v'. (Functor (mk k)) => (v -> v') -> mk k v -> mk k v'
-  mapMK = fmap
-
--- | The Canonical MapKind, which has no constructor, and therefore a
--- @LedgerState blk Canonical@ will have all the contents in memory. This is
--- just a phantom type used to sketch later development and shall not land on
--- the release version.
-data Canonical k v = Canonical
-  deriving stock (Generic, Eq, Show)
-  deriving anyclass NoThunks
-
-newtype DiffMK     k v = DiffMK      (Diff k v)
-  deriving stock (Generic, Eq, Show)
-  deriving anyclass NoThunks
-
-data    EmptyMK    k v = EmptyMK
-  deriving stock (Generic, Eq, Show)
-  deriving anyclass NoThunks
-
-newtype KeysMK     k v = KeysMK      (Set k)
-  deriving stock (Generic, Eq, Show)
-  deriving anyclass NoThunks
-
-newtype SeqDiffMK  k v = SeqDiffMK { getSeqDiffMK :: DiffSeq k v }
-  deriving stock (Generic, Eq, Show)
-  deriving anyclass NoThunks
-
-data    TrackingMK k v = TrackingMK !(Map k v) !(Diff k v)
-  deriving (Generic, Eq, Show, NoThunks)
-
-newtype ValuesMK   k v = ValuesMK    (Map k v)
-  deriving stock (Generic, Eq, Show)
-  deriving anyclass NoThunks
-
--- | A codec 'MapKind' that will be used to refer to @'LedgerTables' l CodecMK@
--- as the codecs that can encode every key and value in the @'LedgerTables' l
--- mk@.
---
--- It is important to note that in the context of the HardForkCombinator, the
--- key @k@ has to be accessible from any era we are currently in, regardless of
--- which era it was created in. Because of that, we need that the serialization
--- of the key remains stable accross eras.
---
--- Ledger will provide more efficient encoders than CBOR, which will produce a
--- @'ShortByteString'@ directly.
-data CodecMK k v = CodecMK
-                     (k -> CBOR.Encoding)
-                     (v -> CBOR.Encoding)
-                     (forall s . CBOR.Decoder s k)
-                     (forall s . CBOR.Decoder s v)
-
-newtype NameMK k v = NameMK String
-
-instance IsMapKind Canonical where
-  emptyMK = Canonical
-  mapMK _ Canonical = Canonical
-
-instance IsMapKind EmptyMK where
-  emptyMK = EmptyMK
-  mapMK _ EmptyMK = EmptyMK
-
-instance IsMapKind KeysMK where
-  emptyMK = KeysMK mempty
-  mapMK _ (KeysMK ks) = KeysMK ks
-
-instance IsMapKind ValuesMK where
-  emptyMK = ValuesMK mempty
-  mapMK f (ValuesMK vs) = ValuesMK $ fmap f vs
-
-instance IsMapKind TrackingMK where
-  emptyMK = TrackingMK mempty mempty
-  mapMK f (TrackingMK vs d) = TrackingMK (fmap f vs) (fmap f d)
-
-instance IsMapKind DiffMK where
-  emptyMK = DiffMK mempty
-  mapMK f (DiffMK d) = DiffMK $ fmap f d
-
-instance IsMapKind SeqDiffMK where
-  emptyMK = SeqDiffMK empty
-  mapMK f (SeqDiffMK ds) = SeqDiffMK $ mapDiffSeq f ds
-
-instance Ord k => Semigroup (KeysMK k v) where
-  KeysMK l <> KeysMK r = KeysMK (l <> r)
-
-instance Ord k => Monoid (KeysMK k v) where
-  mempty = KeysMK mempty
-
-instance Functor (DiffMK k) where
-  fmap f (DiffMK d) = DiffMK $ fmap f d
 
 {-------------------------------------------------------------------------------
   Serialization Codecs
@@ -365,9 +212,9 @@ class (Key l ~ Void, Value l ~ Void) => LedgerTablesAreTrivial l where
   --
   -- This function is useful to combine functions that operate on functions that
   -- transform the map kind on a ledger state (eg @applyChainTickLedgerResult@).
-  convertMapKind :: IsMapKind mk' => l mk -> l mk'
+  convertMapKind :: l mk -> l mk'
 
 trivialLedgerTables ::
-     (IsMapKind mk, LedgerTablesAreTrivial l)
+     (CanEmptyMK mk, LedgerTablesAreTrivial l)
   => LedgerTables l mk
 trivialLedgerTables = LedgerTables emptyMK

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Tables.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Tables.hs
@@ -62,11 +62,11 @@ class ( Ord (Key l)
   -- The constraints on @mk@ are necessary because the 'CardanoBlock' instance
   -- uses them.
   projectLedgerTables ::
-       (CanMapMK mk, CanMapKeysMK mk, CanEmptyMK mk)
+       (CanMapMK mk, CanMapKeysMK mk, ZeroableMK mk)
     => l mk
     -> LedgerTables l mk
   default projectLedgerTables ::
-         (CanEmptyMK mk, LedgerTablesAreTrivial l)
+         (ZeroableMK mk, LedgerTablesAreTrivial l)
       => l mk
       -> LedgerTables l mk
   projectLedgerTables _ = trivialLedgerTables
@@ -82,7 +82,7 @@ class ( Ord (Key l)
   -- The constraints on @mk@ are necessary because the 'CardanoBlock' instance
   -- uses them.
   withLedgerTables ::
-       (CanMapMK mk, CanMapKeysMK mk, CanEmptyMK mk)
+       (CanMapMK mk, CanMapKeysMK mk, ZeroableMK mk)
     => l any
     -> LedgerTables l mk
     -> l mk
@@ -215,6 +215,6 @@ class (Key l ~ Void, Value l ~ Void) => LedgerTablesAreTrivial l where
   convertMapKind :: l mk -> l mk'
 
 trivialLedgerTables ::
-     (CanEmptyMK mk, LedgerTablesAreTrivial l)
+     (ZeroableMK mk, LedgerTablesAreTrivial l)
   => LedgerTables l mk
 trivialLedgerTables = LedgerTables emptyMK

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Tables/MapKind.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Tables/MapKind.hs
@@ -1,0 +1,216 @@
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE DeriveAnyClass             #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
+{-# LANGUAGE QuantifiedConstraints      #-}
+{-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE StandaloneKindSignatures   #-}
+{-# LANGUAGE TypeFamilies               #-}
+
+module Ouroboros.Consensus.Ledger.Tables.MapKind (
+    -- * Classes
+    CanEmptyMK (..)
+  , CanMapKeysMK (..)
+  , CanMapMK (..)
+  , EqMK
+  , NoThunksMK
+  , ShowMK
+    -- * Concrete MapKinds
+  , Canonical (..)
+  , CodecMK (..)
+  , DiffMK (..)
+  , EmptyMK (..)
+  , KeysMK (..)
+  , SeqDiffMK (..)
+  , TrackingMK (..)
+  , ValuesMK (..)
+  ) where
+
+import qualified Codec.CBOR.Decoding as CBOR
+import qualified Codec.CBOR.Encoding as CBOR
+import           Data.Kind (Constraint)
+import           Data.Map.Diff.Strict (Diff)
+import qualified Data.Map.Diff.Strict.Internal as Diff.Internal
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import           Data.Set (Set)
+import qualified Data.Set as Set
+import           GHC.Generics (Generic)
+import           NoThunks.Class
+import           Ouroboros.Consensus.Ledger.Tables.Common
+import           Ouroboros.Consensus.Ledger.Tables.DiffSeq
+
+{-------------------------------------------------------------------------------
+  Classes
+-------------------------------------------------------------------------------}
+
+type CanEmptyMK :: MapKind -> Constraint
+class CanEmptyMK mk where
+  emptyMK :: forall k v. (Ord k, Eq v) => mk k v
+
+type CanMapMK :: MapKind -> Constraint
+class CanMapMK mk where
+  mapMK :: (v -> v') -> mk k v -> mk k v'
+
+type CanMapKeysMK :: MapKind -> Constraint
+class CanMapKeysMK mk where
+  mapKeysMK :: Ord k' => (k -> k') -> mk k v -> mk k' v
+
+-- | For convenience, such that we don't have to include @QuantifiedConstraints@
+-- everywhere.
+type ShowMK :: MapKind -> Constraint
+class (forall k v. (Show k, Show v) => Show (mk k v)) => ShowMK mk
+
+-- | For convenience, such that we don't have to include @QuantifiedConstraints@
+-- everywhere.
+type EqMK :: MapKind -> Constraint
+class (forall k v. (Eq k, Eq v) => Eq (mk k v)) => EqMK mk
+
+-- | For convenience, such that we don't have to include @QuantifiedConstraints@
+-- everywhere.
+type NoThunksMK :: MapKind -> Constraint
+class (forall k v. (NoThunks k, NoThunks v) => NoThunks (mk k v))
+   => NoThunksMK mk
+
+{-------------------------------------------------------------------------------
+  EmptyMK
+-------------------------------------------------------------------------------}
+
+data EmptyMK k v = EmptyMK
+  deriving stock (Generic, Eq, Show)
+  deriving anyclass NoThunks
+  deriving anyclass (ShowMK, EqMK, NoThunksMK)
+
+instance CanEmptyMK EmptyMK where
+  emptyMK = EmptyMK
+
+instance CanMapMK EmptyMK where
+  mapMK _ EmptyMK = EmptyMK
+
+instance CanMapKeysMK EmptyMK where
+  mapKeysMK _ EmptyMK = EmptyMK
+
+{-------------------------------------------------------------------------------
+  KeysMK
+-------------------------------------------------------------------------------}
+
+newtype KeysMK k v = KeysMK (Set k)
+  deriving stock (Generic, Eq, Show)
+  deriving newtype (Semigroup, Monoid)
+  deriving anyclass NoThunks
+  deriving anyclass (ShowMK, EqMK, NoThunksMK)
+
+instance CanEmptyMK KeysMK where
+  emptyMK = KeysMK mempty
+
+instance CanMapMK KeysMK where
+  mapMK _ (KeysMK ks) = KeysMK ks
+
+instance CanMapKeysMK KeysMK where
+  mapKeysMK f (KeysMK ks) = KeysMK $ Set.map f ks
+
+{-------------------------------------------------------------------------------
+  ValuesMK
+-------------------------------------------------------------------------------}
+
+newtype ValuesMK k v = ValuesMK { getValuesMK :: Map k v }
+  deriving stock (Generic, Eq, Show)
+  deriving anyclass NoThunks
+  deriving anyclass (ShowMK, EqMK, NoThunksMK)
+
+instance CanEmptyMK ValuesMK where
+  emptyMK = ValuesMK mempty
+
+instance CanMapMK ValuesMK where
+  mapMK f (ValuesMK vs) = ValuesMK $ fmap f vs
+
+instance CanMapKeysMK ValuesMK where
+  mapKeysMK f (ValuesMK vs) = ValuesMK $ Map.mapKeys f vs
+
+{-------------------------------------------------------------------------------
+  EmptyMK
+-------------------------------------------------------------------------------}
+
+newtype DiffMK k v = DiffMK { getDiffMK :: Diff k v }
+  deriving stock (Generic, Eq, Show)
+  deriving newtype Functor
+  deriving anyclass NoThunks
+  deriving anyclass (ShowMK, EqMK, NoThunksMK)
+
+instance CanEmptyMK DiffMK where
+  emptyMK = DiffMK mempty
+
+instance CanMapKeysMK DiffMK where
+  mapKeysMK f (DiffMK (Diff.Internal.Diff m)) = DiffMK . Diff.Internal.Diff $
+    Map.mapKeys f m
+
+instance CanMapMK DiffMK where
+  mapMK f (DiffMK d) = DiffMK $ fmap f d
+
+{-------------------------------------------------------------------------------
+  TrackingMK
+-------------------------------------------------------------------------------}
+
+data TrackingMK k v = TrackingMK !(Map k v) !(Diff k v)
+  deriving (Generic, Eq, Show, NoThunks)
+  deriving anyclass (ShowMK, EqMK, NoThunksMK)
+
+instance CanEmptyMK TrackingMK where
+  emptyMK = TrackingMK mempty mempty
+
+instance CanMapMK TrackingMK where
+  mapMK f (TrackingMK vs d) = TrackingMK (fmap f vs) (fmap f d)
+
+instance CanMapKeysMK TrackingMK where
+  mapKeysMK f (TrackingMK vs d) =
+      TrackingMK
+        (getValuesMK . mapKeysMK f . ValuesMK $ vs)
+        (getDiffMK . mapKeysMK f . DiffMK $ d)
+
+{-------------------------------------------------------------------------------
+  Canonical
+-------------------------------------------------------------------------------}
+
+-- | The Canonical MapKind, which has no constructor, and therefore a
+-- @LedgerState blk Canonical@ will have all the contents in memory. This is
+-- just a phantom type used to sketch later development and shall not land on
+-- the release version.
+data Canonical k v = Canonical
+  deriving stock (Generic, Eq, Show)
+  deriving anyclass NoThunks
+  deriving anyclass (ShowMK, EqMK, NoThunksMK)
+
+{-------------------------------------------------------------------------------
+  SeqDiffMK
+-------------------------------------------------------------------------------}
+
+newtype SeqDiffMK  k v = SeqDiffMK { getSeqDiffMK :: DiffSeq k v }
+  deriving stock (Generic, Eq, Show)
+  deriving anyclass NoThunks
+  deriving anyclass (ShowMK, EqMK, NoThunksMK)
+
+instance CanEmptyMK SeqDiffMK where
+  emptyMK = SeqDiffMK empty
+
+{-------------------------------------------------------------------------------
+  CodecMK
+-------------------------------------------------------------------------------}
+
+-- | A codec 'MapKind' that will be used to refer to @'LedgerTables' l CodecMK@
+-- as the codecs that can encode every key and value in the @'LedgerTables' l
+-- mk@.
+--
+-- It is important to note that in the context of the HardForkCombinator, the
+-- key @k@ has to be accessible from any era we are currently in, regardless of
+-- which era it was created in. Because of that, we need that the serialization
+-- of the key remains stable accross eras.
+--
+-- Ledger will provide more efficient encoders than CBOR, which will produce a
+-- @'ShortByteString'@ directly.
+data CodecMK k v = CodecMK {
+    encodeKey   :: !(k -> CBOR.Encoding)
+  , encodeValue :: !(v -> CBOR.Encoding)
+  , decodeKey   :: !(forall s . CBOR.Decoder s k)
+  , decodeValue :: !(forall s . CBOR.Decoder s v)
+  }

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Tables/Utils.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Tables/Utils.hs
@@ -58,14 +58,14 @@ import           Ouroboros.Consensus.Ledger.Tables
 -------------------------------------------------------------------------------}
 
 over ::
-     (HasLedgerTables l, CanMapMK mk', CanMapKeysMK mk', CanEmptyMK mk')
+     (HasLedgerTables l, CanMapMK mk', CanMapKeysMK mk', ZeroableMK mk')
   => l mk
   -> LedgerTables l mk'
   -> l mk'
 over = withLedgerTables
 
 ltprj ::
-     (HasLedgerTables l, Castable l l', CanMapMK mk, CanMapKeysMK mk, CanEmptyMK mk)
+     (HasLedgerTables l, Castable l l', CanMapMK mk, CanMapKeysMK mk, ZeroableMK mk)
   => l mk
   -> LedgerTables l' mk
 ltprj = castLedgerTables . projectLedgerTables
@@ -86,7 +86,7 @@ forgetLedgerTables :: HasLedgerTables l => l mk -> l EmptyMK
 forgetLedgerTables l = withLedgerTables l emptyLedgerTables
 
 -- | Empty values for every table
-emptyLedgerTables :: (CanEmptyMK mk, LedgerTableConstraints l) => LedgerTables l mk
+emptyLedgerTables :: (ZeroableMK mk, LedgerTableConstraints l) => LedgerTables l mk
 emptyLedgerTables = ltpure emptyMK
 
 --

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Tables/Utils.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Tables/Utils.hs
@@ -57,10 +57,17 @@ import           Ouroboros.Consensus.Ledger.Tables
   Projection and injection
 -------------------------------------------------------------------------------}
 
-over :: (HasLedgerTables l, IsMapKind mk') => l mk -> LedgerTables l mk' -> l mk'
+over ::
+     (HasLedgerTables l, CanMapMK mk', CanMapKeysMK mk', CanEmptyMK mk')
+  => l mk
+  -> LedgerTables l mk'
+  -> l mk'
 over = withLedgerTables
 
-ltprj :: (HasLedgerTables l, Castable l l', IsMapKind mk) => l mk -> LedgerTables l' mk
+ltprj ::
+     (HasLedgerTables l, Castable l l', CanMapMK mk, CanMapKeysMK mk, CanEmptyMK mk)
+  => l mk
+  -> LedgerTables l' mk
 ltprj = castLedgerTables . projectLedgerTables
 
 {-------------------------------------------------------------------------------
@@ -79,7 +86,7 @@ forgetLedgerTables :: HasLedgerTables l => l mk -> l EmptyMK
 forgetLedgerTables l = withLedgerTables l emptyLedgerTables
 
 -- | Empty values for every table
-emptyLedgerTables :: (IsMapKind mk, LedgerTableConstraints l) => LedgerTables l mk
+emptyLedgerTables :: (CanEmptyMK mk, LedgerTableConstraints l) => LedgerTables l mk
 emptyLedgerTables = ltpure emptyMK
 
 --

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/BackingStore/LMDB.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/BackingStore/LMDB.hs
@@ -146,9 +146,9 @@ data LMDBMK k v = LMDBMK String !(LMDB.Database k v)
 
 getDb ::
      LMDB.Internal.IsMode mode
-  => NameMK k v
+  => K2 String k v
   -> LMDB.Transaction mode (LMDBMK k v)
-getDb (NameMK name) = LMDBMK name <$> LMDB.getDatabase (Just name)
+getDb (K2 name) = LMDBMK name <$> LMDB.getDatabase (Just name)
 
 -- | @'rangeRead' n db codec ksMay@ performs a range read of @count@ values from
 -- database @db@, starting from some key depending on @ksMay@.
@@ -436,7 +436,7 @@ newLMDBBackingStoreInitialiser dbTracer limits sfs initFrom = do
      -- Here we get the LMDB.Databases for the tables of the ledger state
      -- Must be read-write transaction because tables may need to be created
      dbBackingTables <- liftIO $ LMDB.readWriteTransaction dbEnv $
-       lttraverse getDb (ltpure $ NameMK "utxo")
+       lttraverse getDb (ltpure $ K2 "utxo")
 
      dbNextId <- IOLike.newTVarIO 0
 


### PR DESCRIPTION
# Description

Reducing the footprint of `IsMapKind` enables solving #264 because the `IsMapKind` constraint is currently too strict since it bundles functionality/superclass constraints that are hard to satisfy in some contexts