### PR TITLE
Cleanup of cabal files

### DIFF
--- a/.github/workflows/cabal.project.local
+++ b/.github/workflows/cabal.project.local
@@ -1,6 +1,9 @@
-
 package cardano-crypto-praos
   flags: -external-libsodium-vrf
 
 program-options
   ghc-options: -Werror
+
+if impl(ghc >= 9.6)
+  program-options
+    ghc-options: -Wno-error=redundant-constraints

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ flowchart TD
 The packages contain many test-suites that complicate the dependency graph as
 they create new depencency arcs.
 
-This repository also provides two executables:
+This repository also provides four executables:
 
 - `ouroboros-consensus-cardano/app/db-analyser.hs`: for analyzing ChainDBs as
   the ones created by the node. This helps identifying performance hotspots and
@@ -34,6 +34,12 @@ This repository also provides two executables:
 
 - `ouroboros-consensus-cardano/app/db-synthesizer.hs`: for quickly generating
   chains to be used in benchmarking.
+
+- `ouroboros-consensus-cardano/app/db-truncater.hs`: for truncating an immutable
+  DB.
+
+- `ouroboros-consensus-cardano/app/immdb-server.hs`: for serving a immutable DB
+  stored locally.
 
 To list all the available Cabal components, one can use the following script
 because unfortunately, `cabal` doesn't have a command to list the [available
@@ -112,7 +118,7 @@ To use CHaP, follow their Readme, but in short:
 
 2. Run `cabal update` to pull in the latest index.
 3. Specify which version of the index you want for both Hackage and CHaP. Note
