### PR TITLE
Fixup tags in create-release.hs

### DIFF
--- a/scripts/release/create-release.hs
+++ b/scripts/release/create-release.hs
@@ -252,7 +252,7 @@ createGitCommit package next = do
 
 createGitTag :: FilePath -> Version -> Shell ()
 createGitTag package next = do
-  let tagName = packageNameWithVersion package next
+  let tagName = "release-" <> packageNameWithVersion package next
   liftIO $ putStrLn $ "Creating git tag: " <> show tagName
   procs "git" ["tag", packageNameWithVersion]
 

--- a/scripts/release/create-release.hs
+++ b/scripts/release/create-release.hs
@@ -85,10 +85,6 @@ main = sh do
       unless skipGit do
         createGitCommit packageName next
 
-        -- note that this tags each package release with the commit that released
-        -- that package, not the commit with all of the packages released
-        createGitTag packageName next
-
 -- | Pairs of packages with a list of their dependencies. We use the
 --   dependencies to calculate which version changes should require a version
 --   bump in a package's dependencies as well.
@@ -249,12 +245,6 @@ createGitCommit package next = do
         "release " <> packageNameWithVersion package next
   liftIO $ putStrLn $ "Creating git commit: " <> show commitString
   procs "git" ["commit", "-am", commitString] mempty
-
-createGitTag :: FilePath -> Version -> Shell ()
-createGitTag package next = do
-  let tagName = "release-" <> packageNameWithVersion package next
-  liftIO $ putStrLn $ "Creating git tag: " <> show tagName
-  procs "git" ["tag", packageNameWithVersion]
 
 packageNameWithVersion :: FilePath -> Version -> Text
 packageNameWithVersion package v = Text.pack $


### PR DESCRIPTION
The first commit adds the `release-` prefix to the tag names the tool makes.

The second commit removes the ability to make tags from the script. As-is, this script tags the commits that it creates. However, we don't want to tag those commits, we want to instead tag the merge of the PR that adds those commits to the `origin/main`.