### PR TITLE
Consolidate protocol parameters across eras

### DIFF
--- a/ouroboros-consensus-cardano/changelog.d/20230815_110046_joris_275_consolidate_protocolparams_across_eras.md
+++ b/ouroboros-consensus-cardano/changelog.d/20230815_110046_joris_275_consolidate_protocolparams_across_eras.md
@@ -1,0 +1,33 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->
+
+### Non-Breaking
+
+- Add a `ProtocolTransitionParams` data family, and provide instances for
+  transitions from Byron to Shelley and Shelley-based eras to Shelley-based
+  eras.
+- Add a data instance of `ProtocolParams` for the Cardano block.
+- Provide a `CardanoProtocolParams` type synonym and associated pattern synonym
+  (with record syntax).
+- Export all `ProtocolParams` and `ProtocolTransitionParams` instances from
+  `Ouroboros.Consensus.Cardano` and `Ouroboros.Consensus.Cardano.Node`.
+
+### Breaking
+
+- Refactor `ProtocolParamsByron` to a data instance of `ProtocolParams`.
+- Refactor protocol parameters for Shelley eras (e.g, `ProtocolParamsAlonzo` and `ProtocolParamsBabbage`) to data instances of `ProtocolParams`.
+- Export all Shelley `ProtocolParams` data instances from `Ouroboros.Consensus.Shelley.Node`.
+- Remove the `ProtocolTransitionParamsShelleyBased` datatype in favour of
+  `ProtocolTransitionParams`.
+- Make `protocolInfoCardano` require a `CardanoProtocolParams` type as its only
+  argument, instead of a long list of arguments.

--- a/ouroboros-consensus-cardano/src/byron-testlib/Test/ThreadNet/Infra/Byron/ProtocolInfo.hs
+++ b/ouroboros-consensus-cardano/src/byron-testlib/Test/ThreadNet/Infra/Byron/ProtocolInfo.hs
@@ -59,7 +59,7 @@ mkProtocolByron params coreNodeId genesisConfig genesisSecrets =
     blockForging :: [BlockForging m ByronBlock]
     blockForging = blockForgingByron protocolParams
 
