### PR TITLE
Unshadow `distribLedgerTables`

### DIFF
--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Ledger/Query.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Ledger/Query.hs
@@ -62,7 +62,7 @@ import           Ouroboros.Consensus.HardFork.Combinator.Block
 import           Ouroboros.Consensus.HardFork.Combinator.Info
 import           Ouroboros.Consensus.HardFork.Combinator.Ledger
                      (HardForkHasLedgerTables, HasCanonicalTxIn,
-                     injectLedgerTables)
+                     distribLedgerTables, injectLedgerTables)
 import           Ouroboros.Consensus.HardFork.Combinator.PartialConfig
 import           Ouroboros.Consensus.HardFork.Combinator.State (Current (..),
                      HardForkState (..), Past (..), Situated (..))
@@ -120,6 +120,7 @@ data instance BlockQuery (HardForkBlock xs) :: Type -> Type where
 instance ( All SingleEraBlock xs
          , HardForkHasLedgerTables xs
          , HasCanonicalTxIn xs
+         , CanHardFork xs
          )
       => QueryLedger (HardForkBlock xs) where
   answerBlockQuery (ExtLedgerCfg cfg) query dlv =
@@ -160,8 +161,8 @@ instance ( All SingleEraBlock xs
 distribDiskLedgerView ::
      forall xs m.
      ( Monad m
-     , All SingleEraBlock xs
      , HasCanonicalTxIn xs
+     , CanHardFork xs
      )
   => DiskLedgerView m (ExtLedgerState (HardForkBlock xs))
   -> NS (DiskLedgerView m :.: ExtLedgerState) xs
@@ -180,7 +181,8 @@ distribDiskLedgerView dlv =
         , dlvQueryBatchSize
         } = dlv
 
-    f :: Index xs x
+    f :: Ord (Key (LedgerState x))
+      => Index xs x
       -> Product HeaderState (Flip LedgerState EmptyMK) x
       -> (DiskLedgerView m :.: ExtLedgerState) x
     f idx (Pair hst lst) = Comp $ DiskLedgerView {
@@ -192,18 +194,18 @@ distribDiskLedgerView dlv =
           }
 
     query' ::
-         forall x.
-         Index xs x
+         forall x. Ord (Key (LedgerState x))
+      => Index xs x
       -> LedgerTables (ExtLedgerState x) KeysMK
       -> m (LedgerTables (ExtLedgerState x) ValuesMK)
-    query' i = fmap (distribLedgerTables i) . query . injectLedgerTables' i
+    query' i = fmap (distribLedgerTables' i) . query . injectLedgerTables' i
 
     rangeQuery' ::
-         forall x.
-         Index xs x
+         forall x. Ord (Key (LedgerState x))
+      => Index xs x
       -> RangeQuery (LedgerTables (ExtLedgerState x) KeysMK)
       -> m (LedgerTables (ExtLedgerState x) ValuesMK)
-    rangeQuery' i = fmap (distribLedgerTables i) . rangeQuery . injectRangeQuery i
+    rangeQuery' i = fmap (distribLedgerTables' i) . rangeQuery . injectRangeQuery i
 
     injectLedgerTables' ::
          forall x mk. (CanMapMK mk, CanMapKeysMK mk)
@@ -221,14 +223,14 @@ distribDiskLedgerView dlv =
       -> RangeQuery (LedgerTables (ExtLedgerState (HardForkBlock xs)) mk)
     injectRangeQuery i (RangeQuery ks p) = RangeQuery (fmap (injectLedgerTables' i) ks) p
 
-    distribLedgerTables ::
-         forall x mk. (CanMapMK mk, CanMapKeysMK mk)
+    distribLedgerTables' ::
+         forall x mk. (Ord (Key (LedgerState x)), CanMapMaybeMK mk, CanMapKeysMK mk)
       => Index xs x
       -> LedgerTables (ExtLedgerState (HardForkBlock xs)) mk
       -> LedgerTables (ExtLedgerState x) mk
-    distribLedgerTables i = castLedgerTables
-                          . distribLedgerTables i
-                          . castLedgerTables
+    distribLedgerTables' i = castLedgerTables
+                           . distribLedgerTables i
+                           . castLedgerTables
 
 -- | Precondition: the 'ledgerState' and 'headerState' should be from the same
 -- era. In practice, this is _always_ the case, unless the 'ExtLedgerState' was


### PR DESCRIPTION
# Description

Untie an infinite loop in the traversing query handler
