### PR TITLE
Put strict bounds on `fs-api` and `fs-sim` dependencies

### DIFF
--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -522,7 +522,7 @@ library cardano-tools
     , contra-tracer
     , directory
     , filepath
-    , fs-api
+    , fs-api                         ^>=0.1
     , microlens
     , mtl
     , network

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -107,7 +107,7 @@ library
     , contra-tracer
     , deepseq
     , filepath
-    , fs-api
+    , fs-api                       ^>=0.1
     , hashable
     , io-classes                   ^>=1.1
     , mtl
@@ -150,7 +150,7 @@ library diffusion-testlib
     , containers
     , contra-tracer
     , fgl
-    , fs-sim                                                        >=0.2
+    , fs-sim                                                        ^>=0.2
     , graphviz                                                      >=2999.20.1.0
     , io-classes
     , io-sim
@@ -247,8 +247,8 @@ test-suite consensus-test
     , containers
     , diffusion-testlib
     , directory
-    , fs-api
-    , fs-sim                                                        >=0.2
+    , fs-api                                                        ^>=0.1
+    , fs-sim                                                        ^>=0.2
     , io-sim
     , mtl
     , nothunks

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -305,7 +305,7 @@ library
     , contra-tracer
     , deepseq
     , filelock
-    , fs-api
+    , fs-api                       ^>=0.1
     , hashable
     , io-classes                   ^>=1.1
     , measures
@@ -385,8 +385,8 @@ library consensus-testlib
     , directory
     , file-embed
     , filepath
-    , fs-api
-    , fs-sim                                                  >=0.2
+    , fs-api                                                  ^>=0.1
+    , fs-sim                                                  ^>=0.2
     , generics-sop
     , io-sim
     , mtl
@@ -523,7 +523,7 @@ test-suite consensus-test
     , containers
     , contra-tracer
     , deepseq
-    , fs-api
+    , fs-api                                                              ^>=0.1
     , generics-sop
     , hashable
     , io-classes
@@ -612,8 +612,8 @@ test-suite storage-test
     , consensus-testlib
     , containers
     , contra-tracer
-    , fs-api
-    , fs-sim                    >=0.2
+    , fs-api                    ^>=0.1
+    , fs-sim                    ^>=0.2
     , generics-sop
     , hashable
     , io-classes


### PR DESCRIPTION
# Description

Releasing a new version of `fs-api` or `fs-sim` breaks builds for older consensus versions. This is be mirrored by revisions in CHaP: see https://github.com/input-output-hk/cardano-haskell-packages/pull/417