-   that it has to be higher or equal to the highest timestamp of the release
+   that it has to be higher or equal to the highest timestamp of the released
    versions of the packages that you want to use as dependencies:
 
    ```
@@ -127,6 +133,17 @@ your `build-depends` list on your cabal files.
 If you use Nix, see the [CHaP
 website](https://input-output-hk.github.io/cardano-haskell-packages/) on how to
 configure CHaP for haskell.nix.
+
+Sublibraries are private by default, so if you make direct use of any of the
+sublibraries declared in this repository, you shall enable the `+expose-sublibs`
+flag on the relevant dependency, either passing the flag `--constraint
+"ouroboros-consensus +expose-sublibs"` to cabal or adding the following snippet
+to your `cabal.project`:
+
+```
+package ouroboros-consensus
+  flags: +expose-sublibs
+```
 
 ## How to contribute to the project
 

--- a/cabal.project
+++ b/cabal.project
@@ -19,28 +19,47 @@ index-state:
   , cardano-haskell-packages 2023-08-02T14:18:01Z
 
 packages:
-  ./ouroboros-consensus
-  ./ouroboros-consensus-cardano
-  ./ouroboros-consensus-protocol
-  ./ouroboros-consensus-diffusion
+  ouroboros-consensus
+  ouroboros-consensus-cardano
+  ouroboros-consensus-protocol
+  ouroboros-consensus-diffusion
 
-tests: True
-benchmarks: True
+-- We want to always build the test-suites and benchmarks
+tests: true
+benchmarks: true
+
+--
+-- Expose sublibs
+--
+
+package ouroboros-consensus
+  flags: +expose-sublibs
+
+package ouroboros-consensus-protocol
+  flags: +expose-sublibs
+
+package ouroboros-consensus-diffusion
+  flags: +expose-sublibs
+
+--
+-- Enable assertions
+--
 
 package cardano-ledger-core
+  flags: +asserts
+
+package cardano-ledger-mary
   flags: +asserts
 
 package cardano-ledger-shelley
   flags: +asserts
 
-package fs-api
-  flags: +asserts
-
-package fs-sim
-  flags: +asserts
-
 package io-classes
   flags: +asserts
+
+-- https://github.com/input-output-hk/io-sim/issues/94
+-- package io-sim
+--   flags: +asserts
 
 package network-mux
   flags: +asserts
@@ -48,13 +67,13 @@ package network-mux
 package ouroboros-consensus
   flags: +asserts
 
+package ouroboros-consensus-protocols
+  flags: +asserts
+
 package ouroboros-consensus-cardano
   flags: +asserts
 
 package ouroboros-consensus-diffusion
-  flags: +asserts
-
-package ouroboros-consensus-protocol
   flags: +asserts
 
 package ouroboros-network
@@ -77,8 +96,3 @@ package strict-stm
 
 package text-short
   flags: +asserts
-
-if impl(ghc >= 9.6)
-  allow-newer:
-    , *:base
-    , *:ghc-prim

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -158,9 +158,6 @@ library byronspec
   import:          common-lib
 
   if flag(expose-sublibs)
-    visibility: private
-
-  else
     visibility: public
 
   hs-source-dirs:  src/byronspec
@@ -197,9 +194,6 @@ library byron-testlib
   import:          common-lib
 
   if flag(expose-sublibs)
-    visibility: private
-
-  else
     visibility: public
 
   hs-source-dirs:  src/byron-testlib
@@ -279,9 +273,6 @@ library shelley-testlib
   import:          common-lib
 
   if flag(expose-sublibs)
-    visibility: private
-
-  else
     visibility: public
 
   hs-source-dirs:  src/shelley-testlib
@@ -362,9 +353,6 @@ library cardano-testlib
   import:          common-lib
 
   if flag(expose-sublibs)
-    visibility: private
-
-  else
     visibility: public
 
   hs-source-dirs:  src/cardano-testlib
@@ -458,7 +446,10 @@ test-suite cardano-test
 library cardano-tools
   import:          common-lib
   hs-source-dirs:  src/tools
-  visibility:      public
+
+  if flag(expose-sublibs)
+    visibility: public
+
   exposed-modules:
     Cardano.Api.Any
     Cardano.Api.Protocol.Types

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/Consensus/Cardano/MiniProtocol/LocalTxSubmission/Server.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/Consensus/Cardano/MiniProtocol/LocalTxSubmission/Server.hs
@@ -2,8 +2,6 @@
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings  #-}
 
--- TODO: remove once we find out why GHC is reporting 'Redundant constraint: Show (LedgerSupportsMempool.ApplyTxErr blk)' in 'should_process_and_return'
-{-# OPTIONS_GHC -Wno-redundant-constraints #-}
 -- | Test that we can submit transactions to the mempool using the local
 -- submission server, in different Cardano eras.
 --
@@ -121,7 +119,6 @@ processTxs tracer mockedMempool txs =
 _should_process_and_return ::
      ( Show (Ledger.GenTx blk)
      , Eq   (Ledger.ApplyTxErr blk)
-     , Show (Ledger.ApplyTxErr blk)
      , Show (SubmitResult (LedgerSupportsMempool.ApplyTxErr blk))
      )
   => MockedMempool IO blk -> [(Ledger.GenTx blk, SubmitResult (LedgerSupportsMempool.ApplyTxErr blk))] -> IO ()

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -26,6 +26,11 @@ flag asserts
   manual:      False
   default:     False
 
+flag expose-sublibs
+  description: Expose all private sublibraries
+  manual:      True
+  default:     False
+
 common common-lib
   default-language: Haskell2010
   ghc-options:
@@ -64,41 +69,6 @@ library
     , Ouroboros.Consensus.Node.Run
     , Ouroboros.Consensus.Node.NetworkProtocolVersion
 
-  other-extensions:
-    BangPatterns
-    ConstraintKinds
-    DataKinds
-    DeriveAnyClass
-    DeriveFunctor
-    DeriveGeneric
-    EmptyDataDecls
-    FlexibleContexts
-    FlexibleInstances
-    FunctionalDependencies
-    GADTs
-    GeneralizedNewtypeDeriving
-    KindSignatures
-    LambdaCase
-    MultiParamTypeClasses
-    NamedFieldPuns
-    OverloadedStrings
-    PackageImports
-    PolyKinds
-    RankNTypes
-    RecordWildCards
-    ScopedTypeVariables
-    StandaloneDeriving
-    TemplateHaskell
-    TupleSections
-    TypeApplications
-    TypeFamilies
-    TypeFamilyDependencies
-    TypeInType
-    TypeOperators
-    UndecidableInstances
-    UndecidableSuperClasses
-    ViewPatterns
-
   build-depends:
     , base                         >=4.14   && <4.19
     , bytestring                   >=0.10   && <0.12
@@ -127,7 +97,10 @@ library
 library diffusion-testlib
   import:          common-lib
   hs-source-dirs:  src/diffusion-testlib
-  visibility:      public
+
+  if flag(expose-sublibs)
+    visibility: public
+
   exposed-modules:
     Test.ThreadNet.General
     Test.ThreadNet.Network
@@ -171,7 +144,10 @@ library diffusion-testlib
 
 library mock-testlib
   import:          common-lib
-  visibility:      public
+
+  if flag(expose-sublibs)
+    visibility: public
+
   hs-source-dirs:  src/mock-testlib
   exposed-modules:
     Test.Consensus.Ledger.Mock.Generators

--- a/ouroboros-consensus-protocol/ouroboros-consensus-protocol.cabal
+++ b/ouroboros-consensus-protocol/ouroboros-consensus-protocol.cabal
@@ -24,9 +24,25 @@ flag asserts
   manual:      False
   default:     False
 
-library
-  hs-source-dirs:   src/ouroboros-consensus-protocol
+flag expose-sublibs
+  description: Expose all private sublibraries
+  manual:      True
+  default:     False
+
+common common-lib
   default-language: Haskell2010
+  ghc-options:
+    -Wall -Wcompat -Wincomplete-uni-patterns
+    -Wincomplete-record-updates -Wpartial-fields -Widentities
+    -Wredundant-constraints -Wmissing-export-lists -Wunused-packages
+    -Wno-unticked-promoted-constructors
+
+  if flag(asserts)
+    ghc-options: -fno-ignore-asserts
+
+library
+  import:          common-lib
+  hs-source-dirs:  src/ouroboros-consensus-protocol
   exposed-modules:
     Ouroboros.Consensus.Protocol.Ledger.HotKey
     Ouroboros.Consensus.Protocol.Ledger.Util
@@ -57,25 +73,18 @@ library
     , serialise
     , text
 
-  ghc-options:
-    -Wall -Wcompat -Wincomplete-uni-patterns
-    -Wincomplete-record-updates -Wpartial-fields -Widentities
-    -Wredundant-constraints -Wmissing-export-lists -Wunused-packages
-
-  if flag(asserts)
-    ghc-options: -fno-ignore-asserts
-
 library protocol-testlib
-  visibility:       public
-  hs-source-dirs:   src/protocol-testlib
-  default-language: Haskell2010
-  exposed-modules:  Test.Consensus.Protocol.Serialisation.Generators
+  import:          common-lib
+
+  if flag(expose-sublibs)
+    visibility: public
+
+  hs-source-dirs:  src/protocol-testlib
+  exposed-modules: Test.Consensus.Protocol.Serialisation.Generators
   build-depends:
     , base
-    , bytestring
     , cardano-crypto-class
     , cardano-crypto-tests
-    , cardano-ledger-core
     , cardano-ledger-shelley-test
     , cardano-protocol-tpraos
     , cardano-slotting

--- a/ouroboros-consensus-protocol/src/protocol-testlib/Test/Consensus/Protocol/Serialisation/Generators.hs
+++ b/ouroboros-consensus-protocol/src/protocol-testlib/Test/Consensus/Protocol/Serialisation/Generators.hs
@@ -1,20 +1,19 @@
-{-# LANGUAGE DerivingStrategies  #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 -- | Generators suitable for serialisation. Note that these are not guaranteed
 -- to be semantically correct at all, only structurally correct.
-module Test.Consensus.Protocol.Serialisation.Generators where
+module Test.Consensus.Protocol.Serialisation.Generators () where
 
 import           Cardano.Crypto.KES (signedKES)
 import           Cardano.Crypto.VRF (evalCertified)
-import           Cardano.Ledger.Crypto (Crypto)
 import           Cardano.Protocol.TPraos.BHeader (HashHeader, PrevHash (..))
 import           Cardano.Protocol.TPraos.OCert (KESPeriod (KESPeriod),
                      OCert (OCert))
 import           Cardano.Slotting.Block (BlockNo (BlockNo))
 import           Cardano.Slotting.Slot (SlotNo (SlotNo),
                      WithOrigin (At, Origin))
-import           Data.ByteString (ByteString)
 import           Ouroboros.Consensus.Protocol.Praos (PraosState (PraosState))
 import qualified Ouroboros.Consensus.Protocol.Praos as Praos
 import           Ouroboros.Consensus.Protocol.Praos.Header (Header (Header),

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -46,8 +46,8 @@ common common-test
   ghc-options: -threaded -rtsopts
 
 library
-  import:           common-lib
-  hs-source-dirs:   src/ouroboros-consensus
+  import:          common-lib
+  hs-source-dirs:  src/ouroboros-consensus
   exposed-modules:
     Data.SOP.Counting
     Data.SOP.Functors
@@ -254,41 +254,6 @@ library
     Ouroboros.Consensus.Util.TraceSize
     Ouroboros.Consensus.Util.Versioned
 
-  other-extensions:
-    BangPatterns
-    ConstraintKinds
-    DataKinds
-    DeriveAnyClass
-    DeriveFunctor
-    DeriveGeneric
-    EmptyDataDecls
-    FlexibleContexts
-    FlexibleInstances
-    FunctionalDependencies
-    GADTs
-    GeneralizedNewtypeDeriving
-    KindSignatures
-    LambdaCase
-    MultiParamTypeClasses
-    NamedFieldPuns
-    OverloadedStrings
-    PackageImports
-    PolyKinds
-    RankNTypes
-    RecordWildCards
-    ScopedTypeVariables
-    StandaloneDeriving
-    TemplateHaskell
-    TupleSections
-    TypeApplications
-    TypeFamilies
-    TypeFamilyDependencies
-    TypeInType
-    TypeOperators
-    UndecidableInstances
-    UndecidableSuperClasses
-    ViewPatterns
-
   build-depends:
     , base                         >=4.14     && <4.19
     , base16-bytestring
@@ -332,7 +297,10 @@ library
 library consensus-testlib
   import:          common-lib
   hs-source-dirs:  src/consensus-testlib
-  visibility:      public
+
+  if flag(expose-sublibs)
+    visibility: public
+
   exposed-modules:
     Test.Util.BoolProps
     Test.Util.ChainDB
@@ -411,7 +379,10 @@ library consensus-testlib
 
 library mock-block
   import:          common-lib
-  visibility:      public
+
+  if flag(expose-sublibs)
+    visibility: public
+
   hs-source-dirs:  src/mock-block
   exposed-modules:
     Ouroboros.Consensus.Mock.Ledger
@@ -456,7 +427,10 @@ library mock-block
 
 library mempool-test-utils
   import:          common-lib
-  visibility:      public
+
+  if flag(expose-sublibs)
+    visibility: public
+
   hs-source-dirs:  src/mempool-test-utils
   exposed-modules: Test.Consensus.Mempool.Mocked
   build-depends:
@@ -470,9 +444,6 @@ library tutorials
   import:         common-lib
 
   if flag(expose-sublibs)
-    visibility: private
-
-  else
     visibility: public
 
   hs-source-dirs: src/tutorials

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/EarlyExit.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/EarlyExit.hs
@@ -8,11 +8,6 @@
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE UndecidableInstances       #-}
 
--- Regression in GHC 9.6.1: spurious "Redundant constraint", where the constraint is inside a
--- quantified constraint
--- https://gitlab.haskell.org/ghc/ghc/-/issues/23323
-{-# OPTIONS_GHC -Wno-redundant-constraints #-}
-
 module Ouroboros.Consensus.Util.EarlyExit (
     exitEarly
   , withEarlyExit

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/BlockchainTime/Simple.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/BlockchainTime/Simple.hs
@@ -11,11 +11,6 @@
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE UndecidableInstances       #-}
 
--- Get an invalid redundant constraint warning due to
--- https://gitlab.haskell.org/ghc/ghc/-/issues/23323
--- which hopefully will be fixed in ghc-9.6.3.
-{-# OPTIONS_GHC -Wno-redundant-constraints #-}
-
 -- | Tests for the computation of blockchain time.
 --
 -- The @BlockchainTime@ in consensus used to be ubiquitous throughout the code


### PR DESCRIPTION
- Make proper use of `flag(expose-sublibs)`.
- Remove unneeded `allow-newer` constraints.
- Uniformize the GHC options of `ouroboros-consensus-protocol:protocol-testlib`.
- Remove `other-extensions`.
