### PR TITLE
Fix `GetIsValid` bugs (once and for all?) 

### DIFF
--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/Model.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/Model.hs
@@ -424,7 +424,11 @@ addBlock cfg blk m = Model {
       immutableChainHashes `isPrefixOf`
       map blockHash (Chain.toOldestFirst fork)
 
-    consideredCandidates = filter (extendsImmutableChain . fst) candidates
+    -- Considered candidates are candidates that extend the immutable part of
+    -- the chain. Furthermore, the current selected chain is not considered as a
+    -- candidate.
+    consideredCandidates = filter ((/= CPS.chainState (cps m)) . fst)
+                         $ filter (extendsImmutableChain . fst) candidates
 
     newChain  :: Chain blk
     newLedger :: ExtLedgerState blk

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/Model.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/Model.hs
@@ -440,109 +440,10 @@ addBlock cfg blk m = Model {
           (currentChain m)
       $ consideredCandidates
 
-    -- See note [Getting the valid blocks] just below
     valid' = foldl
                (Chain.foldChain (\s b -> Set.insert (blockHash b) s))
                (valid m)
-               (takeWhile (not . Chain.isPrefixOf newChain)
-                (map fst consideredCandidates) ++ [newChain])
-
--- = Getting the valid blocks
---
--- The chain selection algorithms implemented by the model and by the SUT differ
--- but have the same outcome.We illustrate this with an example. Imagine having
--- the following candidate chains where @v@ represents a valid block and @x@
--- represents an invalid block:
---
--- > C0: vvvvvxxxxx
--- > C1: vvvvvvvx
--- > C2: vvv
---
--- For candidate Cx, we will call CxV the valid prefix and CxI the invalid suffix.
---
--- The chain selection algorithm will run whenever we add a block, although it
--- will only select a new chain when adding a block results in a chain that is
--- longer than the currently selected chain. Note that the chain selection
--- algorithm doesn't know beforehand the validity of the blocks in the
--- candidates. The process it follows will be:
---
--- 1. Sort the chains by 'SelectView'. Note that for Praos this will trivially
--- imply first consider the candidates by length.
---
---    > sortedCandidates == [C0, C1, C2]
---
--- 2. Until a candidate is found to be valid and longer than the currently selected
---    chain, take the head of the (sorted) list of candidates and validate the
---    blocks in it one by one.
---
---    If a block in the candidate is found to be invalid, the candidate is
---    truncated, added back to the list, and the algorithm starts again at step 1.
---    The valid blocks in the candidate are recorded in the set of known-valid
---    blocks, so that the next time they are applied, it is known that applying
---    said block can't fail and therefore some checks can be skipped. The invalid
---    blocks in the candidate are recorded in the set of known-invalid blocks so
---    that they are not applied again.
---
---    The steps on the example are as follows:
---
---    1.  Start with the sorted candidate chains: [C0, C1, C2]
---    2.  Validate first chain C0 resulting in C0V and C0I.
---    3.  Append C0V to the list of remaining candidates: [C1, C2] ++ [C0V]
---    4.  Add the valid blocks to the state:
---        > knownValid = append C0V knownValid
---    5.  Add the invalid blocks to the state:
---        > knownInvalid = append C0I knownInvalid
---    6.  Re-sort list
---        > sortBy `selectView` [C1, C2, C0V] == [C1, C0V, C2]
---    7.  Validate first chain C1 resulting in C1V and C1I.
---    8.  Append C1V to the list of remaining candidates: [C0V, C2] ++ [C1V]
---    9.  Add the valid blocks to the state:
---        > knownValid   = append C1V knownValid
---    10. Add the invalid blocks to the state:
---        > knownInvalid = append C1I knownInvalid
---    11. Re-sort list
---        > sortBy `selectView` [C0V, C2, C1V] == [C1V, C0V, C2]
---    12. Validate first chain C1V, which is fully valid and returned.
---
--- 3. If such a candidate is found, the algorithm will return it as a result.
---    Otherwise, the algorithm will return a 'Nothing'.
---
---    > chainSelection [C0, C1, C2] = Just C1V
---
--- On the other hand, the chain selection on the model takes some shortcuts to
--- achieve the same result:
---
--- 1. 'validChains' will return the list of candidates sorted by 'SelectView' and
---    each candidate is truncated to its valid prefix.
---
---    > validChains [C0, C1, C2] = (invalid == C0I + C1I, candidates == [C0V, C1V, C2])
---
--- 2. 'selectChain' will sort the chains by 'SelectView' but note that now it will
---    use the 'SelectView' of the already truncated candidate.
---
---    > selectChain [C0V, C1V, C2] = listToMaybe (sortBy `selectView` [C0V, C1V, C2])
---    >                            = listToMaybe ([C1V, C0V, C2])
---    >                            = Just C1V
---
---    The selected candidate will be the same one that the chain selection
---    algorithm would choose. However, as the chain selection algorithm will
---    consider the candidates as they were sorted by 'SelectView' on the
---    non-truncated candidates, blocks in 'C0V' are also considered valid by the
---    real algorithm.
---
---    To get as a result a set of valid blocks that mirrors the one from the
---    real algorithm, the model can process the list of candidates returned by
---    'validChains' until it find the one 'selectChain' chose as these will be
---    the ones that the real algorithm would test and re-add to the list once
---    truncated.
---
---    > knownInvalid = append (C0I + C1I) knownInvalid
---    > knownValid   = foldl append knownValid (takeWhile (/= C1V) candidates ++ [C1V])
---
---    Note that the set of known valid blocks is equivalent to the set computed
---    by real algorithm, but the set of known invalid blocks is a superset of
---    the ones known by the real algorithm. See the note
---    Ouroboros.Storage.ChainDB.StateMachine.[Invalid blocks].
+               (map fst candidates)
 
 addBlocks :: (Eq blk, LedgerSupportsProtocol blk)
           => TopLevelConfig blk
@@ -877,12 +778,8 @@ validChains cfg m bs =
     -- first, which results in the valid chain A->B', which is then chosen
     -- over the equally preferable A->B as it will be the first in the list
     -- after a stable sort.
-    sortChains $ pruneKnownInvalid <$> chains bs
+    sortChains $ chains bs
   where
-    pruneKnownInvalid chain =
-      -- We don't want known invalid blocks to influence the sorting of candidate chains.
-      Chain.takeWhile (\b -> blockHash b `Map.notMember` (invalid m)) chain
-
     sortChains :: [Chain blk] -> [Chain blk]
     sortChains =
       sortBy $ flip (


### PR DESCRIPTION
# Description

Closes #123.

This PR changes two parts of the ChainDB model:

* We reinstate that the model knows about *all* valid and invalid blocks for *all* for all chains that can be constructed using blocks in the model immutable DB and model volatile DB. That is, the `valid` and `invalid` fields of the model are now updated more rigorously.
* We simplify model chain selection by not approximating in which order candidate chains are considered by real chain selection. 

This has two effects:

* The fact that the model knows about all valid and invalid blocks is not a problem for the `GetIsValid` command. The model might know in advance which blocks are valid/invalid even before the SUT knows about them, but the only condition we require for test success in the case of the `GetIsValid` command is: *if* the SUT says that a block is valid or invalid, then the model should have the same response. Conversely, if the SUT says it does not know if a block is valid or invalid, then the model's response is ignored (or in other words, it can be anything).
* Before this PR, the model already knew about all valid and invalid blocks of candidate fragments before running chain selection. In contrast, the SUT only finds out about valid/invalid blocks on the fly during real chain selection as it validates blocks on chain fragments that haven't been considered before. Known invalid blocks impact the sorting of considered fragments in both model and SUT chain selection. Since the SUT knows about fewer invalid blocks than the model, model and SUT chain selection might consider chain fragments in a different order. However: if the SUT chain selection finds new invalid blocks, then real considered fragments are reduced to valid prefixes and re-sorted into the list of considered chain fragments. The result of model and SUT chain selection is the same regardless: the model merely skips these "re-sorting" steps because it already knows about all invalid blocks. In other words, the model performs "best-case" chain selection where all invalid blocks are always known, whereas the SUT does not. Still, the fact that the SUT knows about some (not necessarily all) invalid blocks serves as an optimisation because longer chains containing invalid blocks can be reduced to valid prefixes before running real chain selection. Note also that knowledge about invalid blocks should not (and does not) influence which chain is eventually selected. Otherwise, chain selection would be non-deterministic.

## Future test failures

Assuming that above arguments are correct, if we find a `GetIsValid` failure again in the future, the first thing to check would be if we are somehow not recording some valid/invalid blocks. Model chain selection should not have to change.

## Logs

Known failing test seeds were used to rerun tests, and the tests pass.

### [ouroboros-consensus#123](https://github.com/input-output-hk/ouroboros-consensus/issues/123)

<details>
<summary>Recreate test failure</summary>

```sh
... $ git checkout 439a15f
... $ cabal run storage-test -- -p 'ChainDB q-s-m' --quickcheck-replay=616511
ouroboros-storage
  Storage
    ChainDB
      ChainDB q-s-m
        sequential: 
          ...

          PostconditionFailed "AnnotateC \"real response didn't match model response\" (PredicateC (Resp {getResp = Right (IsValid (IsValidResult {real = True, isValid = Just True}))} :/= Resp {getResp = Right (IsValid (IsValidResult {real = False, isValid = Nothing}))}))" /= Ok
          Use --quickcheck-replay=616511 to reproduce.

1 out of 1 tests failed (9.74s)
```

</details>

```sh
... $ cabal run storage-test -- -p 'ChainDB q-s-m' --quickcheck-replay=616511
ouroboros-storage
  Storage
    ChainDB
      ChainDB q-s-m
        sequential: OK (78.88s)
          +++ OK, passed 100000 tests.
          
         ...

All 1 tests passed (78.89s)
```

### [ouroboros-network#3689](https://github.com/input-output-hk/ouroboros-network/issues/3689)

<details>
<summary>ouroboros-network-3689.patch</summary>

```
diff --git a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/Model.hs b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/Model.hs
index ffc17f020..b1c944ef7 100644
--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/Model.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/Model.hs
@@ -873,12 +873,8 @@ validChains cfg m bs =
     -- first, which results in the valid chain A->B', which is then chosen
     -- over the equally preferable A->B as it will be the first in the list
     -- after a stable sort.
-    sortChains $ pruneKnownInvalid <$> chains bs
+    sortChains $ chains bs
   where
-    pruneKnownInvalid chain =
-      -- We don't want known invalid blocks to influence the sorting of candidate chains.
-      Chain.takeWhile (\b -> blockHash b `Map.notMember` (invalid m)) chain
-
     sortChains :: [Chain blk] -> [Chain blk]
     sortChains =
       sortBy $ flip (
```

</details>

<details>
<summary>Recreate test failure</summary>

```sh
... $ git checkout 439a15f
... $ git apply ouroboros-network-3689.patch
... $ cabal run storage-test -- -p 'ChainDB q-s-m' --quickcheck-replay=455411
ouroboros-storage
  Storage
    ChainDB
      ChainDB q-s-m
        sequential: 
          ...

          PostconditionFailed "AnnotateC \"real response didn't match model response\" (PredicateC (Resp {getResp = Right (IsValid (IsValidResult {real = True, isValid = Just True}))} :/= Resp {getResp = Right (IsValid (IsValidResult {real = False, isValid = Nothing}))}))" /= Ok
          Use --quickcheck-replay=455411 to reproduce.

1 out of 1 tests failed (39.23s)
```

</details>

```sh
... $ cabal run storage-test -- -p 'ChainDB q-s-m' --quickcheck-replay=455411
ouroboros-storage
  Storage
    ChainDB
      ChainDB q-s-m
        sequential: OK (80.63s)
          +++ OK, passed 100000 tests.
          
          ...

All 1 tests passed (80.63s)
```

</details>

### [ouroboros-network#3389](https://github.com/input-output-hk/ouroboros-network/issues/3389)

```sh
... $ cabal run storage-test -- -p 'ChainDB q-s-m' --quickcheck-replay=999301
ouroboros-storage
  Storage
    ChainDB
      ChainDB q-s-m
        sequential: OK (83.41s)
          +++ OK, passed 100000 tests.
          
          ...

All 1 tests passed (83.41s)
```

### [ouroboros-network#3440](https://github.com/input-output-hk/ouroboros-network/issues/3440)



```sh
... $ cabal run storage-test -- -p 'ChainDB q-s-m' --quickcheck-replay=758015
ouroboros-storage
  Storage
    ChainDB
      ChainDB q-s-m
        sequential: OK (78.40s)
          +++ OK, passed 100000 tests.
          
          ...

All 1 tests passed (78.40s)
```