### PR TITLE
First tick across the era boundary when translating the ledger/chain-dep state

### DIFF
--- a/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Node.hs
+++ b/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Node.hs
@@ -133,10 +133,11 @@ byronBlockForging maxTxCapacityOverrides creds = BlockForging {
       forgeLabel       = blcLabel creds
     , canBeLeader
     , updateForgeState = \_ _ _ -> return $ ForgeStateUpdated ()
-    , checkCanForge    = \cfg slot tickedPBftState _isLeader () ->
+    , checkCanForge    = \cfg tickedLedgerView slot tickedPBftState _isLeader () ->
                              pbftCheckCanForge
                                (configConsensus cfg)
                                canBeLeader
+                               tickedLedgerView
                                slot
                                tickedPBftState
     , forgeBlock       = \cfg -> return ....: forgeByronBlock cfg maxTxCapacityOverrides

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/CanHardFork.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/CanHardFork.hs
@@ -73,6 +73,7 @@ import           Ouroboros.Consensus.Protocol.PBFT.State (PBftState)
 import qualified Ouroboros.Consensus.Protocol.PBFT.State as PBftState
 import           Ouroboros.Consensus.Protocol.Praos (Praos)
 import qualified Ouroboros.Consensus.Protocol.Praos as Praos
+import           Ouroboros.Consensus.Protocol.Praos.Translate ()
 import           Ouroboros.Consensus.Protocol.TPraos
 import qualified Ouroboros.Consensus.Protocol.TPraos as TPraos
 import           Ouroboros.Consensus.Protocol.Translate (TranslateProto)
@@ -407,12 +408,12 @@ translateLedgerStateByronToShelleyWrapper =
 translateChainDepStateByronToShelleyWrapper ::
      RequiringBoth
        WrapConsensusConfig
-       (Translate WrapChainDepState)
+       (TickedTranslate WrapChainDepState)
        ByronBlock
        (ShelleyBlock (TPraos c) (ShelleyEra c))
 translateChainDepStateByronToShelleyWrapper =
     RequireBoth $ \_ (WrapConsensusConfig cfgShelley) ->
-      Translate $ \_ (WrapChainDepState pbftState) ->
+      Translate $ \_ (Comp (WrapTickedChainDepState (TickedPBftState pbftState))) ->
         WrapChainDepState $
           translateChainDepStateByronToShelley cfgShelley pbftState
 

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/CanHardFork.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/CanHardFork.hs
@@ -139,7 +139,7 @@ byronTransition ByronPartialLedgerConfig{..} shelleyMajorVersion state =
     . Byron.Inspect.protocolUpdates byronLedgerConfig
     $ state
   where
-    ByronTransitionInfo transitionInfo = byronLedgerTransition state
+    ByronTransitionInfo transitionInfo tipBlockNo = byronLedgerTransition state
 
     genesis = byronLedgerConfig
     k       = CC.Genesis.gdK $ CC.Genesis.configGenesisData genesis
@@ -192,7 +192,7 @@ byronTransition ByronPartialLedgerConfig{..} shelleyMajorVersion state =
     isReallyStable (BlockNo bno) = distance >= CC.unBlockCount k
       where
         distance :: Word64
-        distance = case byronLedgerTipBlockNo state of
+        distance = case tipBlockNo of
                      Origin                  -> bno + 1
                      NotOrigin (BlockNo tip) -> tip - bno
 
@@ -393,7 +393,7 @@ translateLedgerStateByronToShelleyWrapper =
         shelleyLedgerTip =
           translatePointByronToShelley
             (ledgerTipPoint ledgerByron)
-            (byronLedgerTipBlockNo ledgerByron)
+            (byronLedgerTipBlockNo $ byronLedgerTransition ledgerByron)
       , shelleyLedgerState =
           SL.translateToShelleyLedgerState
             (toFromByronTranslationContext (shelleyLedgerGenesis cfgShelley))

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/CanHardFork.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/CanHardFork.hs
@@ -61,8 +61,7 @@ import           Ouroboros.Consensus.Cardano.Block
 import           Ouroboros.Consensus.Forecast
 import           Ouroboros.Consensus.HardFork.Combinator
 import           Ouroboros.Consensus.HardFork.Combinator.State.Types
-import           Ouroboros.Consensus.HardFork.History (Bound (boundSlot),
-                     addSlots)
+import           Ouroboros.Consensus.HardFork.History (Bound (..), addSlots)
 import           Ouroboros.Consensus.HardFork.Simple
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
@@ -389,7 +388,7 @@ translateLedgerStateByronToShelleyWrapper ::
        (ShelleyBlock (TPraos c) (ShelleyEra c))
 translateLedgerStateByronToShelleyWrapper =
     RequireBoth $ \_ (WrapLedgerConfig cfgShelley) ->
-    Translate   $ \epochNo ledgerByron ->
+    Translate   $ \bound ledgerByron ->
       ShelleyLedgerState {
         shelleyLedgerTip =
           translatePointByronToShelley
@@ -398,7 +397,7 @@ translateLedgerStateByronToShelleyWrapper =
       , shelleyLedgerState =
           SL.translateToShelleyLedgerState
             (toFromByronTranslationContext (shelleyLedgerGenesis cfgShelley))
-            epochNo
+            (boundEpoch bound)
             (byronLedgerState ledgerByron)
       , shelleyLedgerTransition =
           ShelleyTransitionInfo{shelleyAfterVoting = 0}
@@ -514,7 +513,7 @@ translateLedgerStateShelleyToAllegraWrapper ::
        (ShelleyBlock (TPraos c) (AllegraEra c))
 translateLedgerStateShelleyToAllegraWrapper =
     ignoringBoth $
-      Translate $ \_epochNo ->
+      Translate $ \_bound ->
         unComp . SL.translateEra' () . Comp
 
 translateTxShelleyToAllegraWrapper ::
@@ -546,7 +545,7 @@ translateLedgerStateAllegraToMaryWrapper ::
        (ShelleyBlock (TPraos c) (MaryEra c))
 translateLedgerStateAllegraToMaryWrapper =
     ignoringBoth $
-      Translate $ \_epochNo ->
+      Translate $ \_bound ->
         unComp . SL.translateEra' () . Comp
 
 {-------------------------------------------------------------------------------
@@ -582,7 +581,7 @@ translateLedgerStateMaryToAlonzoWrapper ::
        (ShelleyBlock (TPraos c) (AlonzoEra c))
 translateLedgerStateMaryToAlonzoWrapper =
     RequireBoth $ \_cfgMary cfgAlonzo ->
-      Translate $ \_epochNo ->
+      Translate $ \_bound ->
         unComp . SL.translateEra' (getAlonzoTranslationContext cfgAlonzo) . Comp
 
 getAlonzoTranslationContext ::
@@ -623,7 +622,7 @@ translateLedgerStateAlonzoToBabbageWrapper ::
        (ShelleyBlock (Praos c) (BabbageEra c))
 translateLedgerStateAlonzoToBabbageWrapper =
     RequireBoth $ \_cfgAlonzo _cfgBabbage ->
-      Translate $ \_epochNo ->
+      Translate $ \_bound ->
         unComp . SL.translateEra' () . Comp . transPraosLS
   where
     transPraosLS ::
@@ -685,7 +684,7 @@ translateLedgerStateBabbageToConwayWrapper ::
        (ShelleyBlock (Praos c) (ConwayEra c))
 translateLedgerStateBabbageToConwayWrapper =
     RequireBoth $ \_cfgBabbage cfgConway ->
-      Translate $ \_epochNo ->
+      Translate $ \_bound ->
         unComp . SL.translateEra' (getConwayTranslationContext cfgConway) . Comp
 
 getConwayTranslationContext ::

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node/Praos.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node/Praos.hs
@@ -101,7 +101,7 @@ praosSharedBlockForging
         updateForgeState = \_ curSlot _ ->
           forgeStateUpdateInfoFromUpdateInfo
             <$> HotKey.evolve hotKey (slotToPeriod curSlot),
-        checkCanForge = \cfg curSlot _tickedChainDepState _isLeader ->
+        checkCanForge = \cfg _tickedLedgerView curSlot _tickedChainDepState _isLeader ->
           praosCheckCanForge
             (configConsensus cfg)
             curSlot,

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node/TPraos.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node/TPraos.hs
@@ -143,7 +143,7 @@ shelleySharedBlockForging hotKey slotToPeriod credentials maxTxCapacityOverrides
       , updateForgeState = \_ curSlot _ ->
                                forgeStateUpdateInfoFromUpdateInfo <$>
                                  HotKey.evolve hotKey (slotToPeriod curSlot)
-      , checkCanForge    = \cfg curSlot _tickedChainDepState ->
+      , checkCanForge    = \cfg _tickedLedgerView curSlot _tickedChainDepState ->
                                tpraosCheckCanForge
                                  (configConsensus cfg)
                                  forgingVRFHash

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Protocol/Abstract.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Protocol/Abstract.hs
@@ -47,6 +47,8 @@ import           Data.Word (Word64)
 import           GHC.Generics (Generic)
 import           NoThunks.Class (NoThunks)
 import           Numeric.Natural (Natural)
+import           Ouroboros.Consensus.HardFork.Combinator.Abstract.SingleEraBlock
+                     (SingleEraProtocol)
 import           Ouroboros.Consensus.Protocol.Abstract (CanBeLeader,
                      ChainDepState, ConsensusConfig, ConsensusProtocol,
                      IsLeader, LedgerView, ValidateView)
@@ -193,6 +195,7 @@ class ProtocolHeaderSupportsLedger proto where
 
 class
   ( ConsensusProtocol proto,
+    SingleEraProtocol proto,
     Typeable (ShelleyProtocolHeader proto),
     ProtocolHeaderSupportsEnvelope proto,
     ProtocolHeaderSupportsKES proto,

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/ShelleyHFC.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/ShelleyHFC.hs
@@ -341,12 +341,12 @@ translateChainDepStateAcrossShelley ::
      )
   => RequiringBoth
        WrapConsensusConfig
-       (Translate WrapChainDepState)
+       (TickedTranslate WrapChainDepState)
        (ShelleyBlock protoFrom eraFrom)
        (ShelleyBlock protoTo eraTo)
 translateChainDepStateAcrossShelley =
     ignoringBoth $
-      Translate $ \_bound (WrapChainDepState chainDepState) ->
+      Translate $ \_bound (Comp (WrapTickedChainDepState chainDepState)) ->
         -- Same protocol, same 'ChainDepState'. Note that we don't have to apply
         -- any changes related to an epoch transition, this is already done when
         -- ticking the state.

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/ShelleyHFC.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/ShelleyHFC.hs
@@ -291,7 +291,7 @@ translateChainDepStateAcrossShelley ::
        (ShelleyBlock protoTo eraTo)
 translateChainDepStateAcrossShelley =
     ignoringBoth $
-      Translate $ \_epochNo (WrapChainDepState chainDepState) ->
+      Translate $ \_bound (WrapChainDepState chainDepState) ->
         -- Same protocol, same 'ChainDepState'. Note that we don't have to apply
         -- any changes related to an epoch transition, this is already done when
         -- ticking the state.

--- a/ouroboros-consensus-cardano/src/unstable-byron-testlib/Test/Consensus/Byron/Examples.hs
+++ b/ouroboros-consensus-cardano/src/unstable-byron-testlib/Test/Consensus/Byron/Examples.hs
@@ -168,9 +168,8 @@ exampleChainDepState = S.fromList signers
 
 emptyLedgerState :: LedgerState ByronBlock
 emptyLedgerState = ByronLedgerState {
-      byronLedgerTipBlockNo = Origin
-    , byronLedgerState      = initState
-    , byronLedgerTransition = ByronTransitionInfo Map.empty
+      byronLedgerState      = initState
+    , byronLedgerTransition = ByronTransitionInfo Map.empty Origin
     }
   where
     initState :: CC.Block.ChainValidationState

--- a/ouroboros-consensus-cardano/src/unstable-byron-testlib/Test/Consensus/Byron/Generators.hs
+++ b/ouroboros-consensus-cardano/src/unstable-byron-testlib/Test/Consensus/Byron/Generators.hs
@@ -260,10 +260,12 @@ instance Arbitrary CC.Del.Map where
   arbitrary = CC.Del.fromList <$> arbitrary
 
 instance Arbitrary ByronTransition where
-  arbitrary = ByronTransitionInfo . Map.fromList <$> arbitrary
+  arbitrary = ByronTransitionInfo
+    <$> (Map.fromList <$> arbitrary)
+    <*> arbitrary
 
 instance Arbitrary (LedgerState ByronBlock) where
-  arbitrary = ByronLedgerState <$> arbitrary <*> arbitrary <*> arbitrary
+  arbitrary = ByronLedgerState <$> arbitrary <*> arbitrary
 
 instance Arbitrary (TipInfoIsEBB ByronBlock) where
   arbitrary = TipInfoIsEBB <$> arbitrary <*> elements [IsEBB, IsNotEBB]

--- a/ouroboros-consensus-cardano/src/unstable-cardano-testlib/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-testlib/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
@@ -160,7 +160,7 @@ instance ShelleyBasedHardForkConstraints proto1 era1 proto2 era2
       translateLedgerState =
           InPairs.RequireBoth
         $ \_cfg1 cfg2 -> HFC.Translate
-        $ \_epochNo ->
+        $ \_bound ->
               unComp
             . SL.translateEra'
                 (shelleyLedgerTranslationContext (unwrapLedgerConfig cfg2))

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Forging.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Forging.hs
@@ -139,7 +139,7 @@ runForge epochSize_ nextSlot opts chainDB blockForging cfg = do
         -- Check if any forger is slot leader
         let
             checkShouldForge' f =
-              checkShouldForge f nullTracer cfg currentSlot tickedChainDepState
+              checkShouldForge f nullTracer cfg currentSlot ledgerView tickedChainDepState
 
         checks <- zip blockForging <$> liftIO (mapM checkShouldForge' blockForging)
 

--- a/ouroboros-consensus-cardano/src/unstable-shelley-testlib/Test/Consensus/Shelley/Examples.hs
+++ b/ouroboros-consensus-cardano/src/unstable-shelley-testlib/Test/Consensus/Shelley/Examples.hs
@@ -37,6 +37,7 @@ import qualified Ouroboros.Consensus.Protocol.Praos.Header as Praos
 import           Ouroboros.Consensus.Protocol.Praos.Translate ()
 import           Ouroboros.Consensus.Protocol.TPraos (TPraos,
                      TPraosState (TPraosState))
+import qualified Ouroboros.Consensus.Protocol.TPraos as TPraos
 import           Ouroboros.Consensus.Protocol.Translate (TranslateProto,
                      translateChainDepState)
 import           Ouroboros.Consensus.Shelley.Eras
@@ -230,7 +231,10 @@ fromShelleyLedgerExamplesPraos ShelleyLedgerExamples {
     , shelleyLedgerTransition = ShelleyTransitionInfo {shelleyAfterVoting = 0}
     }
     chainDepState = translateChainDepState @(TPraos (EraCrypto era)) @(Praos (EraCrypto era))
-      $ TPraosState (NotOrigin 1) sleChainDepState
+      TPraos.TickedChainDepState {
+          TPraos.tickedTPraosStateChainDepState = sleChainDepState
+        , TPraos.tickedTPraosStateSlot          = SlotNo 1
+        }
     extLedgerState = ExtLedgerState
                        ledgerState
                        (genesisHeaderState chainDepState)

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -227,6 +227,7 @@ test-suite consensus-test
     , quiet
     , serialise
     , si-timers
+    , sop-core
     , sop-extras
     , strict-sop-core
     , tasty

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -352,6 +352,7 @@ forkBlockForging IS{..} blockForging =
                 (forgeStateInfoTracer tracers))
               cfg
               currentSlot
+              ledgerView
               tickedChainDepState
           case shouldForge of
             ForgeStateUpdateError err -> do

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator.hs
@@ -437,7 +437,7 @@ ledgerState_AtoB = InPairs.ignoringBoth $ Translate $ \_ (Comp st) -> LgrB {
 chainDepState_AtoB ::
      RequiringBoth
        WrapConsensusConfig
-       (Translate WrapChainDepState)
+       (TickedTranslate WrapChainDepState)
        BlockA
        BlockB
 chainDepState_AtoB = InPairs.ignoringBoth $ Translate $ \_ _ ->

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/A.hs
@@ -35,6 +35,7 @@ module Test.Consensus.HardFork.Combinator.A (
   , LedgerState (..)
   , NestedCtxt_ (..)
   , StorageConfig (..)
+  , Ticked (..)
   , TxId (..)
   ) where
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/A.hs
@@ -103,12 +103,16 @@ data instance ConsensusConfig ProtocolA = CfgA {
   deriving NoThunks via OnlyCheckWhnfNamed "CfgA" (ConsensusConfig ProtocolA)
 
 instance SingleEraProtocol ProtocolA where
+  type HorizonView ProtocolA = ()
+
+  projectHorizonView        _ _ = TickedTrivial
   eraTransitionHorizonView _cfg = TickedTrivial
+
+  tickChainDepState_  _ _ _ _   = TickedTrivial
 
 instance ConsensusProtocol ProtocolA where
   type ChainDepState ProtocolA = ()
   type LedgerView    ProtocolA = ()
-  type HorizonView   ProtocolA = ()
   type IsLeader      ProtocolA = ()
   type CanBeLeader   ProtocolA = ()
   type ValidateView  ProtocolA = ()
@@ -121,9 +125,8 @@ instance ConsensusProtocol ProtocolA where
 
   protocolSecurityParam = cfgA_k
 
-  projectHorizonView _ _ = TickedTrivial
+  tickChainDepState = tickChainDepStateDefault
 
-  tickChainDepState_    _ _ _ _   = TickedTrivial
   updateChainDepState   _ _ _ _ _ = return ()
   reupdateChainDepState _ _ _ _ _ = ()
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/A.hs
@@ -102,6 +102,9 @@ data instance ConsensusConfig ProtocolA = CfgA {
     }
   deriving NoThunks via OnlyCheckWhnfNamed "CfgA" (ConsensusConfig ProtocolA)
 
+instance SingleEraProtocol ProtocolA where
+  eraTransitionHorizonView _cfg = TickedTrivial
+
 instance ConsensusProtocol ProtocolA where
   type ChainDepState ProtocolA = ()
   type LedgerView    ProtocolA = ()

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/A.hs
@@ -105,21 +105,24 @@ data instance ConsensusConfig ProtocolA = CfgA {
 instance ConsensusProtocol ProtocolA where
   type ChainDepState ProtocolA = ()
   type LedgerView    ProtocolA = ()
+  type HorizonView   ProtocolA = ()
   type IsLeader      ProtocolA = ()
   type CanBeLeader   ProtocolA = ()
   type ValidateView  ProtocolA = ()
   type ValidationErr ProtocolA = Void
 
-  checkIsLeader CfgA{..} () slot _ =
+  checkIsLeader CfgA{..} () _ slot _ =
       if slot `Set.member` cfgA_leadInSlots
       then Just ()
       else Nothing
 
   protocolSecurityParam = cfgA_k
 
-  tickChainDepState     _ _ _ _ = TickedTrivial
-  updateChainDepState   _ _ _ _ = return ()
-  reupdateChainDepState _ _ _ _ = ()
+  projectHorizonView _ _ = TickedTrivial
+
+  tickChainDepState_    _ _ _ _   = TickedTrivial
+  updateChainDepState   _ _ _ _ _ = return ()
+  reupdateChainDepState _ _ _ _ _ = ()
 
 data BlockA = BlkA {
       blkA_header :: Header BlockA
@@ -313,7 +316,7 @@ blockForgingA = BlockForging {
      forgeLabel       = "BlockA"
    , canBeLeader      = ()
    , updateForgeState = \_ _ _ -> return $ ForgeStateUpdated ()
-   , checkCanForge    = \_ _ _ _ _ -> return ()
+   , checkCanForge    = \_ _ _ _ _ _ -> return ()
    , forgeBlock       = \cfg bno slot st txs proof -> return $
        forgeBlockA cfg bno slot st (fmap txForgetValidated txs) proof
    }

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/B.hs
@@ -90,21 +90,24 @@ data instance ConsensusConfig ProtocolB = CfgB {
 instance ConsensusProtocol ProtocolB where
   type ChainDepState ProtocolB = ()
   type LedgerView    ProtocolB = ()
+  type HorizonView   ProtocolB = ()
   type IsLeader      ProtocolB = ()
   type CanBeLeader   ProtocolB = ()
   type ValidateView  ProtocolB = ()
   type ValidationErr ProtocolB = Void
 
-  checkIsLeader CfgB{..} () slot _ =
+  checkIsLeader CfgB{..} () _ slot _ =
       if slot `Set.member` cfgB_leadInSlots
       then Just ()
       else Nothing
 
   protocolSecurityParam = cfgB_k
 
-  tickChainDepState     _ _ _ _ = TickedTrivial
-  updateChainDepState   _ _ _ _ = return ()
-  reupdateChainDepState _ _ _ _ = ()
+  projectHorizonView _ _ = TickedTrivial
+
+  tickChainDepState_    _ _ _ _   = TickedTrivial
+  updateChainDepState   _ _ _ _ _ = return ()
+  reupdateChainDepState _ _ _ _ _ = ()
 
 data BlockB = BlkB {
       blkB_header :: Header BlockB
@@ -239,7 +242,7 @@ blockForgingB = BlockForging {
      forgeLabel       = "BlockB"
    , canBeLeader      = ()
    , updateForgeState = \_ _ _ -> return $ ForgeStateUpdated ()
-   , checkCanForge    = \_ _ _ _ _ -> return ()
+   , checkCanForge    = \_ _ _ _ _ _ -> return ()
    , forgeBlock       = \cfg bno slot st txs proof -> return $
        forgeBlockB cfg bno slot st (fmap txForgetValidated txs) proof
    }

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/B.hs
@@ -88,12 +88,16 @@ data instance ConsensusConfig ProtocolB = CfgB {
   deriving NoThunks via OnlyCheckWhnfNamed "CfgB" (ConsensusConfig ProtocolB)
 
 instance SingleEraProtocol ProtocolB where
+  type HorizonView ProtocolB = ()
+
+  projectHorizonView        _ _ = TickedTrivial
   eraTransitionHorizonView _cfg = TickedTrivial
+
+  tickChainDepState_  _ _ _ _   = TickedTrivial
 
 instance ConsensusProtocol ProtocolB where
   type ChainDepState ProtocolB = ()
   type LedgerView    ProtocolB = ()
-  type HorizonView   ProtocolB = ()
   type IsLeader      ProtocolB = ()
   type CanBeLeader   ProtocolB = ()
   type ValidateView  ProtocolB = ()
@@ -106,9 +110,8 @@ instance ConsensusProtocol ProtocolB where
 
   protocolSecurityParam = cfgB_k
 
-  projectHorizonView _ _ = TickedTrivial
+  tickChainDepState = tickChainDepStateDefault
 
-  tickChainDepState_    _ _ _ _   = TickedTrivial
   updateChainDepState   _ _ _ _ _ = return ()
   reupdateChainDepState _ _ _ _ _ = ()
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/B.hs
@@ -87,6 +87,9 @@ data instance ConsensusConfig ProtocolB = CfgB {
     }
   deriving NoThunks via OnlyCheckWhnfNamed "CfgB" (ConsensusConfig ProtocolB)
 
+instance SingleEraProtocol ProtocolB where
+  eraTransitionHorizonView _cfg = TickedTrivial
+
 instance ConsensusProtocol ProtocolB where
   type ChainDepState ProtocolB = ()
   type LedgerView    ProtocolB = ()

--- a/ouroboros-consensus-protocol/src/ouroboros-consensus-protocol/Ouroboros/Consensus/Protocol/Praos.hs
+++ b/ouroboros-consensus-protocol/src/ouroboros-consensus-protocol/Ouroboros/Consensus/Protocol/Praos.hs
@@ -74,6 +74,8 @@ import           GHC.Generics (Generic)
 import           NoThunks.Class (NoThunks)
 import           Numeric.Natural (Natural)
 import           Ouroboros.Consensus.Block (WithOrigin (NotOrigin))
+import           Ouroboros.Consensus.HardFork.Combinator.Abstract.SingleEraBlock
+                     (SingleEraProtocol (..))
 import qualified Ouroboros.Consensus.HardFork.History as History
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Protocol.Ledger.HotKey (HotKey)
@@ -365,6 +367,9 @@ deriving instance PraosCrypto c => Eq (PraosValidationErr c)
 deriving instance PraosCrypto c => NoThunks (PraosValidationErr c)
 
 deriving instance PraosCrypto c => Show (PraosValidationErr c)
+
+instance SingleEraProtocol (Praos c) where
+  eraTransitionHorizonView _cfg = TickedTrivial
 
 instance PraosCrypto c => ConsensusProtocol (Praos c) where
   type ChainDepState (Praos c) = PraosState c

--- a/ouroboros-consensus-protocol/src/ouroboros-consensus-protocol/Ouroboros/Consensus/Protocol/Translate.hs
+++ b/ouroboros-consensus-protocol/src/ouroboros-consensus-protocol/Ouroboros/Consensus/Protocol/Translate.hs
@@ -16,11 +16,4 @@ class TranslateProto protoFrom protoTo
   translateTickedLedgerView ::
     Ticked (LedgerView protoFrom) -> Ticked (LedgerView protoTo)
   translateChainDepState ::
-    ChainDepState protoFrom -> ChainDepState protoTo
-
--- | Degenerate instance - we may always translate from a protocol to itself.
-instance TranslateProto singleProto singleProto
-  where
-  translateConsensusConfig = id
-  translateTickedLedgerView = id
-  translateChainDepState = id
+    Ticked (ChainDepState protoFrom) -> ChainDepState protoTo

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Abstract/SingleEraBlock.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Abstract/SingleEraBlock.hs
@@ -9,6 +9,7 @@
 module Ouroboros.Consensus.HardFork.Combinator.Abstract.SingleEraBlock (
     -- * Single era block
     SingleEraBlock (..)
+  , SingleEraProtocol (..)
   , proxySingle
   , singleEraTransition'
     -- * Era index
@@ -45,12 +46,20 @@ import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.Ledger.SupportsPeerSelection
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Node.InitStorage
+import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Storage.Serialisation
+import           Ouroboros.Consensus.Ticked (Ticked)
 import           Ouroboros.Consensus.Util.Condense
 
 {-------------------------------------------------------------------------------
   SingleEraBlock
 -------------------------------------------------------------------------------}
+
+-- | Protocols which can be used as part of a 'HardForkProtocol'.
+class SingleEraProtocol p where
+  -- | The horizon view that will be used when ticking across an era boundary.
+  -- In all other cases, the HFC logic will use 'projectHorizonView'.
+  eraTransitionHorizonView :: ConsensusConfig p -> Ticked (HorizonView p)
 
 -- | Blocks from which we can assemble a hard fork
 class ( LedgerSupportsProtocol blk
@@ -67,6 +76,7 @@ class ( LedgerSupportsProtocol blk
       , ConfigSupportsNode blk
       , NodeInitStorage blk
       , BlockSupportsMetrics blk
+      , SingleEraProtocol (BlockProtocol blk)
         -- Instances required to support testing
       , Eq   (GenTx blk)
       , Eq   (Validated (GenTx blk))

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Embed/Nary.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Embed/Nary.hs
@@ -34,6 +34,7 @@ import qualified Ouroboros.Consensus.HardFork.Combinator.State as State
 import qualified Ouroboros.Consensus.HardFork.History as History
 import           Ouroboros.Consensus.HeaderValidation (AnnTip, HeaderState (..),
                      genesisHeaderState)
+import           Ouroboros.Consensus.Ledger.Abstract (LedgerResult (..))
 import           Ouroboros.Consensus.Ledger.Extended (ExtLedgerState (..))
 import           Ouroboros.Consensus.Storage.Serialisation
 import           Ouroboros.Consensus.TypeFamilyWrappers
@@ -205,10 +206,14 @@ injectInitialExtLedgerState cfg extLedgerState0 =
 
     targetEraLedgerState :: LedgerState (HardForkBlock (x ': xs))
     targetEraLedgerState =
-        HardForkLedgerState $
+        -- Note that we are discarding the ledger events here that might arise
+        -- via the ticking (by zero slots) performed in 'extendToEraOfSlot'. Usually,
+        -- only testnets and benchmark scenarios have hard forks scheduled for
+        -- the first slot, so this seems acceptable.
+        HardForkLedgerState . lrResult $
           -- We can immediately extend it to the right slot, executing any
           -- scheduled hard forks in the first slot
-          extendToSlot
+          extendToEraOfSlot
             (configLedger cfg)
             (SlotNo 0)
             (initHardForkState (ledgerState extLedgerState0))

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Embed/Nary.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Embed/Nary.hs
@@ -208,7 +208,7 @@ injectInitialExtLedgerState cfg extLedgerState0 =
         HardForkLedgerState $
           -- We can immediately extend it to the right slot, executing any
           -- scheduled hard forks in the first slot
-          State.extendToSlot
+          extendToSlot
             (configLedger cfg)
             (SlotNo 0)
             (initHardForkState (ledgerState extLedgerState0))

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Embed/Nary.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Embed/Nary.hs
@@ -25,11 +25,11 @@ import           Data.SOP.BasicFunctors
 import           Data.SOP.Counting (Exactly (..))
 import           Data.SOP.Dict (Dict (..))
 import           Data.SOP.Index
-import qualified Data.SOP.InPairs as InPairs
 import           Data.SOP.Strict
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.HardFork.Combinator
+import qualified Ouroboros.Consensus.HardFork.Combinator.Protocol as Protocol
 import qualified Ouroboros.Consensus.HardFork.Combinator.State as State
 import qualified Ouroboros.Consensus.HardFork.History as History
 import           Ouroboros.Consensus.HeaderValidation (AnnTip, HeaderState (..),
@@ -228,11 +228,8 @@ injectInitialExtLedgerState cfg extLedgerState0 =
     targetEraChainDepState :: HardForkChainDepState (x ': xs)
     targetEraChainDepState =
         -- Align the 'ChainDepState' with the ledger state of the target era.
-        State.align
-          (InPairs.requiringBoth
-            (hmap (WrapConsensusConfig . configConsensus) cfgs)
-            (translateChainDepState hardForkEraTranslation))
-          (hpure (fn_2 (\_ st -> st)))
+        Protocol.extendToHorizon
+          (hmap (WrapConsensusConfig . configConsensus) cfgs)
           (hardForkLedgerStatePerEra targetEraLedgerState)
           firstEraChainDepState
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Protocol.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Protocol.hs
@@ -96,14 +96,13 @@ instance CanHardFork xs => ConsensusProtocol (HardForkProtocol xs) where
   type ValidationErr (HardForkProtocol xs) = HardForkValidationErr xs
   type SelectView    (HardForkProtocol xs) = HardForkSelectView    xs
   type LedgerView    (HardForkProtocol xs) = HardForkLedgerView    xs
-  type HorizonView   (HardForkProtocol xs) = HardForkLedgerView    xs
   type CanBeLeader   (HardForkProtocol xs) = HardForkCanBeLeader   xs
   type IsLeader      (HardForkProtocol xs) = HardForkIsLeader      xs
   type ValidateView  (HardForkProtocol xs) = OneEraValidateView    xs
 
   -- Operations on the state
 
-  tickChainDepState_    = tick
+  tickChainDepState     = tick
   checkIsLeader         = check
   updateChainDepState   = update
   reupdateChainDepState = reupdate
@@ -114,8 +113,6 @@ instance CanHardFork xs => ConsensusProtocol (HardForkProtocol xs) where
 
   -- Security parameter must be equal across /all/ eras
   protocolSecurityParam = hardForkConsensusConfigK
-
-  projectHorizonView _cfg = id
 
 {-------------------------------------------------------------------------------
   BlockSupportsProtocol

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Protocol.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Protocol.hs
@@ -51,7 +51,7 @@ import           Ouroboros.Consensus.HardFork.Combinator.Protocol.ChainSel
 import           Ouroboros.Consensus.HardFork.Combinator.Protocol.LedgerView
                      (HardForkLedgerView, HardForkLedgerView_ (..), Ticked (..))
 import           Ouroboros.Consensus.HardFork.Combinator.State (HardForkState,
-                     Translate (..))
+                     Translate)
 import qualified Ouroboros.Consensus.HardFork.Combinator.State as State
 import           Ouroboros.Consensus.HardFork.Combinator.Translation
 import           Ouroboros.Consensus.Protocol.Abstract

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/State.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/State.hs
@@ -25,20 +25,16 @@ module Ouroboros.Consensus.HardFork.Combinator.State (
   , epochInfoPrecomputedTransitionInfo
   , mostRecentTransitionInfo
   , reconstructSummaryLedger
-    -- * Ledger specific functionality
-  , extendToSlot
   ) where
 
-import           Control.Monad (guard)
 import           Data.Functor.Product
 import           Data.Proxy
 import           Data.SOP.BasicFunctors
 import           Data.SOP.Constraint
 import           Data.SOP.Counting (getExactly)
-import           Data.SOP.InPairs (InPairs, Requiring (..))
 import qualified Data.SOP.InPairs as InPairs
 import           Data.SOP.Strict
-import           Data.SOP.Telescope (Extend (..), ScanNext (..), Telescope)
+import           Data.SOP.Telescope (ScanNext (..), Telescope)
 import qualified Data.SOP.Telescope as Telescope
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HardFork.Combinator.Abstract
@@ -48,10 +44,8 @@ import           Ouroboros.Consensus.HardFork.Combinator.PartialConfig
 import           Ouroboros.Consensus.HardFork.Combinator.State.Infra as X
 import           Ouroboros.Consensus.HardFork.Combinator.State.Instances as X ()
 import           Ouroboros.Consensus.HardFork.Combinator.State.Types as X
-import           Ouroboros.Consensus.HardFork.Combinator.Translation
 import qualified Ouroboros.Consensus.HardFork.History as History
 import           Ouroboros.Consensus.Ledger.Abstract hiding (getTip)
-import           Ouroboros.Consensus.Util ((.:))
 import           Prelude hiding (sequence)
 
 {-------------------------------------------------------------------------------
@@ -164,71 +158,3 @@ epochInfoPrecomputedTransitionInfo ::
 epochInfoPrecomputedTransitionInfo shape transition st =
     History.summaryToEpochInfo $
       reconstructSummary shape transition st
-
-{-------------------------------------------------------------------------------
-  Extending
--------------------------------------------------------------------------------}
-
--- | Extend the telescope until the specified slot is within the era at the tip
-extendToSlot :: forall xs. CanHardFork xs
-             => HardForkLedgerConfig xs
-             -> SlotNo
-             -> HardForkState LedgerState xs -> HardForkState LedgerState xs
-extendToSlot ledgerCfg@HardForkLedgerConfig{..} slot ledgerSt@(HardForkState st) =
-      HardForkState . unI
-    . Telescope.extend
-        ( InPairs.hmap (\f -> Require $ \(K t)
-                           -> Extend  $ \cur
-                           -> I $ howExtend f t cur)
-        $ translate
-        )
-        (hczipWith
-           proxySingle
-           (fn .: whenExtend)
-           pcfgs
-           (getExactly (History.getShape hardForkLedgerConfigShape)))
-    $ st
-  where
-    pcfgs = getPerEraLedgerConfig hardForkLedgerConfigPerEra
-    cfgs  = hcmap proxySingle (completeLedgerConfig'' ei) pcfgs
-    ei    = epochInfoLedger ledgerCfg ledgerSt
-
-    -- Return the end of this era if we should transition to the next
-    whenExtend :: SingleEraBlock              blk
-               => WrapPartialLedgerConfig     blk
-               -> K History.EraParams         blk
-               -> Current LedgerState         blk
-               -> (Maybe :.: K History.Bound) blk
-    whenExtend pcfg (K eraParams) cur = Comp $ K <$> do
-        transition <- singleEraTransition'
-                        pcfg
-                        eraParams
-                        (currentStart cur)
-                        (currentState cur)
-        let endBound = History.mkUpperBound
-                         eraParams
-                         (currentStart cur)
-                         transition
-        guard (slot >= History.boundSlot endBound)
-        return endBound
-
-    howExtend :: Translate LedgerState blk blk'
-              -> History.Bound
-              -> Current LedgerState blk
-              -> (K Past blk, Current LedgerState blk')
-    howExtend f currentEnd cur = (
-          K Past {
-              pastStart    = currentStart cur
-            , pastEnd      = currentEnd
-            }
-        , Current {
-              currentStart = currentEnd
-            , currentState = translateWith f
-                               currentEnd
-                               (currentState cur)
-            }
-        )
-
-    translate :: InPairs (Translate LedgerState) xs
-    translate = InPairs.requiringBoth cfgs $
-                  translateLedgerState hardForkEraTranslation

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/State.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/State.hs
@@ -224,7 +224,7 @@ extendToSlot ledgerCfg@HardForkLedgerConfig{..} slot ledgerSt@(HardForkState st)
         , Current {
               currentStart = currentEnd
             , currentState = translateWith f
-                               (History.boundEpoch currentEnd)
+                               currentEnd
                                (currentState cur)
             }
         )

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/State/Infra.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/State/Infra.hs
@@ -145,7 +145,7 @@ align fs updTip (HardForkState alignWith) (HardForkState toAlign) =
                   }
         , Current { currentStart = curEnd
                   , currentState = translateWith f
-                                     (boundEpoch curEnd)
+                                     curEnd
                                      (currentState curF)
                   }
         )

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/State/Types.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/State/Types.hs
@@ -111,13 +111,15 @@ sequenceHardForkState (HardForkState tel) =
   Supporting types
 -------------------------------------------------------------------------------}
 
--- | Translate @f x@ to @g y@ across an era transition
+-- | Translate @f x@ to @g y@ across an era transition with the provided
+-- 'Bound', which is the exclusive upper bound of the era of @x@ or equivalently
+-- an inclusive lower bound of the era of @y@.
 --
 -- Typically @f@/@g@ will be ('Ticked')
 -- 'Ouroboros.Consensus.Ledger.Basics.LedgerState' or
 -- 'Ouroboros.Consensus.TypeFamilyWrappers.WrapChainDepState'.
 newtype Translate' f g x y = Translate {
-      translateWith :: EpochNo -> f x -> g y
+      translateWith :: Bound -> f x -> g y
     }
 
 -- | Homogenous version of 'Translate''.

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Translation.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Translation.hs
@@ -30,8 +30,12 @@ data EraTranslation xs = EraTranslation {
       --
       -- For more context/motivation, see
       -- <https://github.com/input-output-hk/ouroboros-consensus/issues/339>.
-      translateLedgerState   :: InPairs (RequiringBoth WrapLedgerConfig    (TickedTranslate LedgerState)) xs
-    , translateChainDepState :: InPairs (RequiringBoth WrapConsensusConfig (Translate WrapChainDepState)) xs
+      translateLedgerState   :: InPairs (RequiringBoth WrapLedgerConfig    (TickedTranslate LedgerState))                   xs
+      -- | Translate a @'Ticked' 'ChainDepState'@ from one era to a 'ChainDepState'
+      -- in the next era.
+      --
+      -- Identical remarks as for 'translateLedgerState' apply.
+    , translateChainDepState :: InPairs (RequiringBoth WrapConsensusConfig (TickedTranslate WrapChainDepState))             xs
     , crossEraForecast       :: InPairs (RequiringBoth WrapLedgerConfig    (CrossEraForecaster LedgerState WrapLedgerView)) xs
     }
   deriving NoThunks

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Translation.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Translation.hs
@@ -17,7 +17,20 @@ import           Ouroboros.Consensus.TypeFamilyWrappers
 -------------------------------------------------------------------------------}
 
 data EraTranslation xs = EraTranslation {
-      translateLedgerState   :: InPairs (RequiringBoth WrapLedgerConfig    (Translate LedgerState))       xs
+      -- | Translate a @'Ticked' 'LedgerState'@ from one era to a 'LedgerState'
+      -- in the next era.
+      --
+      -- The HFC will always supply a 'LedgerState' that has just been ticked
+      -- across the era boundary. The translations provided here should *not* do
+      -- any ticking. The HFC will later tick the result to whatever slot was
+      -- requested. Note that it is important that this second ticking operation
+      -- can recognize, if applicable for the underlying ledger, that the epoch
+      -- boundary was already passed, such that epoch-related updates are not
+      -- performed twice.
+      --
+      -- For more context/motivation, see
+      -- <https://github.com/input-output-hk/ouroboros-consensus/issues/339>.
+      translateLedgerState   :: InPairs (RequiringBoth WrapLedgerConfig    (TickedTranslate LedgerState)) xs
     , translateChainDepState :: InPairs (RequiringBoth WrapConsensusConfig (Translate WrapChainDepState)) xs
     , crossEraForecast       :: InPairs (RequiringBoth WrapLedgerConfig    (CrossEraForecaster LedgerState WrapLedgerView)) xs
     }

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HeaderValidation.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HeaderValidation.hs
@@ -430,6 +430,7 @@ validateHeader cfg ledgerView hdr st = do
       updateChainDepState
         (configConsensus cfg)
         (validateView (configBlock cfg) hdr)
+        ledgerView
         (blockSlot hdr)
         (tickedHeaderStateChainDep st)
     return $ HeaderState (NotOrigin (getAnnTip hdr)) chainDepState'
@@ -459,6 +460,7 @@ revalidateHeader cfg ledgerView hdr st =
         reupdateChainDepState
           (configConsensus cfg)
           (validateView (configBlock cfg) hdr)
+          ledgerView
           (blockSlot hdr)
           (tickedHeaderStateChainDep st)
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Protocol/Abstract.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Protocol/Abstract.hs
@@ -7,7 +7,6 @@ module Ouroboros.Consensus.Protocol.Abstract (
     ConsensusConfig
   , ConsensusProtocol (..)
   , preferCandidate
-  , tickChainDepState
     -- * Convenience re-exports
   , SecurityParam (..)
   ) where
@@ -117,16 +116,6 @@ class ( Show (ChainDepState   p)
   -- calculation does not depend on this).
   type family LedgerView p :: Type
 
-  -- | A projection of 'LedgerView' containing only what is needed for ticking
-  --
-  -- For single-era protocols, there are further constraints on this type, see
-  -- 'Ouroboros.Consensus.HardFork.Combinator.Abstract.SingleEraBlock.eraTransitionHorizonView'.
-  -- Usually, 'HorizonView' will be a singleton type.
-  --
-  -- For the 'Ouroboros.Consensus.HardFork.Combinator.Basics.HardForkProtocol'
-  -- combinator, this is the same as the 'LedgerView'.
-  type family HorizonView p :: Type
-
   -- | Validation errors
   type family ValidationErr p :: Type
 
@@ -142,16 +131,12 @@ class ( Show (ChainDepState   p)
                 -> Ticked (ChainDepState p)
                 -> Maybe (IsLeader       p)
 
-  projectHorizonView :: ConsensusConfig     p
-                     -> Ticked (LedgerView  p)
-                     -> Ticked (HorizonView p)
-
-  -- | Tick the 'ChainDepState', also see 'tickChainDepState'
-  tickChainDepState_ :: ConsensusConfig p
-                     -> Ticked (HorizonView p)
-                     -> SlotNo
-                     -> ChainDepState p
-                     -> Ticked (ChainDepState p)
+  -- | Tick the 'ChainDepState'
+  tickChainDepState :: ConsensusConfig p
+                    -> Ticked (LedgerView p)
+                    -> SlotNo
+                    -> ChainDepState p
+                    -> Ticked (ChainDepState p)
 
   -- | Apply a header
   updateChainDepState :: HasCallStack
@@ -183,15 +168,6 @@ class ( Show (ChainDepState   p)
 
   -- | We require that protocols support a @k@ security parameter
   protocolSecurityParam :: ConsensusConfig p -> SecurityParam
-
--- | Tick the 'ChainDepState'
-tickChainDepState :: ConsensusProtocol p
-                  => ConsensusConfig p
-                  -> Ticked (LedgerView p)
-                  -> SlotNo
-                  -> ChainDepState p
-                  -> Ticked (ChainDepState p)
-tickChainDepState cfg = tickChainDepState_ cfg . projectHorizonView cfg
 
 -- | Compare a candidate chain to our own
 --

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Protocol/BFT.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Protocol/BFT.hs
@@ -125,7 +125,6 @@ instance BftCrypto c => ConsensusProtocol (Bft c) where
   type ValidationErr (Bft c) = BftValidationErr
   type ValidateView  (Bft c) = BftValidateView c
   type LedgerView    (Bft c) = ()
-  type HorizonView   (Bft c) = ()
   type IsLeader      (Bft c) = ()
   type ChainDepState (Bft c) = ()
   type CanBeLeader   (Bft c) = CoreNodeId
@@ -159,9 +158,7 @@ instance BftCrypto c => ConsensusProtocol (Bft c) where
       NumCoreNodes numCoreNodes = bftNumNodes
 
   reupdateChainDepState _ _ _ _ _ = ()
-  tickChainDepState_    _ _ _ _   = TickedTrivial
-
-  projectHorizonView _ TickedTrivial = TickedTrivial
+  tickChainDepState     _ _ _ _   = TickedTrivial
 
 instance BftCrypto c => NoThunks (ConsensusConfig (Bft c))
   -- use generic instance

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Protocol/BFT.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Protocol/BFT.hs
@@ -125,13 +125,14 @@ instance BftCrypto c => ConsensusProtocol (Bft c) where
   type ValidationErr (Bft c) = BftValidationErr
   type ValidateView  (Bft c) = BftValidateView c
   type LedgerView    (Bft c) = ()
+  type HorizonView   (Bft c) = ()
   type IsLeader      (Bft c) = ()
   type ChainDepState (Bft c) = ()
   type CanBeLeader   (Bft c) = CoreNodeId
 
   protocolSecurityParam = bftSecurityParam . bftParams
 
-  checkIsLeader BftConfig{..} (CoreNodeId i) (SlotNo n) _ =
+  checkIsLeader BftConfig{..} (CoreNodeId i) TickedTrivial (SlotNo n) _ =
       if n `mod` numCoreNodes == i
       then Just ()
       else Nothing
@@ -141,6 +142,7 @@ instance BftCrypto c => ConsensusProtocol (Bft c) where
 
   updateChainDepState BftConfig{..}
                       (BftValidateView BftFields{..} signed)
+                      TickedTrivial
                       (SlotNo n)
                       _ =
       -- TODO: Should deal with unknown node IDs
@@ -156,8 +158,10 @@ instance BftCrypto c => ConsensusProtocol (Bft c) where
       expectedLeader = CoreId $ CoreNodeId (n `mod` numCoreNodes)
       NumCoreNodes numCoreNodes = bftNumNodes
 
-  reupdateChainDepState _ _ _ _ = ()
-  tickChainDepState     _ _ _ _ = TickedTrivial
+  reupdateChainDepState _ _ _ _ _ = ()
+  tickChainDepState_    _ _ _ _   = TickedTrivial
+
+  projectHorizonView _ TickedTrivial = TickedTrivial
 
 instance BftCrypto c => NoThunks (ConsensusConfig (Bft c))
   -- use generic instance

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Protocol/ModChainSel.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Protocol/ModChainSel.hs
@@ -32,11 +32,13 @@ instance ( ConsensusProtocol p
     type IsLeader      (ModChainSel p s) = IsLeader      p
     type CanBeLeader   (ModChainSel p s) = CanBeLeader   p
     type LedgerView    (ModChainSel p s) = LedgerView    p
+    type HorizonView   (ModChainSel p s) = HorizonView   p
     type ValidationErr (ModChainSel p s) = ValidationErr p
     type ValidateView  (ModChainSel p s) = ValidateView  p
 
     checkIsLeader         = checkIsLeader         . mcsConfigP
-    tickChainDepState     = tickChainDepState     . mcsConfigP
+    projectHorizonView    = projectHorizonView    . mcsConfigP
+    tickChainDepState_    = tickChainDepState_    . mcsConfigP
     updateChainDepState   = updateChainDepState   . mcsConfigP
     reupdateChainDepState = reupdateChainDepState . mcsConfigP
     protocolSecurityParam = protocolSecurityParam . mcsConfigP

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Protocol/ModChainSel.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Protocol/ModChainSel.hs
@@ -32,13 +32,11 @@ instance ( ConsensusProtocol p
     type IsLeader      (ModChainSel p s) = IsLeader      p
     type CanBeLeader   (ModChainSel p s) = CanBeLeader   p
     type LedgerView    (ModChainSel p s) = LedgerView    p
-    type HorizonView   (ModChainSel p s) = HorizonView   p
     type ValidationErr (ModChainSel p s) = ValidationErr p
     type ValidateView  (ModChainSel p s) = ValidateView  p
 
     checkIsLeader         = checkIsLeader         . mcsConfigP
-    projectHorizonView    = projectHorizonView    . mcsConfigP
-    tickChainDepState_    = tickChainDepState_    . mcsConfigP
+    tickChainDepState     = tickChainDepState     . mcsConfigP
     updateChainDepState   = updateChainDepState   . mcsConfigP
     reupdateChainDepState = reupdateChainDepState . mcsConfigP
     protocolSecurityParam = protocolSecurityParam . mcsConfigP

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Protocol/PBFT.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Protocol/PBFT.hs
@@ -60,6 +60,8 @@ import           Data.Word (Word64)
 import           GHC.Generics (Generic)
 import           NoThunks.Class (NoThunks)
 import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.HardFork.Combinator.Abstract.SingleEraBlock
+                     (SingleEraProtocol (..))
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.NodeId (CoreNodeId (..))
 import           Ouroboros.Consensus.Protocol.Abstract
@@ -269,6 +271,9 @@ data PBftIsLeader c = PBftIsLeader {
   deriving (Generic)
 
 instance PBftCrypto c => NoThunks (PBftIsLeader c)
+
+instance SingleEraProtocol (PBft c) where
+  eraTransitionHorizonView _cfg = TickedTrivial
 
 -- | (Static) node configuration
 newtype instance ConsensusConfig (PBft c) = PBftConfig {

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Node.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Node.hs
@@ -83,7 +83,7 @@ simpleBlockForging canBeLeader forgeExt = BlockForging {
       forgeLabel       = "simpleBlockForging"
     , canBeLeader      = canBeLeader
     , updateForgeState = \_ _ _ -> return $ ForgeStateUpdated ()
-    , checkCanForge    = \_ _ _ _ _ -> return ()
+    , checkCanForge    = \_ _ _ _ _ _ -> return ()
     , forgeBlock       = \cfg bno slot lst txs proof ->
         return
           $ forgeSimple

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Node/PBFT.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Node/PBFT.hs
@@ -91,11 +91,12 @@ pbftBlockForging canBeLeader = BlockForging {
       forgeLabel       = "pbftBlockForging"
     , canBeLeader
     , updateForgeState = \_ _ _ -> return $ ForgeStateUpdated ()
-    , checkCanForge    = \cfg slot tickedPBftState _isLeader ->
+    , checkCanForge    = \cfg tickedLedgerView slot tickedPBftState _isLeader ->
                            return $
                              pbftCheckCanForge
                                (configConsensus cfg)
                                canBeLeader
+                               tickedLedgerView
                                slot
                                tickedPBftState
     , forgeBlock       = \cfg slot bno lst txs proof ->

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Node/Praos.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Node/Praos.hs
@@ -125,7 +125,7 @@ praosBlockForging cid initHotKey = do
                                  pure
                                . second forgeStateUpdateInfoFromUpdateInfo
                                . evolveKey sno
-      , checkCanForge    = \_ _ _ _ _ -> return ()
+      , checkCanForge    = \_ _ _ _ _ _ -> return ()
       , forgeBlock       = \cfg bno sno tickedLedgerSt txs isLeader -> do
                                hotKey <- readMVar varHotKey
                                return $

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Protocol/LeaderSchedule.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Protocol/LeaderSchedule.hs
@@ -40,6 +40,7 @@ instance ConsensusProtocol p => ConsensusProtocol (WithLeaderSchedule p) where
 
   type ChainDepState (WithLeaderSchedule p) = ()
   type LedgerView    (WithLeaderSchedule p) = ()
+  type HorizonView   (WithLeaderSchedule p) = ()
   type ValidationErr (WithLeaderSchedule p) = ()
   type IsLeader      (WithLeaderSchedule p) = ()
   type ValidateView  (WithLeaderSchedule p) = ()
@@ -47,16 +48,18 @@ instance ConsensusProtocol p => ConsensusProtocol (WithLeaderSchedule p) where
 
   protocolSecurityParam = protocolSecurityParam . wlsConfigP
 
-  checkIsLeader WLSConfig{..} () slot _ =
+  checkIsLeader WLSConfig{..} () _ slot _ =
     case Map.lookup slot $ getLeaderSchedule wlsConfigSchedule of
         Nothing -> error $ "WithLeaderSchedule: missing slot " ++ show slot
         Just nids
             | wlsConfigNodeId `elem` nids -> Just ()
             | otherwise                   -> Nothing
 
-  tickChainDepState     _ _ _ _ = TickedTrivial
-  updateChainDepState   _ _ _ _ = return ()
-  reupdateChainDepState _ _ _ _ = ()
+  projectHorizonView _ _ = TickedTrivial
+
+  tickChainDepState_    _ _ _ _ = TickedTrivial
+  updateChainDepState   _ _ _ _ _ = return ()
+  reupdateChainDepState _ _ _ _ _ = ()
 
 instance ConsensusProtocol p
       => NoThunks (ConsensusConfig (WithLeaderSchedule p))

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Protocol/LeaderSchedule.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Protocol/LeaderSchedule.hs
@@ -40,7 +40,6 @@ instance ConsensusProtocol p => ConsensusProtocol (WithLeaderSchedule p) where
 
   type ChainDepState (WithLeaderSchedule p) = ()
   type LedgerView    (WithLeaderSchedule p) = ()
-  type HorizonView   (WithLeaderSchedule p) = ()
   type ValidationErr (WithLeaderSchedule p) = ()
   type IsLeader      (WithLeaderSchedule p) = ()
   type ValidateView  (WithLeaderSchedule p) = ()
@@ -55,9 +54,7 @@ instance ConsensusProtocol p => ConsensusProtocol (WithLeaderSchedule p) where
             | wlsConfigNodeId `elem` nids -> Just ()
             | otherwise                   -> Nothing
 
-  projectHorizonView _ _ = TickedTrivial
-
-  tickChainDepState_    _ _ _ _ = TickedTrivial
+  tickChainDepState       _ _ _ _ = TickedTrivial
   updateChainDepState   _ _ _ _ _ = return ()
   reupdateChainDepState _ _ _ _ _ = ()
 

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Protocol/Praos.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Protocol/Praos.hs
@@ -443,7 +443,6 @@ instance PraosCrypto c => ConsensusProtocol (Praos c) where
   protocolSecurityParam = praosSecurityParam . praosParams
 
   type LedgerView    (Praos c) = ()
-  type HorizonView   (Praos c) = ()
   type IsLeader      (Praos c) = PraosProof           c
   type ValidationErr (Praos c) = PraosValidationError c
   type ValidateView  (Praos c) = PraosValidateView    c
@@ -465,9 +464,7 @@ instance PraosCrypto c => ConsensusProtocol (Praos c) where
       rho = evalCertified () rho' praosSignKeyVRF
       y   = evalCertified () y'   praosSignKeyVRF
 
-  projectHorizonView _ _ = TickedTrivial
-
-  tickChainDepState_ _ _ _ = TickedPraosChainDepState
+  tickChainDepState _ _ _ = TickedPraosChainDepState
 
   updateChainDepState cfg@PraosConfig{..}
                       (PraosValidateView PraosFields{..} toSign)

--- a/ouroboros-consensus/src/unstable-tutorials/Ouroboros/Consensus/Tutorial/Simple.lhs
+++ b/ouroboros-consensus/src/unstable-tutorials/Ouroboros/Consensus/Tutorial/Simple.lhs
@@ -132,7 +132,6 @@ Next, we instantiate the `ConsensusProtocol` for `SP`:
 >   type SelectView    SP = BlockNo
 >
 >   type LedgerView    SP = ()
->   type HorizonView   SP = ()
 >
 >   type IsLeader      SP = SP_IsLeader
 >   type CanBeLeader   SP = SP_CanBeLeader
@@ -148,9 +147,7 @@ Next, we instantiate the `ConsensusProtocol` for `SP`:
 >
 >   protocolSecurityParam _cfg = k
 >
->   projectHorizonView _cfg _tlv = TickedTrivial
->
->   tickChainDepState_ _ _ _ _ = TickedTrivial
+>   tickChainDepState _ _ _ _ = TickedTrivial
 >
 >   updateChainDepState _ _ _ _ _ = return ()
 >
@@ -187,7 +184,7 @@ For `SP` we will use only `BlockNo` - to implement the simplest rule of
 preferring longer chains to shorter chains.
 
 
-Ledger Integration: `LedgerView` (and `HorizonView`)
+Ledger Integration: `LedgerView`
 ----------------------------------------------------
 
 Some decisions that a consensus protocol needs to make will depend on the
@@ -199,11 +196,6 @@ a typeclass, namely `LedgerSupportsProtocol`.
 For `SP` we do not require any information from the ledger to make decisions of
 any kind.  In the Praos protocol, the `LedgerView` contains information about
 the stake distribution among other things.
-
-This is used in most functions in `ConsensusProtocol`, but `tickChainDepState_`
-can also work with only a `HorizonView`. For our purposes, we can ignore
-`HorizonView` and assume it to be a singleton type, so there is no difference
-between `tickChainDepState_` and `tickChainDepState` for us.
 
 
 Protocol State: `ChainDepState`, `ValidateView` and `ValidationErr`

--- a/ouroboros-consensus/src/unstable-tutorials/Ouroboros/Consensus/Tutorial/Simple.lhs
+++ b/ouroboros-consensus/src/unstable-tutorials/Ouroboros/Consensus/Tutorial/Simple.lhs
@@ -132,6 +132,7 @@ Next, we instantiate the `ConsensusProtocol` for `SP`:
 >   type SelectView    SP = BlockNo
 >
 >   type LedgerView    SP = ()
+>   type HorizonView   SP = ()
 >
 >   type IsLeader      SP = SP_IsLeader
 >   type CanBeLeader   SP = SP_CanBeLeader
@@ -140,18 +141,20 @@ Next, we instantiate the `ConsensusProtocol` for `SP`:
 >   type ValidateView  SP = ()
 >   type ValidationErr SP = Void
 >
->   checkIsLeader cfg SP_CanBeLeader slot _tcds =
+>   checkIsLeader cfg SP_CanBeLeader _tlv slot _tcds =
 >       if slot `Set.member` cfgsp_slotsLedByMe cfg
 >       then Just SP_IsLeader
 >       else Nothing
 >
 >   protocolSecurityParam _cfg = k
 >
->   tickChainDepState _ _ _ _ = TickedTrivial
+>   projectHorizonView _cfg _tlv = TickedTrivial
 >
->   updateChainDepState _ _ _ _ = return ()
+>   tickChainDepState_ _ _ _ _ = TickedTrivial
 >
->   reupdateChainDepState _ _ _ _ = ()
+>   updateChainDepState _ _ _ _ _ = return ()
+>
+>   reupdateChainDepState _ _ _ _ _ = ()
 
 Finally we define a few extra things used in this instantiation:
 
@@ -184,8 +187,8 @@ For `SP` we will use only `BlockNo` - to implement the simplest rule of
 preferring longer chains to shorter chains.
 
 
-Ledger Integration: `LedgerView`
---------------------------------
+Ledger Integration: `LedgerView` (and `HorizonView`)
+----------------------------------------------------
 
 Some decisions that a consensus protocol needs to make will depend on the
 ledger's state, `LedgerState blk`.  The data required from the ledger is of
@@ -197,8 +200,10 @@ For `SP` we do not require any information from the ledger to make decisions of
 any kind.  In the Praos protocol, the `LedgerView` contains information about
 the stake distribution among other things.
 
-Notably, this is used in the `tickChainDepState` function elsewhere in the
-`ConsensusProtocol`.
+This is used in most functions in `ConsensusProtocol`, but `tickChainDepState_`
+can also work with only a `HorizonView`. For our purposes, we can ignore
+`HorizonView` and assume it to be a singleton type, so there is no difference
+between `tickChainDepState_` and `tickChainDepState` for us.
 
 
 Protocol State: `ChainDepState`, `ValidateView` and `ValidationErr`

--- a/ouroboros-consensus/src/unstable-tutorials/Ouroboros/Consensus/Tutorial/WithEpoch.lhs
+++ b/ouroboros-consensus/src/unstable-tutorials/Ouroboros/Consensus/Tutorial/WithEpoch.lhs
@@ -526,8 +526,6 @@ functions defined above:
 >   -- | View on the ledger required by the protocol
 >   type LedgerView PrtclD = LedgerViewD
 >
->   type HorizonView PrtclD = ()
->
 >   -- | View on a block header required for header validation
 >   type ValidateView  PrtclD = NodeId  -- need this for the leader check
 >                                       -- currently not doing other checks
@@ -544,9 +542,7 @@ functions defined above:
 >
 >   protocolSecurityParam = ccpd_securityParam
 >
->   projectHorizonView _cfg _tlv = TickedTrivial
->
->   tickChainDepState_ _cfg _hv _slot _cds = TickedChainDepStateD
+>   tickChainDepState _cfg _lv _slot _cds = TickedChainDepStateD
 >
 >   -- | apply the header (hdrView) and do a header check.
 >   --


### PR DESCRIPTION
Closes #339, closes https://github.com/input-output-hk/cardano-ledger/issues/3491

This PR is intended to be reviewed commit by commit, which should all compile and pass all tests individually.

On a high level, this PR changes the way we do cross-era ticking in the HFC from **translate-then-tick** to **tick-then-translate-then-tick** for both the ledger state and, for consistency, also for the chain-dep/protocol state. For motivation, see #339, for further directions in this area, see #345.

The first commit enriches an existing test to showcase the problem, it is then fixed in a later commit.

TODO:

 - [ ] Determine whether we need more test, in particular for `ChainDepState` cross-era ticking. We could do this using actual Cardano blocks.
 - [ ] Do we need more documentation? (Maybe a GHC-style note explaining the overall HFC cross-era ticking approach?)