### PR TITLE
Improve GHA caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,16 +69,28 @@ jobs:
         | sort \
         | uniq > dependencies.txt
 
+    # This is used for caching the cabal store.
+    - name: Store month number as environment variable
+      run:  echo "MONTHNUM=$(/usr/bin/date -u '+%m')" >> $GITHUB_ENV
+
     # Restore the cabal store cache. See `save-cabal-store`.
-    - uses: actions/cache/restore@v3
+    #
+    # When we restore a previous cache and store a new key, we store both files
+    # that were already in the cache, and new files that were created. To
+    # prevent the cache from growing to quickly, we reset the cache each month.
+    #
+    # NOTE: it's vital that all restore-keys include the month number.
+    # Otherwise, we could restore a cache from a previous month, which makes
+    # caches grow unboundedly.
+    - name: "Restore cache for cabal-store"
+      uses: actions/cache/restore@v3
       id: restore-cabal-store
-      name: "Restore cache for cabal-store"
       with:
         path: ${{ steps.setup-haskell.outputs.cabal-store }}
-        key: cabal-store-${{ env.CABAL_CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('dependencies.txt') }}
+        key: cabal-store-${{ env.CABAL_CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.MONTHNUM }}-${{ hashFiles('dependencies.txt') }}
         restore-keys: |