-    protocolParams :: ProtocolParamsByron
+    protocolParams :: ProtocolParams ByronBlock
     protocolParams = ProtocolParamsByron {
             byronGenesis                = genesisConfig
           , byronPbftSignatureThreshold = Just $ pbftSignatureThreshold

--- a/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Node.hs
+++ b/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Node.hs
@@ -8,18 +8,19 @@
 
 module Ouroboros.Consensus.Byron.Node (
     PBftSignatureThreshold (..)
-  , ProtocolParamsByron (..)
   , blockForgingByron
   , byronBlockForging
-  , defaultPBftSignatureThreshold
-  , mkByronConfig
-  , protocolClientInfoByron
-  , protocolInfoByron
     -- * Secrets
   , ByronLeaderCredentials (..)
   , ByronLeaderCredentialsError
   , mkByronLeaderCredentials
   , mkPBftCanBeLeader
+    -- * ProtocolInfo
+  , ProtocolParams (..)
+  , defaultPBftSignatureThreshold
+  , mkByronConfig
+  , protocolClientInfoByron
+  , protocolInfoByron
   ) where
 
 import qualified Cardano.Chain.Delegation as Delegation
@@ -151,7 +152,7 @@ mkPBftCanBeLeader (ByronLeaderCredentials sk cert nid _) = PBftCanBeLeader {
     }
 
 blockForgingByron :: Monad m
-                  => ProtocolParamsByron
+                  => ProtocolParams ByronBlock
                   -> [BlockForging m ByronBlock]
 blockForgingByron ProtocolParamsByron { byronLeaderCredentials      = mLeaderCreds
                                       , byronMaxTxCapacityOverrides = maxTxCapacityOverrides
@@ -169,7 +170,7 @@ defaultPBftSignatureThreshold :: PBftSignatureThreshold
 defaultPBftSignatureThreshold = PBftSignatureThreshold 0.22
 
 -- | Parameters needed to run Byron
-data ProtocolParamsByron = ProtocolParamsByron {
+data instance ProtocolParams ByronBlock = ProtocolParamsByron {
       byronGenesis                :: Genesis.Config
     , byronPbftSignatureThreshold :: Maybe PBftSignatureThreshold
     , byronProtocolVersion        :: Update.ProtocolVersion
@@ -178,7 +179,7 @@ data ProtocolParamsByron = ProtocolParamsByron {
     , byronMaxTxCapacityOverrides :: Mempool.TxOverrides ByronBlock
     }
 
-protocolInfoByron :: ProtocolParamsByron
+protocolInfoByron :: ProtocolParams ByronBlock
                   -> ProtocolInfo ByronBlock
 protocolInfoByron ProtocolParamsByron {
                       byronGenesis                = genesisConfig

--- a/ouroboros-consensus-cardano/src/cardano-testlib/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
+++ b/ouroboros-consensus-cardano/src/cardano-testlib/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
@@ -38,8 +38,7 @@ import           Ouroboros.Consensus.Cardano.CanHardFork
                      (ShelleyPartialLedgerConfig (..), forecastAcrossShelley,
                      translateChainDepStateAcrossShelley)
 import           Ouroboros.Consensus.Cardano.Node
-                     (ProtocolTransitionParamsShelleyBased (..),
-                     TriggerHardFork (..))
+                     (ProtocolTransitionParams (..), TriggerHardFork (..))
 import           Ouroboros.Consensus.HardFork.Combinator
 import           Ouroboros.Consensus.HardFork.Combinator.Embed.Binary
 import           Ouroboros.Consensus.HardFork.Combinator.Serialisation
@@ -228,7 +227,7 @@ protocolInfoShelleyBasedHardFork ::
   -> SL.ProtVer
   -> SL.ProtVer
   -> SL.TranslationContext era1
-  -> ProtocolTransitionParamsShelleyBased era2
+  -> ProtocolTransitionParams (ShelleyBlock proto1 era1) (ShelleyBlock proto2 era2)
   -> ( ProtocolInfo      (ShelleyBasedHardForkBlock proto1 era1 proto2 era2)
      , m [BlockForging m (ShelleyBasedHardForkBlock proto1 era1 proto2 era2)]
      )
@@ -274,9 +273,9 @@ protocolInfoShelleyBasedHardFork protocolParamsShelleyBased
     eraParams1 :: History.EraParams
     eraParams1 = shelleyEraParams genesis
 
-    ProtocolTransitionParamsShelleyBased {
-        transitionTranslationContext = transCtxt2
-      , transitionTrigger
+    ProtocolTransitionParamsIntraShelley {
+        transitionIntraShelleyTranslationContext = transCtxt2
+      , transitionIntraShelleyTrigger
       } = protocolTransitionParams
 
     toPartialLedgerConfig1 ::
@@ -284,7 +283,7 @@ protocolInfoShelleyBasedHardFork protocolParamsShelleyBased
       -> PartialLedgerConfig (ShelleyBlock proto1 era1)
     toPartialLedgerConfig1 cfg = ShelleyPartialLedgerConfig {
           shelleyLedgerConfig    = cfg
-        , shelleyTriggerHardFork = transitionTrigger
+        , shelleyTriggerHardFork = transitionIntraShelleyTrigger
         }
 
     -- Era 2

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano.hs
@@ -8,12 +8,8 @@ module Ouroboros.Consensus.Cardano (
   , ProtocolCardano
   , ProtocolShelley
     -- * Abstract over the various protocols
-  , ProtocolParamsAllegra (..)
-  , ProtocolParamsAlonzo (..)
-  , ProtocolParamsByron (..)
-  , ProtocolParamsMary (..)
-  , ProtocolParamsShelley (..)
-  , ProtocolTransitionParamsShelleyBased (..)
+  , ProtocolParams (..)
+  , ProtocolTransitionParams (..)
   , module X
   ) where
 

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node.hs
@@ -14,10 +14,7 @@
 
 module Ouroboros.Consensus.Shelley.Node (
     MaxMajorProtVer (..)
-  , ProtocolParamsAllegra (..)
-  , ProtocolParamsAlonzo (..)
-  , ProtocolParamsMary (..)
-  , ProtocolParamsShelley (..)
+  , ProtocolParams (..)
   , ProtocolParamsShelleyBased (..)
   , SL.Nonce (..)
   , SL.ProtVer (..)
@@ -48,14 +45,14 @@ import           Ouroboros.Consensus.Shelley.Eras (EraCrypto)
 import           Ouroboros.Consensus.Shelley.Ledger
 import           Ouroboros.Consensus.Shelley.Ledger.Inspect ()
 import           Ouroboros.Consensus.Shelley.Ledger.NetworkProtocolVersion ()
+import           Ouroboros.Consensus.Shelley.Node.Praos
 import           Ouroboros.Consensus.Shelley.Node.Serialisation ()
 import           Ouroboros.Consensus.Shelley.Node.TPraos
 import           Ouroboros.Consensus.Shelley.Protocol.Abstract (pHeaderIssuer)
+
 {-------------------------------------------------------------------------------
   ProtocolInfo
 -------------------------------------------------------------------------------}
-
-
 
 protocolClientInfoShelley :: ProtocolClientInfo (ShelleyBlock proto era)
 protocolClientInfoShelley =

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node/Praos.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node/Praos.hs
@@ -1,18 +1,21 @@
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE FlexibleInstances   #-}
 {-# LANGUAGE GADTs               #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeFamilies        #-}
 {-# LANGUAGE TypeOperators       #-}
 
 module Ouroboros.Consensus.Shelley.Node.Praos (
-    ProtocolParamsBabbage (..)
-  , ProtocolParamsConway (..)
-  , praosBlockForging
+    -- * BlockForging
+    praosBlockForging
   , praosSharedBlockForging
+    -- * ProtocolInfo
+  , ProtocolParams (..)
   ) where
 
 import qualified Cardano.Ledger.Shelley.API as SL
@@ -21,6 +24,7 @@ import qualified Cardano.Protocol.TPraos.OCert as SL
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config (configConsensus)
 import qualified Ouroboros.Consensus.Mempool as Mempool
+import           Ouroboros.Consensus.Node.ProtocolInfo
 import qualified Ouroboros.Consensus.Protocol.Ledger.HotKey as HotKey
 import           Ouroboros.Consensus.Protocol.Praos (Praos, PraosParams (..),
                      praosCheckCanForge)
@@ -30,9 +34,8 @@ import           Ouroboros.Consensus.Shelley.Eras (BabbageEra, ConwayEra,
                      EraCrypto, ShelleyBasedEra (shelleyBasedEraName))
 import           Ouroboros.Consensus.Shelley.Ledger (ShelleyBlock,
                      ShelleyCompatible, forgeShelleyBlock)
-import           Ouroboros.Consensus.Shelley.Node
-                     (ShelleyLeaderCredentials (..))
-import           Ouroboros.Consensus.Shelley.Node.Common (ShelleyEraWithCrypto)
+import           Ouroboros.Consensus.Shelley.Node.Common (ShelleyEraWithCrypto,
+                     ShelleyLeaderCredentials (..))
 import           Ouroboros.Consensus.Shelley.Protocol.Praos ()
 import           Ouroboros.Consensus.Util.IOLike (IOLike)
 
@@ -114,14 +117,12 @@ praosSharedBlockForging
   ProtocolInfo
 -------------------------------------------------------------------------------}
 
--- | Parameters needed to run Babbage
-data ProtocolParamsBabbage c = ProtocolParamsBabbage {
+data instance ProtocolParams (ShelleyBlock (Praos c) (BabbageEra c)) = ProtocolParamsBabbage {
     babbageProtVer                :: SL.ProtVer
   , babbageMaxTxCapacityOverrides :: Mempool.TxOverrides (ShelleyBlock (Praos c) (BabbageEra c))
   }
 
--- | Parameters needed to run Conway
-data ProtocolParamsConway c = ProtocolParamsConway {
+data instance ProtocolParams (ShelleyBlock (Praos c) (ConwayEra c)) = ProtocolParamsConway {
     conwayProtVer                :: SL.ProtVer
   , conwayMaxTxCapacityOverrides :: Mempool.TxOverrides (ShelleyBlock (Praos c) (ConwayEra c))
   }

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node/TPraos.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node/TPraos.hs
@@ -7,7 +7,6 @@
 {-# LANGUAGE NamedFieldPuns          #-}
 {-# LANGUAGE OverloadedStrings       #-}
 {-# LANGUAGE PolyKinds               #-}
-{-# LANGUAGE RecordWildCards         #-}
 {-# LANGUAGE ScopedTypeVariables     #-}
 {-# LANGUAGE TypeApplications        #-}
 {-# LANGUAGE TypeFamilies            #-}
@@ -19,10 +18,7 @@
 
 module Ouroboros.Consensus.Shelley.Node.TPraos (
     MaxMajorProtVer (..)
-  , ProtocolParamsAllegra (..)
-  , ProtocolParamsAlonzo (..)
-  , ProtocolParamsMary (..)
-  , ProtocolParamsShelley (..)
+  , ProtocolParams (..)
   , ProtocolParamsShelleyBased (..)
   , SL.Nonce (..)
   , SL.ProtVer (..)
@@ -190,25 +186,25 @@ validateGenesis = first errsToString . SL.validateGenesis
           ("Invalid genesis config:" : map SL.describeValidationErr errs)
 
 -- | Parameters needed to run Shelley
-data ProtocolParamsShelley c = ProtocolParamsShelley {
+data instance ProtocolParams (ShelleyBlock (TPraos c) (ShelleyEra c)) = ProtocolParamsShelley {
       shelleyProtVer                :: SL.ProtVer
     , shelleyMaxTxCapacityOverrides :: Mempool.TxOverrides (ShelleyBlock(TPraos c) (ShelleyEra c) )
     }
 
 -- | Parameters needed to run Allegra
-data ProtocolParamsAllegra c = ProtocolParamsAllegra {
+data instance ProtocolParams (ShelleyBlock (TPraos c) (AllegraEra c)) = ProtocolParamsAllegra {
       allegraProtVer                :: SL.ProtVer
     , allegraMaxTxCapacityOverrides :: Mempool.TxOverrides (ShelleyBlock (TPraos c) (AllegraEra c) )
     }
 
 -- | Parameters needed to run Mary
-data ProtocolParamsMary c = ProtocolParamsMary {
+data instance ProtocolParams (ShelleyBlock (TPraos c) (MaryEra c)) = ProtocolParamsMary {
       maryProtVer                :: SL.ProtVer
     , maryMaxTxCapacityOverrides :: Mempool.TxOverrides (ShelleyBlock (TPraos c) (MaryEra c) )
     }
 
 -- | Parameters needed to run Alonzo
-data ProtocolParamsAlonzo c = ProtocolParamsAlonzo {
+data instance ProtocolParams (ShelleyBlock (TPraos c) (AlonzoEra c)) = ProtocolParamsAlonzo {
       alonzoProtVer                :: SL.ProtVer
     , alonzoMaxTxCapacityOverrides :: Mempool.TxOverrides (ShelleyBlock (TPraos c) (AlonzoEra c) )
     }
@@ -221,8 +217,8 @@ protocolInfoShelley ::
       , TxLimits (ShelleyBlock (TPraos c) (ShelleyEra c))
       )
   => ProtocolParamsShelleyBased (ShelleyEra c)
-  -> ProtocolParamsShelley c
-  -> ( ProtocolInfo (ShelleyBlock (TPraos c)(ShelleyEra c) )
+  -> ProtocolParams (ShelleyBlock (TPraos c) (ShelleyEra c))
+  -> ( ProtocolInfo (ShelleyBlock (TPraos c) (ShelleyEra c) )
      , m [BlockForging m (ShelleyBlock (TPraos c) (ShelleyEra c))]
      )
 protocolInfoShelley protocolParamsShelleyBased

--- a/ouroboros-consensus-cardano/src/tools/Cardano/Node/Protocol/Cardano.hs
+++ b/ouroboros-consensus-cardano/src/tools/Cardano/Node/Protocol/Cardano.hs
@@ -36,7 +36,6 @@ import qualified Ouroboros.Consensus.Cardano.CanHardFork as Consensus
 import           Ouroboros.Consensus.Cardano.Condense ()
 import           Ouroboros.Consensus.HardFork.Combinator.Condense ()
 import qualified Ouroboros.Consensus.Mempool as Mempool
-import qualified Ouroboros.Consensus.Shelley.Node.Praos as Praos
 
 
 ------------------------------------------------------------------------------
@@ -140,178 +139,180 @@ mkSomeConsensusProtocolCardano NodeByronProtocolConfiguration {
     -- It could and should all be automated and these config entries eliminated.
     return $!
       SomeConsensusProtocol CardanoBlockType $ ProtocolInfoArgsCardano
-        Consensus.ProtocolParamsByron {
-          byronGenesis = byronGenesis,
-          byronPbftSignatureThreshold =
-            PBftSignatureThreshold <$> npcByronPbftSignatureThresh,
+        (CardanoProtocolParams
+          Consensus.ProtocolParamsByron {
+            byronGenesis = byronGenesis,
+            byronPbftSignatureThreshold =
+              PBftSignatureThreshold <$> npcByronPbftSignatureThresh,
 
-          -- This is /not/ the Byron protocol version. It is the protocol
-          -- version that this node will use in blocks it creates. It is used
-          -- in the Byron update mechanism to signal that this block-producing
-          -- node is ready to move to the new protocol. For example, when the
-          -- protocol version (according to the ledger state) is 0, this setting
-          -- should be 1 when we are ready to move. Similarly when the current
-          -- protocol version is 1, this should be 2 to indicate we are ready
-          -- to move into the Shelley era.
-          byronProtocolVersion =
-            Byron.ProtocolVersion
-              npcByronSupportedProtocolVersionMajor
-              npcByronSupportedProtocolVersionMinor
-              npcByronSupportedProtocolVersionAlt,
-          byronSoftwareVersion =
-            Byron.SoftwareVersion
-              npcByronApplicationName
-              npcByronApplicationVersion,
-          byronLeaderCredentials =
-            byronLeaderCredentials,
-          byronMaxTxCapacityOverrides =
-            Mempool.mkOverrides Mempool.noOverridesMeasure
-        }
-        Consensus.ProtocolParamsShelleyBased {
-          shelleyBasedGenesis           = shelleyGenesis,
-          shelleyBasedInitialNonce      = Shelley.genesisHashToPraosNonce
-                                            shelleyGenesisHash,
-          shelleyBasedLeaderCredentials = shelleyLeaderCredentials
-        }
-        Consensus.ProtocolParamsShelley {
-          -- This is /not/ the Shelley protocol version. It is the protocol
-          -- version that this node will declare that it understands, when it
-          -- is in the Shelley era. That is, it is the version of protocol
-          -- /after/ Shelley, i.e. Allegra.
-          shelleyProtVer =
-            ProtVer (natVersion @3) 0,
-          shelleyMaxTxCapacityOverrides =
-            Mempool.mkOverrides Mempool.noOverridesMeasure
-        }
-        Consensus.ProtocolParamsAllegra {
-          -- This is /not/ the Allegra protocol version. It is the protocol
-          -- version that this node will declare that it understands, when it
-          -- is in the Allegra era. That is, it is the version of protocol
-          -- /after/ Allegra, i.e. Mary.
-          allegraProtVer =
-            ProtVer (natVersion @4) 0,
-          allegraMaxTxCapacityOverrides =
-            Mempool.mkOverrides Mempool.noOverridesMeasure
-        }
-        Consensus.ProtocolParamsMary {
-          -- This is /not/ the Mary protocol version. It is the protocol
-          -- version that this node will declare that it understands, when it
-          -- is in the Mary era. That is, it is the version of protocol
-          -- /after/ Mary, i.e. Alonzo.
-          maryProtVer = ProtVer (natVersion @5) 0,
-          maryMaxTxCapacityOverrides =
-            Mempool.mkOverrides Mempool.noOverridesMeasure
-        }
-        Consensus.ProtocolParamsAlonzo {
-          -- This is /not/ the Alonzo protocol version. It is the protocol
-          -- version that this node will declare that it understands, when it
-          -- is in the Alonzo era. That is, it is the version of protocol
-          -- /after/ Alonzo, i.e. Babbage.
-          alonzoProtVer = ProtVer (natVersion @6) 0,
-          alonzoMaxTxCapacityOverrides =
-            Mempool.mkOverrides Mempool.noOverridesMeasure
-        }
-        Praos.ProtocolParamsBabbage {
-          -- This is /not/ the Babbage protocol version. It is the protocol
-          -- version that this node will declare that it understands, when it
-          -- is in the Babbage era.
-          Praos.babbageProtVer = ProtVer (natVersion @7) 0,
-          Praos.babbageMaxTxCapacityOverrides =
-            Mempool.mkOverrides Mempool.noOverridesMeasure
-        }
-        Praos.ProtocolParamsConway {
-          -- This is /not/ the Conway protocol version. It is the protocol
-          -- version that this node will declare that it understands, when it
-          -- is in the Conway era.
-          Praos.conwayProtVer =
-            if npcTestEnableDevelopmentHardForkEras
-            then ProtVer (natVersion @9) 0  -- Advertise we can support Conway
-            else ProtVer (natVersion @8) 0, -- Otherwise we only advertise we know about Babbage
-          Praos.conwayMaxTxCapacityOverrides =
-            Mempool.mkOverrides Mempool.noOverridesMeasure
-        }
-        -- 'ProtocolTransitionParamsShelleyBased' specifies the parameters
-        -- needed to transition between two eras. The comments below also apply
-        -- for the Shelley -> Allegra and Allegra -> Mary hard forks.
-        --
-        -- Byron to Shelley hard fork parameters
-        Consensus.ProtocolTransitionParamsShelleyBased {
-          transitionTranslationContext = toFromByronTranslationContext shelleyGenesis,
-          transitionTrigger =
-            -- What will trigger the Byron -> Shelley hard fork?
-            case npcTestShelleyHardForkAtEpoch of
+            -- This is /not/ the Byron protocol version. It is the protocol
+            -- version that this node will use in blocks it creates. It is used
+            -- in the Byron update mechanism to signal that this block-producing
+            -- node is ready to move to the new protocol. For example, when the
+            -- protocol version (according to the ledger state) is 0, this setting
+            -- should be 1 when we are ready to move. Similarly when the current
+            -- protocol version is 1, this should be 2 to indicate we are ready
+            -- to move into the Shelley era.
+            byronProtocolVersion =
+              Byron.ProtocolVersion
+                npcByronSupportedProtocolVersionMajor
+                npcByronSupportedProtocolVersionMinor
+                npcByronSupportedProtocolVersionAlt,
+            byronSoftwareVersion =
+              Byron.SoftwareVersion
+                npcByronApplicationName
+                npcByronApplicationVersion,
+            byronLeaderCredentials =
+              byronLeaderCredentials,
+            byronMaxTxCapacityOverrides =
+              Mempool.mkOverrides Mempool.noOverridesMeasure
+          }
+          Consensus.ProtocolParamsShelleyBased {
+            shelleyBasedGenesis           = shelleyGenesis,
+            shelleyBasedInitialNonce      = Shelley.genesisHashToPraosNonce
+                                              shelleyGenesisHash,
+            shelleyBasedLeaderCredentials = shelleyLeaderCredentials
+          }
+          Consensus.ProtocolParamsShelley {
+            -- This is /not/ the Shelley protocol version. It is the protocol
+            -- version that this node will declare that it understands, when it
+            -- is in the Shelley era. That is, it is the version of protocol
+            -- /after/ Shelley, i.e. Allegra.
+            shelleyProtVer =
+              ProtVer (natVersion @3) 0,
+            shelleyMaxTxCapacityOverrides =
+              Mempool.mkOverrides Mempool.noOverridesMeasure
+          }
+          Consensus.ProtocolParamsAllegra {
+            -- This is /not/ the Allegra protocol version. It is the protocol
+            -- version that this node will declare that it understands, when it
+            -- is in the Allegra era. That is, it is the version of protocol
+            -- /after/ Allegra, i.e. Mary.
+            allegraProtVer =
+              ProtVer (natVersion @4) 0,
+            allegraMaxTxCapacityOverrides =
+              Mempool.mkOverrides Mempool.noOverridesMeasure
+          }
+          Consensus.ProtocolParamsMary {
+            -- This is /not/ the Mary protocol version. It is the protocol
+            -- version that this node will declare that it understands, when it
+            -- is in the Mary era. That is, it is the version of protocol
+            -- /after/ Mary, i.e. Alonzo.
+            maryProtVer = ProtVer (natVersion @5) 0,
+            maryMaxTxCapacityOverrides =
+              Mempool.mkOverrides Mempool.noOverridesMeasure
+          }
+          Consensus.ProtocolParamsAlonzo {
+            -- This is /not/ the Alonzo protocol version. It is the protocol
+            -- version that this node will declare that it understands, when it
+            -- is in the Alonzo era. That is, it is the version of protocol
+            -- /after/ Alonzo, i.e. Babbage.
+            alonzoProtVer = ProtVer (natVersion @6) 0,
+            alonzoMaxTxCapacityOverrides =
+              Mempool.mkOverrides Mempool.noOverridesMeasure
+          }
+          Consensus.ProtocolParamsBabbage {
+            -- This is /not/ the Babbage protocol version. It is the protocol
+            -- version that this node will declare that it understands, when it
+            -- is in the Babbage era.
+            Consensus.babbageProtVer = ProtVer (natVersion @7) 0,
+            Consensus.babbageMaxTxCapacityOverrides =
+              Mempool.mkOverrides Mempool.noOverridesMeasure
+          }
+          Consensus.ProtocolParamsConway {
+            -- This is /not/ the Conway protocol version. It is the protocol
+            -- version that this node will declare that it understands, when it
+            -- is in the Conway era.
+            Consensus.conwayProtVer =
+              if npcTestEnableDevelopmentHardForkEras
+              then ProtVer (natVersion @9) 0  -- Advertise we can support Conway
+              else ProtVer (natVersion @8) 0, -- Otherwise we only advertise we know about Babbage
+            Consensus.conwayMaxTxCapacityOverrides =
+              Mempool.mkOverrides Mempool.noOverridesMeasure
+          }
+          -- 'ProtocolTransitionParams' specifies the parameters needed to
+          -- transition between two eras. The comments below also apply for the
+          -- Shelley -> Allegra and Allegra -> Mary hard forks.
+          --
+          -- Byron to Shelley hard fork parameters
+          Consensus.ProtocolTransitionParamsByronToShelley {
+            transitionByronToShelleyTranslationContext = toFromByronTranslationContext shelleyGenesis,
+            transitionByronToShelleyTrigger =
+              -- What will trigger the Byron -> Shelley hard fork?
+              case npcTestShelleyHardForkAtEpoch of
 
-               -- This specifies the major protocol version number update that will
-               -- trigger us moving to the Shelley protocol.
-               --
-               -- Version 0 is Byron with Ouroboros classic
-               -- Version 1 is Byron with Ouroboros Permissive BFT
-               -- Version 2 is Shelley
-               -- Version 3 is Allegra
-               -- Version 4 is Mary
-               -- Version 5 is Alonzo
-               -- Version 6 is Alonzo (intra era hardfork)
-               -- Version 7 is Babbage
-               -- Version 8 is Babbage (intra era hardfork)
-               -- Version 9 is Conway
-               --
-               -- But we also provide an override to allow for simpler test setups
-               -- such as triggering at the 0 -> 1 transition .
-               --
-               Nothing -> Consensus.TriggerHardForkAtVersion
-                            (maybe 2 fromIntegral npcTestShelleyHardForkAtVersion)
-
-               -- Alternatively, for testing we can transition at a specific epoch.
-               --
-               Just epochNo -> Consensus.TriggerHardForkAtEpoch epochNo
-        }
-        -- Shelley to Allegra hard fork parameters
-        Consensus.ProtocolTransitionParamsShelleyBased {
-          transitionTranslationContext = (),
-          transitionTrigger =
-            case npcTestAllegraHardForkAtEpoch of
-               Nothing -> Consensus.TriggerHardForkAtVersion
-                            (maybe 3 fromIntegral npcTestAllegraHardForkAtVersion)
-               Just epochNo -> Consensus.TriggerHardForkAtEpoch epochNo
-        }
-        -- Allegra to Mary hard fork parameters
-        Consensus.ProtocolTransitionParamsShelleyBased {
-          transitionTranslationContext = (),
-          transitionTrigger =
-            case npcTestMaryHardForkAtEpoch of
-               Nothing -> Consensus.TriggerHardForkAtVersion
-                            (maybe 4 fromIntegral npcTestMaryHardForkAtVersion)
-               Just epochNo -> Consensus.TriggerHardForkAtEpoch epochNo
-        }
-        -- Mary to Alonzo hard fork parameters
-        Consensus.ProtocolTransitionParamsShelleyBased {
-          transitionTranslationContext = alonzoGenesis,
-          transitionTrigger =
-            case npcTestAlonzoHardForkAtEpoch of
-               Nothing -> Consensus.TriggerHardForkAtVersion
-                            (maybe 5 fromIntegral npcTestAlonzoHardForkAtVersion)
-               Just epochNo -> Consensus.TriggerHardForkAtEpoch epochNo
-        }
-        -- Alonzo to Babbage hard fork parameters
-        Consensus.ProtocolTransitionParamsShelleyBased {
-          transitionTranslationContext = (),
-          transitionTrigger =
-             case npcTestBabbageHardForkAtEpoch of
+                -- This specifies the major protocol version number update that will
+                -- trigger us moving to the Shelley protocol.
+                --
+                -- Version 0 is Byron with Ouroboros classic
+                -- Version 1 is Byron with Ouroboros Permissive BFT
+                -- Version 2 is Shelley
+                -- Version 3 is Allegra
+                -- Version 4 is Mary
+                -- Version 5 is Alonzo
+                -- Version 6 is Alonzo (intra era hardfork)
+                -- Version 7 is Babbage
+                -- Version 8 is Babbage (intra era hardfork)
+                -- Version 9 is Conway
+                --
+                -- But we also provide an override to allow for simpler test setups
+                -- such as triggering at the 0 -> 1 transition .
+                --
                 Nothing -> Consensus.TriggerHardForkAtVersion
-                             (maybe 7 fromIntegral npcTestBabbageHardForkAtVersion)
-                Just epochNo -> Consensus.TriggerHardForkAtEpoch epochNo
+                              (maybe 2 fromIntegral npcTestShelleyHardForkAtVersion)
 
-        }
-        -- Babbage to Conway hard fork parameters
-        Consensus.ProtocolTransitionParamsShelleyBased {
-          transitionTranslationContext = conwayGenesis,
-          transitionTrigger =
-             case npcTestConwayHardForkAtEpoch of
+                -- Alternatively, for testing we can transition at a specific epoch.
+                --
+                Just epochNo -> Consensus.TriggerHardForkAtEpoch epochNo
+          }
+          -- Shelley to Allegra hard fork parameters
+          Consensus.ProtocolTransitionParamsIntraShelley {
+            transitionIntraShelleyTranslationContext = (),
+            transitionIntraShelleyTrigger =
+              case npcTestAllegraHardForkAtEpoch of
                 Nothing -> Consensus.TriggerHardForkAtVersion
-                             (maybe 9 fromIntegral npcTestConwayHardForkAtVersion)
+                              (maybe 3 fromIntegral npcTestAllegraHardForkAtVersion)
                 Just epochNo -> Consensus.TriggerHardForkAtEpoch epochNo
+          }
+          -- Allegra to Mary hard fork parameters
+          Consensus.ProtocolTransitionParamsIntraShelley {
+            transitionIntraShelleyTranslationContext = (),
+            transitionIntraShelleyTrigger =
+              case npcTestMaryHardForkAtEpoch of
+                Nothing -> Consensus.TriggerHardForkAtVersion
+                              (maybe 4 fromIntegral npcTestMaryHardForkAtVersion)
+                Just epochNo -> Consensus.TriggerHardForkAtEpoch epochNo
+          }
+          -- Mary to Alonzo hard fork parameters
+          Consensus.ProtocolTransitionParamsIntraShelley {
+            transitionIntraShelleyTranslationContext = alonzoGenesis,
+            transitionIntraShelleyTrigger =
+              case npcTestAlonzoHardForkAtEpoch of
+                Nothing -> Consensus.TriggerHardForkAtVersion
+                              (maybe 5 fromIntegral npcTestAlonzoHardForkAtVersion)
+                Just epochNo -> Consensus.TriggerHardForkAtEpoch epochNo
+          }
+          -- Alonzo to Babbage hard fork parameters
+          Consensus.ProtocolTransitionParamsIntraShelley {
+            transitionIntraShelleyTranslationContext = (),
+            transitionIntraShelleyTrigger =
+              case npcTestBabbageHardForkAtEpoch of
+                  Nothing -> Consensus.TriggerHardForkAtVersion
+                              (maybe 7 fromIntegral npcTestBabbageHardForkAtVersion)
+                  Just epochNo -> Consensus.TriggerHardForkAtEpoch epochNo
 
-        }
+          }
+          -- Babbage to Conway hard fork parameters
+          Consensus.ProtocolTransitionParamsIntraShelley {
+            transitionIntraShelleyTranslationContext = conwayGenesis,
+            transitionIntraShelleyTrigger =
+              case npcTestConwayHardForkAtEpoch of
+                  Nothing -> Consensus.TriggerHardForkAtVersion
+                              (maybe 9 fromIntegral npcTestConwayHardForkAtVersion)
+                  Just epochNo -> Consensus.TriggerHardForkAtEpoch epochNo
+
+          }
+        )
 
 ------------------------------------------------------------------------------
 -- Errors

--- a/ouroboros-consensus-cardano/src/tools/Cardano/Node/Protocol/Shelley.hs
+++ b/ouroboros-consensus-cardano/src/tools/Cardano/Node/Protocol/Shelley.hs
@@ -48,9 +48,8 @@ import qualified Ouroboros.Consensus.Mempool as Mempool
 import           Ouroboros.Consensus.Protocol.Praos.Common
                      (PraosCanBeLeader (..))
 import           Ouroboros.Consensus.Shelley.Node (Nonce (..),
-                     ProtocolParamsShelley (..),
-                     ProtocolParamsShelleyBased (..), ShelleyGenesis (..),
-                     ShelleyLeaderCredentials (..))
+                     ProtocolParams (..), ProtocolParamsShelleyBased (..),
+                     ShelleyGenesis (..), ShelleyLeaderCredentials (..))
 import           Prelude (String, id)
 
 

--- a/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBAnalyser/Block/Byron.hs
+++ b/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBAnalyser/Block/Byron.hs
@@ -26,7 +26,7 @@ import qualified Data.ByteString.Lazy as BL
 import           Ouroboros.Consensus.Byron.Ledger (ByronBlock)
 import qualified Ouroboros.Consensus.Byron.Ledger as Byron
 import           Ouroboros.Consensus.Byron.Node (PBftSignatureThreshold (..),
-                     ProtocolParamsByron (..), protocolInfoByron)
+                     ProtocolParams (..), protocolInfoByron)
 import qualified Ouroboros.Consensus.Mempool as Mempool
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Text.Builder (decimal)

--- a/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBAnalyser/Block/Cardano.hs
+++ b/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBAnalyser/Block/Cardano.hs
@@ -68,7 +68,6 @@ import           Ouroboros.Consensus.Protocol.Praos.Translate ()
 import           Ouroboros.Consensus.Shelley.HFEras ()
 import           Ouroboros.Consensus.Shelley.Ledger.Block (ShelleyBlock)
 import           Ouroboros.Consensus.Shelley.Ledger.SupportsProtocol ()
-import           Ouroboros.Consensus.Shelley.Node.Praos
 import           System.Directory (makeAbsolute)
 import           System.FilePath (takeDirectory, (</>))
 
@@ -297,52 +296,54 @@ mkCardanoProtocolInfo ::
   -> ProtocolInfo (CardanoBlock StandardCrypto)
 mkCardanoProtocolInfo genesisByron signatureThreshold genesisShelley genesisAlonzo genesisConway initialNonce hardForkTriggers =
     fst $ protocolInfoCardano @_ @IO
-      ProtocolParamsByron {
-          byronGenesis                = genesisByron
-        , byronPbftSignatureThreshold = signatureThreshold
-        , byronProtocolVersion        = Byron.Update.ProtocolVersion 1 2 0
-        , byronSoftwareVersion        = Byron.Update.SoftwareVersion (Byron.Update.ApplicationName "db-analyser") 2
-        , byronLeaderCredentials      = Nothing
-        , byronMaxTxCapacityOverrides = Mempool.mkOverrides Mempool.noOverridesMeasure
-        }
-      ProtocolParamsShelleyBased {
-          shelleyBasedGenesis           = genesisShelley
-        , shelleyBasedInitialNonce      = initialNonce
-        , shelleyBasedLeaderCredentials = []
-        }
-      ProtocolParamsShelley {
-          -- Note that this is /not/ the Shelley protocol version, see
-          -- https://github.com/input-output-hk/cardano-node/blob/daeae61a005776ee7b7514ce47de3933074234a8/cardano-node/src/Cardano/Node/Protocol/Cardano.hs#L167-L170
-          -- and the succeeding comments.
-          shelleyProtVer                = ProtVer (SL.natVersion @3) 0
-        , shelleyMaxTxCapacityOverrides = Mempool.mkOverrides Mempool.noOverridesMeasure
-        }
-      ProtocolParamsAllegra {
-          allegraProtVer                = ProtVer (SL.natVersion @4) 0
-        , allegraMaxTxCapacityOverrides = Mempool.mkOverrides Mempool.noOverridesMeasure
-        }
-      ProtocolParamsMary {
-          maryProtVer                   = ProtVer (SL.natVersion @5) 0
-        , maryMaxTxCapacityOverrides    = Mempool.mkOverrides Mempool.noOverridesMeasure
-        }
-      ProtocolParamsAlonzo {
-          alonzoProtVer                 = ProtVer (SL.natVersion @7) 0
-        , alonzoMaxTxCapacityOverrides  = Mempool.mkOverrides Mempool.noOverridesMeasure
-        }
-      ProtocolParamsBabbage {
-          babbageProtVer                 = ProtVer (SL.natVersion @9) 0
-        , babbageMaxTxCapacityOverrides  = Mempool.mkOverrides Mempool.noOverridesMeasure
-        }
-      ProtocolParamsConway {
-          conwayProtVer                  = ProtVer (SL.natVersion @9) 0
-        , conwayMaxTxCapacityOverrides   = Mempool.mkOverrides Mempool.noOverridesMeasure
-        }
-      (unShelleyTransitionArguments shelleyTransition)
-      (unShelleyTransitionArguments allegraTransition)
-      (unShelleyTransitionArguments maryTransition)
-      (unShelleyTransitionArguments alonzoTransition)
-      (unShelleyTransitionArguments babbageTransition)
-      (unShelleyTransitionArguments conwayTransition)
+      (CardanoProtocolParams
+        ProtocolParamsByron {
+            byronGenesis                = genesisByron
+          , byronPbftSignatureThreshold = signatureThreshold
+          , byronProtocolVersion        = Byron.Update.ProtocolVersion 1 2 0
+          , byronSoftwareVersion        = Byron.Update.SoftwareVersion (Byron.Update.ApplicationName "db-analyser") 2
+          , byronLeaderCredentials      = Nothing
+          , byronMaxTxCapacityOverrides = Mempool.mkOverrides Mempool.noOverridesMeasure
+          }
+        ProtocolParamsShelleyBased {
+            shelleyBasedGenesis           = genesisShelley
+          , shelleyBasedInitialNonce      = initialNonce
+          , shelleyBasedLeaderCredentials = []
+          }
+        ProtocolParamsShelley {
+            -- Note that this is /not/ the Shelley protocol version, see
+            -- https://github.com/input-output-hk/cardano-node/blob/daeae61a005776ee7b7514ce47de3933074234a8/cardano-node/src/Cardano/Node/Protocol/Cardano.hs#L167-L170
+            -- and the succeeding comments.
+            shelleyProtVer                = ProtVer (SL.natVersion @3) 0
+          , shelleyMaxTxCapacityOverrides = Mempool.mkOverrides Mempool.noOverridesMeasure
+          }
+        ProtocolParamsAllegra {
+            allegraProtVer                = ProtVer (SL.natVersion @4) 0
+          , allegraMaxTxCapacityOverrides = Mempool.mkOverrides Mempool.noOverridesMeasure
+          }
+        ProtocolParamsMary {
+            maryProtVer                   = ProtVer (SL.natVersion @5) 0
+          , maryMaxTxCapacityOverrides    = Mempool.mkOverrides Mempool.noOverridesMeasure
+          }
+        ProtocolParamsAlonzo {
+            alonzoProtVer                 = ProtVer (SL.natVersion @7) 0
+          , alonzoMaxTxCapacityOverrides  = Mempool.mkOverrides Mempool.noOverridesMeasure
+          }
+        ProtocolParamsBabbage {
+            babbageProtVer                 = ProtVer (SL.natVersion @9) 0
+          , babbageMaxTxCapacityOverrides  = Mempool.mkOverrides Mempool.noOverridesMeasure
+          }
+        ProtocolParamsConway {
+            conwayProtVer                  = ProtVer (SL.natVersion @9) 0
+          , conwayMaxTxCapacityOverrides   = Mempool.mkOverrides Mempool.noOverridesMeasure
+          }
+        (unByronToShelleyTransitionArguments shelleyTransition)
+        (unIntraShelleyTransitionArguments   allegraTransition)
+        (unIntraShelleyTransitionArguments   maryTransition)
+        (unIntraShelleyTransitionArguments   alonzoTransition)
+        (unIntraShelleyTransitionArguments   babbageTransition)
+        (unIntraShelleyTransitionArguments   conwayTransition)
+      )
   where
     ( shelleyTransition :*
       allegraTransition :*
@@ -353,11 +354,19 @@ mkCardanoProtocolInfo genesisByron signatureThreshold genesisShelley genesisAlon
       Nil
       ) = hardForkTriggers
 
-    unShelleyTransitionArguments ::
+    unByronToShelleyTransitionArguments ::
          ShelleyTransitionArguments (ShelleyBlock proto era)
-      -> ProtocolTransitionParamsShelleyBased era
-    unShelleyTransitionArguments (ShelleyTransitionArguments ctxt trigger) =
-      ProtocolTransitionParamsShelleyBased
+      -> ProtocolTransitionParams ByronBlock (ShelleyBlock proto era)
+    unByronToShelleyTransitionArguments (ShelleyTransitionArguments ctxt trigger) =
+      ProtocolTransitionParamsByronToShelley
+      (ctxt (genesisShelley, genesisAlonzo, genesisConway))
+      trigger
+
+    unIntraShelleyTransitionArguments ::
+         ShelleyTransitionArguments (ShelleyBlock proto era)
+      -> ProtocolTransitionParams (ShelleyBlock proto' era') (ShelleyBlock proto era)
+    unIntraShelleyTransitionArguments (ShelleyTransitionArguments ctxt trigger) =
+      ProtocolTransitionParamsIntraShelley
       (ctxt (genesisShelley, genesisAlonzo, genesisConway))
       trigger
 

--- a/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBAnalyser/Block/Shelley.hs
+++ b/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBAnalyser/Block/Shelley.hs
@@ -48,9 +48,8 @@ import           Ouroboros.Consensus.Shelley.Ledger (ShelleyCompatible,
 import           Ouroboros.Consensus.Shelley.Ledger.Block (ShelleyBlock)
 import qualified Ouroboros.Consensus.Shelley.Ledger.Block as Shelley
 import           Ouroboros.Consensus.Shelley.Node (Nonce (..),
-                     ProtocolParamsShelley (..),
-                     ProtocolParamsShelleyBased (..), ShelleyGenesis,
-                     protocolInfoShelley)
+                     ProtocolParams (..), ProtocolParamsShelleyBased (..),
+                     ShelleyGenesis, protocolInfoShelley)
 import           Text.Builder (decimal)
 
 -- | Usable for each Shelley-based era

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/AllegraMary.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/AllegraMary.hs
@@ -34,8 +34,7 @@ import           Lens.Micro ((^.))
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Cardano.Condense ()
 import           Ouroboros.Consensus.Cardano.Node
-                     (ProtocolTransitionParamsShelleyBased (..),
-                     TriggerHardFork (..))
+                     (ProtocolTransitionParams (..), TriggerHardFork (..))
 import           Ouroboros.Consensus.Config.SecurityParam
 import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.Common
                      (isHardForkNodeToNodeEnabled)
@@ -248,10 +247,10 @@ prop_simple_allegraMary_convergence TestSetup
                         [Shelley.mkLeaderCredentials
                           (coreNodes !! fromIntegral nid)]
                     }
-                protocolTransitionParamsShelleyBased =
-                  ProtocolTransitionParamsShelleyBased {
-                      transitionTranslationContext = ()
-                    , transitionTrigger            =
+                protocolTransitionParamsIntraShelley =
+                  ProtocolTransitionParamsIntraShelley {
+                      transitionIntraShelleyTranslationContext = ()
+                    , transitionIntraShelleyTrigger            =
                         TriggerHardForkAtVersion $ SL.getVersion majorVersion2
                     }
                 (protocolInfo, blockForging) =
@@ -260,7 +259,7 @@ prop_simple_allegraMary_convergence TestSetup
                     (SL.ProtVer majorVersion1 0)
                     (SL.ProtVer majorVersion2 0)
                     ()
-                    protocolTransitionParamsShelleyBased
+                    protocolTransitionParamsIntraShelley
              in TestNodeInitialization {
                   tniCrucialTxs   =
                     if not setupHardFork then [] else

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/MaryAlonzo.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/MaryAlonzo.hs
@@ -35,8 +35,7 @@ import           Lens.Micro
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Cardano.Condense ()
 import           Ouroboros.Consensus.Cardano.Node
-                     (ProtocolTransitionParamsShelleyBased (..),
-                     TriggerHardFork (..))
+                     (ProtocolTransitionParams (..), TriggerHardFork (..))
 import           Ouroboros.Consensus.Config.SecurityParam
 import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.Common
                      (isHardForkNodeToNodeEnabled)
@@ -253,10 +252,10 @@ prop_simple_allegraAlonzo_convergence TestSetup
                         [Shelley.mkLeaderCredentials
                           (coreNodes !! fromIntegral nid)]
                     }
-                protocolTransitionParamsShelleyBased =
-                  ProtocolTransitionParamsShelleyBased {
-                      transitionTranslationContext = alonzoGenesis
-                    , transitionTrigger            =
+                protocolTransitionParamsIntraShelley =
+                  ProtocolTransitionParamsIntraShelley {
+                      transitionIntraShelleyTranslationContext = alonzoGenesis
+                    , transitionIntraShelleyTrigger            =
                         TriggerHardForkAtVersion $ SL.getVersion majorVersion2
                     }
                 (protocolInfo, blockForging) =
@@ -265,7 +264,7 @@ prop_simple_allegraAlonzo_convergence TestSetup
                     (SL.ProtVer majorVersion1 0)
                     (SL.ProtVer majorVersion2 0)
                     ()
-                    protocolTransitionParamsShelleyBased
+                    protocolTransitionParamsIntraShelley
             in
             TestNodeInitialization {
                 tniCrucialTxs   =

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/ShelleyAllegra.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/ShelleyAllegra.hs
@@ -36,8 +36,7 @@ import           Lens.Micro ((^.))
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Cardano.Condense ()
 import           Ouroboros.Consensus.Cardano.Node
-                     (ProtocolTransitionParamsShelleyBased (..),
-                     TriggerHardFork (..))
+                     (ProtocolTransitionParams (..), TriggerHardFork (..))
 import           Ouroboros.Consensus.Config.SecurityParam
 import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.Common
                      (isHardForkNodeToNodeEnabled)
@@ -260,10 +259,10 @@ prop_simple_shelleyAllegra_convergence TestSetup
                         [Shelley.mkLeaderCredentials
                           (coreNodes !! fromIntegral nid)]
                     }
-                protocolTransitionParamsShelleyBased =
-                  ProtocolTransitionParamsShelleyBased {
-                      transitionTranslationContext = ()
-                    , transitionTrigger            =
+                protocolTransitionParamsIntraShelley =
+                  ProtocolTransitionParamsIntraShelley {
+                      transitionIntraShelleyTranslationContext = ()
+                    , transitionIntraShelleyTrigger            =
                         TriggerHardForkAtVersion $ SL.getVersion majorVersion2
                     }
                 (protocolInfo, blockForging) =
@@ -272,7 +271,7 @@ prop_simple_shelleyAllegra_convergence TestSetup
                     (SL.ProtVer majorVersion1 0)
                     (SL.ProtVer majorVersion2 0)
                     (SL.toFromByronTranslationContext genesisShelley)
-                    protocolTransitionParamsShelleyBased
+                    protocolTransitionParamsIntraShelley
             in
             TestNodeInitialization {
                 tniCrucialTxs   =

--- a/ouroboros-consensus/changelog.d/20230815_105847_joris_275_consolidate_protocolparams_across_eras.md
+++ b/ouroboros-consensus/changelog.d/20230815_105847_joris_275_consolidate_protocolparams_across_eras.md
@@ -1,0 +1,26 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->
+
+### Non-Breaking
+
+- Add `ProtocolParams` data family to `Ouroboros.Consensus.Node.ProtocolInfo`.
+- Add `PerEraProtocolParams` newtype to
+  `Ouroboros.Consensus.HardFork.Combinator.AcrossEras`.
+
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/AcrossEras.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/AcrossEras.hs
@@ -24,6 +24,7 @@ module Ouroboros.Consensus.HardFork.Combinator.AcrossEras (
   , PerEraCodecConfig (..)
   , PerEraConsensusConfig (..)
   , PerEraLedgerConfig (..)
+  , PerEraProtocolParams (..)
   , PerEraStorageConfig (..)
     -- * Values for /some/ eras
   , SomeErasCanBeLeader (..)
@@ -80,6 +81,7 @@ import           Ouroboros.Consensus.HardFork.Combinator.Info
 import           Ouroboros.Consensus.HardFork.Combinator.Lifting
 import           Ouroboros.Consensus.HardFork.Combinator.PartialConfig
 import           Ouroboros.Consensus.Ledger.SupportsMempool
+import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.TypeFamilyWrappers
 import           Ouroboros.Consensus.Util (allEqual)
 import           Ouroboros.Consensus.Util.Assert
@@ -94,6 +96,8 @@ newtype PerEraCodecConfig     xs = PerEraCodecConfig     { getPerEraCodecConfig 
 newtype PerEraConsensusConfig xs = PerEraConsensusConfig { getPerEraConsensusConfig :: NP WrapPartialConsensusConfig xs }
 newtype PerEraLedgerConfig    xs = PerEraLedgerConfig    { getPerEraLedgerConfig    :: NP WrapPartialLedgerConfig    xs }
 newtype PerEraStorageConfig   xs = PerEraStorageConfig   { getPerEraStorageConfig   :: NP StorageConfig              xs }
+
+newtype PerEraProtocolParams  xs = PerEraProtocolParams  { getPerEraProtocolParams  :: NP ProtocolParams             xs }
 
 {-------------------------------------------------------------------------------
   Values for /some/ eras

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Node/ProtocolInfo.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Node/ProtocolInfo.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE RecordWildCards            #-}
 {-# LANGUAGE TypeFamilies               #-}
 
 module Ouroboros.Consensus.Node.ProtocolInfo (
@@ -8,8 +7,11 @@ module Ouroboros.Consensus.Node.ProtocolInfo (
   , ProtocolClientInfo (..)
   , ProtocolInfo (..)
   , enumCoreNodes
+    -- * Protocol parameters
+  , ProtocolParams
   ) where
 
+import           Data.Kind (Type)
 import           Data.Word
 import           NoThunks.Class (NoThunks)
 import           Ouroboros.Consensus.Block
@@ -43,3 +45,9 @@ data ProtocolInfo b = ProtocolInfo {
 data ProtocolClientInfo b = ProtocolClientInfo {
        pClientInfoCodecConfig :: CodecConfig b
      }
+
+{-------------------------------------------------------------------------------
+  Protocol parameters
+-------------------------------------------------------------------------------}
+
+data family ProtocolParams blk :: Type


### PR DESCRIPTION
# Description

Closes #275.

This PR adds a new `ProtocolParams` data family, with instances for all Byron and Shelley blocks, and an instance for the Cardano block. This simplies `protocolInfoCardano` because per-era protocol parameter arguments are now bundled in the Cardano `ProtocolParams` type.

Tip: hiding whitespace should make the reviewable diff smaller.

See https://github.com/input-output-hk/ouroboros-consensus/pull/282#pullrequestreview-1571502484, which discusses possible follow-up issues for other improvements to `protocolInfoCardano`.
