### PR TITLE
Update index-state and put upper bound on `hashable-1.4.3.0`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,9 +14,9 @@ repository cardano-haskell-packages
 -- update either of these.
 index-state:
   -- Bump this if you need newer packages from Hackage
-  , hackage.haskell.org 2023-07-19T10:36:07Z
+  , hackage.haskell.org 2023-08-02T14:18:01Z
   -- Bump this if you need newer packages from CHaP
-  , cardano-haskell-packages 2023-07-19T11:28:31Z
+  , cardano-haskell-packages 2023-08-02T14:18:01Z
 
 packages:
   ./ouroboros-consensus

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1689766485,
-        "narHash": "sha256-30c/iX+enOh+5eJXExvNNm4q8DvV0VkteBgtnQw44zM=",
+        "lastModified": 1690980715,
+        "narHash": "sha256-yqUWb4v+ddfVsYJNHkW3kDGgBLY2H2JJ8AelL1DklqI=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "287eba80d1c76342825e3b1b9fe0c2043200a3e0",
+        "rev": "0ced21474b5c8a4ce8320c1f61d5b9fcef3e3029",
         "type": "github"
       },
       "original": {
@@ -186,11 +186,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1688516853,
-        "narHash": "sha256-BR7kmt/vblCHJUZyszWV2SDI786HmqBCZCnM37RfFd8=",
+        "lastModified": 1690935861,
+        "narHash": "sha256-CxYnaxQudPKOoSPOtpQ9ZVogjDWz3B+ZgL4YumEBY9g=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "6aa31b7e500039788e62ee028fbc04d461424c02",
+        "rev": "4e6c3592ff197354762f3272515245ca862608ca",
         "type": "github"
       },
       "original": {

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -108,7 +108,7 @@ library
     , deepseq
     , filepath
     , fs-api                       ^>=0.1
-    , hashable
+    , hashable                     <1.4.3
     , io-classes                   ^>=1.1
     , mtl
     , ouroboros-consensus          ^>=0.9

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -306,7 +306,7 @@ library
     , deepseq
     , filelock
     , fs-api                       ^>=0.1
-    , hashable
+    , hashable                     <1.4.3
     , io-classes                   ^>=1.1
     , measures
     , mtl


### PR DESCRIPTION
It looks like `hashable-1.4.3.0` is breaking `ChainDB.Unit` tests, so we put an exclusive upper bound on it for now: see #272.
