### PR TITLE
Fix docusaurus' prism config.

### DIFF
--- a/docs/website/docusaurus.config.js
+++ b/docs/website/docusaurus.config.js
@@ -65,9 +65,6 @@ const config = {
     ({
       // Replace with your project's social card
       image: 'img/docusaurus-social-card.jpg',
-      prism: {
-        additionalLanguages: ['haskell'],
-      },
       navbar: {
         title: 'Ouroboros Consensus',
         logo: {
@@ -146,6 +143,7 @@ const config = {
       prism: {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
+        additionalLanguages: ['haskell'],
       },
     }),
 };


### PR DESCRIPTION
We configured `prism` in two places, which overrode part of our settings.