-          cabal-store-${{ env.CABAL_CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('dependencies.txt') }}
-          cabal-store-${{ env.CABAL_CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}
+          cabal-store-${{ env.CABAL_CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.MONTHNUM }}-${{ hashFiles('dependencies.txt') }}
+          cabal-store-${{ env.CABAL_CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.MONTHNUM }}-
 
     # NOTE: We skip caching of the dist-newstyle folder for now, since we're
     # often getting the following cabal warning, which leads to compilation
@@ -112,9 +124,9 @@ jobs:
     # rebuilt if any of the later steps fail and the job has to be re-run.
     #
     # See https://github.com/actions/cache/tree/v3/save#always-save-cache.
-    - uses: actions/cache/save@v3
+    - name: "Save cache for cabal-store"
+      uses: actions/cache/save@v3
       id: save-cabal-store
-      name: "Save cache for cabal-store"
       if: steps.build-dependencies.outcome == 'success'
       with:
         path: ${{ steps.setup-haskell.outputs.cabal-store }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,27 +92,22 @@ jobs:
           cabal-store-${{ env.CABAL_CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.MONTHNUM }}-${{ hashFiles('dependencies.txt') }}
           cabal-store-${{ env.CABAL_CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.MONTHNUM }}-
 
-    # NOTE: We skip caching of the dist-newstyle folder for now, since we're
-    # often getting the following cabal warning, which leads to compilation
-    # failures: "Warning: This package indirectly depends on multiple versions
-    # of the same package. This is very likely to cause a compile failure.".
+    # This is used for caching the `dist-newstyle` directory.
+    - name: Store week number as environment variable
+      run: echo "WEEKNUM=$(/usr/bin/date -u '+%W')" >> $GITHUB_ENV
+
+    # Cache the `dist-newstyle` folder.
     #
-    # # This is used for caching the `dist-newstyle` directory.
-    # - name: Store week number as environment variable
-    #   run: echo "WEEKNUM=$(/usr/bin/date -u '+%W')" >> $GITHUB_ENV
-    #
-    # # When we restore a previous cache and store a new key, we also store files
-    # # that were part of the last restoration but were not actually used. To
-    # # prevent the cache from growing too quickly we only store a new cache every
-    # # week.
-    # - uses: actions/cache@v3
-    #   name: "Cache `dist-newstyle`"
-    #   with:
-    #     path: |
-    #       dist-newstyle
-    #       !dist-newstyle/**/.git
-    #     key: cache-dist-${{ env.CABAL_CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.WEEKNUM }}
-    #     restore-keys: cache-dist-${{ env.CABAL_CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}
+    # See 'restore-cabal-store' for why we use the week number in the primary
+    # key and restore keys.
+    - name: "Cache dist-newstyle"
+      uses: actions/cache@v3
+      with:
+        path: dist-newstyle
+        key: cache-dist-${{ env.CABAL_CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.WEEKNUM }}-${{ hashFiles('dependencies.txt') }}
+        restore-keys: |
+          cache-dist-${{ env.CABAL_CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.WEEKNUM }}-${{ hashFiles('dependencies.txt') }}
+          cache-dist-${{ env.CABAL_CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.WEEKNUM }}-
 
     - name: Build dependencies
       id: build-dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,41 +51,43 @@ jobs:
         cabal clean
         cabal update
 
-    - name: Generate dist-newstyle/cache/plan.json
-      run: cabal build all --dry-run --minimize-conflict-set
-
-    # We create a `dependencies.txt` file that can be used to index the cabal-store cache.
+    # We create a `dependencies.txt` file that can be used to index the cabal
+    # store cache.
     #
     # We do not use `plan.json` directly because adding a dependency to our
     # Cabal files which was already present somewhere else would result in a
-    # diferent plan, even though the set of dependences is the same.
+    # diferent plan, even though the set of dependencies is the same.
     #
     # In the future we should consider using `cabal-cache` like in the
     # `cardano-node`'s GitHub workflow.
     - name: Record dependencies to be used as cache keys
       id: record-deps
       run: |
-        cabal build all --dry-run
+        cabal build all --dry-run --minimize-conflict-set
         cat dist-newstyle/cache/plan.json \
         | jq '.["install-plan"][].id' \
         | sort \
         | uniq > dependencies.txt
 
-    - uses: actions/cache@v3
-      name: "Cache `cabal store`"
+    # Restore the cabal store cache. See `save-cabal-store`.
+    - uses: actions/cache/restore@v3
+      id: restore-cabal-store
+      name: "Restore cache for cabal-store"
       with:
         path: ${{ steps.setup-haskell.outputs.cabal-store }}
-        key: cache-store-${{ env.CABAL_CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('dependencies.txt') }}
-        restore-keys: cache-store-${{ env.CABAL_CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}
-
-    # This is used for caching the `dist-newstyle` directory.
-    - name: Store week number as environment variable
-      run: echo "WEEKNUM=$(/usr/bin/date -u '+%W')" >> $GITHUB_ENV
+        key: cabal-store-${{ env.CABAL_CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('dependencies.txt') }}
+        restore-keys: |
+          cabal-store-${{ env.CABAL_CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('dependencies.txt') }}
+          cabal-store-${{ env.CABAL_CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}
 
     # NOTE: We skip caching of the dist-newstyle folder for now, since we're
     # often getting the following cabal warning, which leads to compilation
     # failures: "Warning: This package indirectly depends on multiple versions
     # of the same package. This is very likely to cause a compile failure.".
+    #
+    # # This is used for caching the `dist-newstyle` directory.
+    # - name: Store week number as environment variable
+    #   run: echo "WEEKNUM=$(/usr/bin/date -u '+%W')" >> $GITHUB_ENV
     #
     # # When we restore a previous cache and store a new key, we also store files
     # # that were part of the last restoration but were not actually used. To
@@ -101,7 +103,22 @@ jobs:
     #     restore-keys: cache-dist-${{ env.CABAL_CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}
 
     - name: Build dependencies
+      id: build-dependencies
       run: cabal build --only-dependencies all -j
+
+    # Save the cabal store cache if the dependencies were succesfully built,
+    # even if subsequent consensus builds/tests/benchmarks could fail. This
+    # should shave off some running time because dependencies don't have to be
+    # rebuilt if any of the later steps fail and the job has to be re-run.
+    #
+    # See https://github.com/actions/cache/tree/v3/save#always-save-cache.
+    - uses: actions/cache/save@v3
+      id: save-cabal-store
+      name: "Save cache for cabal-store"
+      if: steps.build-dependencies.outcome == 'success'
+      with:
+        path: ${{ steps.setup-haskell.outputs.cabal-store }}
+        key:  ${{ steps.restore-cabal-store.outputs.cache-primary-key }}
 
     - name: Build projects [build]
       run: cabal build all -j

--- a/ouroboros-consensus/src/ouroboros-consensus/Data/SOP/Strict.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Data/SOP/Strict.hs
@@ -370,3 +370,4 @@ instance All (Compose NoThunks f) xs
                      noThunks ("fst" : ctxt) x
                    , noThunks ("snd" : ctxt) xs
                    ]
+


### PR DESCRIPTION
# Description

I've done a bit of research into programmatic cache deletion through GitHub actions since our Linux cabal store cache had grown to 1.5GB. So far I could not find a satisfying, automatic solution to deleting caches. I looked into deleting caches based on a size threshold, but I realised that only deleting caches that are above a size threshold means we still keep around caches that are large but just under the size threshold. In addition, a tool like https://github.com/actions/gh-actions-cache/ does not provide filtering for cache sizes. It looks to me like hard "resets" like updating the `CABAL_CACHE_VERSION` in the workflow file is still the way to go, because it makes older caches unrestorable and therefore these caches are eventually evicted automatically if they are old enough. However, this requires manual intervention. One other option would be to use a similar approach to how we used to cache the `dist-newstyle` folder, using something like the month number, invalidating caches at the start of each month. @input-output-hk/ouroboros-consensus what do you think?

EDIT: One advantage of the month-number approach is that long-lived branches do not keep large caches alive. If `CABAL_CACHE_VERSION` is updated on `main`, only caches created on branches that branch off after that point will inherit the updated version.