### PR TITLE
Require that LedgerView family is empty

### DIFF
--- a/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/PBFT.hs
+++ b/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/PBFT.hs
@@ -72,14 +72,14 @@ instance BlockSupportsProtocol ByronBlock where
 
   selectView _ = mkPBftSelectView
 
-toPBftLedgerView :: Delegation.Map -> PBftLedgerView PBftByronCrypto
-toPBftLedgerView = PBftLedgerView . Delegation.unMap
+toPBftLedgerView :: Delegation.Map -> Ticked (PBftLedgerView PBftByronCrypto)
+toPBftLedgerView = TickedPBftLedgerView . Delegation.unMap
 
 toTickedPBftLedgerView :: Delegation.Map -> Ticked (PBftLedgerView PBftByronCrypto)
 toTickedPBftLedgerView = TickedPBftLedgerView . Delegation.unMap
 
-fromPBftLedgerView :: PBftLedgerView PBftByronCrypto -> Delegation.Map
-fromPBftLedgerView = Delegation.Map . pbftDelegates
+fromPBftLedgerView :: Ticked (PBftLedgerView PBftByronCrypto) -> Delegation.Map
+fromPBftLedgerView = Delegation.Map . tickedPBftDelegates
 
 encodeByronChainDepState
   :: ChainDepState (BlockProtocol ByronBlock)

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/CanHardFork.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/CanHardFork.hs
@@ -476,7 +476,7 @@ crossEraForecastByronToShelleyWrapper =
     forecast cfgShelley bound forecastFor currentByronState
         | forecastFor < maxFor
         = return $
-            WrapTickedLedgerView $ TickedPraosLedgerView $
+            WrapTickedLedgerView $ TickedTPraosLedgerView $
               SL.mkInitialShelleyLedgerView
                 (toFromByronTranslationContext (shelleyLedgerGenesis cfgShelley))
         | otherwise

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
@@ -84,7 +84,7 @@ import           Ouroboros.Consensus.Ledger.CommonProtocolParams
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Protocol.Ledger.Util (isNewEpoch)
 import           Ouroboros.Consensus.Protocol.TPraos (MaxMajorProtVer (..),
-                     Ticked (TickedPraosLedgerView))
+                     Ticked (TickedTPraosLedgerView))
 import           Ouroboros.Consensus.Shelley.Eras (EraCrypto)
 import           Ouroboros.Consensus.Shelley.Ledger.Block
 import           Ouroboros.Consensus.Shelley.Ledger.Config

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/SupportsProtocol.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/SupportsProtocol.hs
@@ -36,7 +36,6 @@ import           Ouroboros.Consensus.Ledger.SupportsProtocol
                      (LedgerSupportsProtocol (..))
 import           Ouroboros.Consensus.Protocol.Praos (Praos)
 import qualified Ouroboros.Consensus.Protocol.Praos as Praos
-import qualified Ouroboros.Consensus.Protocol.Praos.Views as Praos
 import           Ouroboros.Consensus.Protocol.TPraos (TPraos)
 import qualified Ouroboros.Consensus.Protocol.TPraos as TPraos
 import           Ouroboros.Consensus.Protocol.Translate (TranslateProto,
@@ -54,7 +53,7 @@ instance
   LedgerSupportsProtocol (ShelleyBlock (TPraos crypto) era)
   where
   protocolLedgerView _cfg =
-    TPraos.TickedPraosLedgerView
+    TPraos.TickedTPraosLedgerView
       . SL.currentLedgerView
       . tickedShelleyLedgerState
 
@@ -63,7 +62,7 @@ instance
   ledgerViewForecastAt cfg ledgerState = Forecast at $ \for ->
     if
         | NotOrigin for == at ->
-          return $ TPraos.TickedPraosLedgerView $ SL.currentLedgerView shelleyLedgerState
+          return $ TPraos.TickedTPraosLedgerView $ SL.currentLedgerView shelleyLedgerState
         | for < maxFor ->
           return $ futureLedgerView for
         | otherwise ->
@@ -79,11 +78,11 @@ instance
       swindow = SL.stabilityWindow globals
       at = ledgerTipSlot ledgerState
 
-      futureLedgerView :: SlotNo -> Ticked (SL.LedgerView (EraCrypto era))
+      futureLedgerView :: SlotNo -> Ticked (TPraos.TPraosLedgerView (EraCrypto era))
       futureLedgerView =
         either
           (\e -> error ("futureLedgerView failed: " <> show e))
-          TPraos.TickedPraosLedgerView
+          TPraos.TickedTPraosLedgerView
           . SL.futureLedgerView globals shelleyLedgerState
 
       -- Exclusive upper bound
@@ -106,8 +105,7 @@ instance
         pparam :: forall a. Lens.Micro.Lens' (LedgerCore.PParams era) a -> a
         pparam lens = getPParams nes Lens.Micro.^. lens
 
-     in Praos.TickedPraosLedgerView $
-          Praos.LedgerView
+     in Praos.TickedPraosLedgerView
             { Praos.lvPoolDistr       = nesPd,
               Praos.lvMaxBodySize     = pparam LedgerCore.ppMaxBBSizeL,
               Praos.lvMaxHeaderSize   = pparam LedgerCore.ppMaxBHSizeL,

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Protocol/Praos.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Protocol/Praos.hs
@@ -63,7 +63,7 @@ instance PraosCrypto c => ProtocolHeaderSupportsEnvelope (Praos c) where
 
   type EnvelopeCheckError _ = PraosEnvelopeError
 
-  envelopeChecks cfg (TickedPraosLedgerView lv) hdr = do
+  envelopeChecks cfg lv hdr = do
     unless (m <= maxpv) $ throwError (ObsoleteNode m maxpv)
     unless (fromIntegral (bhviewHSize bhv) <= maxHeaderSize) $
       throwError $

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Protocol/TPraos.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Protocol/TPraos.hs
@@ -22,7 +22,7 @@ import           Ouroboros.Consensus.Protocol.Signed (Signed,
 import           Ouroboros.Consensus.Protocol.TPraos
                      (MaxMajorProtVer (MaxMajorProtVer), TPraos,
                      TPraosCannotForge, TPraosFields (..), TPraosToSign (..),
-                     Ticked (TickedPraosLedgerView), forgeTPraosFields,
+                     Ticked (TickedTPraosLedgerView), forgeTPraosFields,
                      tpraosMaxMajorPV, tpraosParams, tpraosSlotsPerKESPeriod)
 import           Ouroboros.Consensus.Shelley.Protocol.Abstract (ProtoCrypto,
                      ProtocolHeaderSupportsEnvelope (..),
@@ -46,7 +46,7 @@ instance PraosCrypto c => ProtocolHeaderSupportsEnvelope (TPraos c) where
 
   type EnvelopeCheckError _ = ChainPredicateFailure
 
-  envelopeChecks cfg (TickedPraosLedgerView lv) hdr =
+  envelopeChecks cfg (TickedTPraosLedgerView lv) hdr =
     SL.chainChecks
       maxPV
       (SL.lvChainChecks lv)

--- a/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/General.hs
+++ b/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/General.hs
@@ -50,7 +50,6 @@ import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.Node.Run
 import           Ouroboros.Consensus.NodeId
-import           Ouroboros.Consensus.Protocol.Abstract (LedgerView)
 import           Ouroboros.Consensus.Protocol.LeaderSchedule
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
 import           Ouroboros.Consensus.TypeFamilyWrappers
@@ -58,7 +57,6 @@ import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Consensus.Util.Enclose (pattern FallingEdge)
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.Orphans ()
-import           Ouroboros.Consensus.Util.RedundantConstraints
 import qualified Ouroboros.Network.Mock.Chain as MockChain
 import qualified System.FS.Sim.MockFS as Mock
 import           System.FS.Sim.MockFS (MockFS)
@@ -490,8 +488,6 @@ prop_general_internal syncity pga testOutput =
     propSync prop = case syncity of
         Sync     -> prop
         SemiSync -> property True
-
-    _ = keepRedundantConstraint (Proxy @(Show (LedgerView (BlockProtocol blk))))
 
     PropGeneralArgs
       { pgaBlockProperty       = prop_valid_block

--- a/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
@@ -89,7 +89,6 @@ import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Consensus.Util.Enclose (pattern FallingEdge)
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.Orphans ()
-import           Ouroboros.Consensus.Util.RedundantConstraints
 import           Ouroboros.Consensus.Util.ResourceRegistry
 import           Ouroboros.Consensus.Util.STM
 import           Ouroboros.Consensus.Util.Time
@@ -421,8 +420,6 @@ runThreadNetwork systemTime ThreadNetworkArgs
 
     mkTestOutput vertexInfos
   where
-    _ = keepRedundantConstraint (Proxy @(Show (LedgerView (BlockProtocol blk))))
-
     -- epoch size of the first era (ie the one that might have EBBs)
     epochSize0 :: EpochSize
     epochSize0 = HFF.futureFirstEpochSize future

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator.hs
@@ -429,7 +429,7 @@ forecast_AtoB ::
         BlockA
         BlockB
 forecast_AtoB = InPairs.ignoringBoth $ CrossEraForecaster $ \_ _ _ -> return $
-    WrapTickedLedgerView TickedTrivial
+    WrapTickedLedgerView TickedVoid
 
 injectTx_AtoB ::
      RequiringBoth

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/A.hs
@@ -80,6 +80,7 @@ import           Ouroboros.Consensus.Node.Serialisation
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Storage.ImmutableDB (simpleChunkInfo)
 import           Ouroboros.Consensus.Storage.Serialisation
+import           Ouroboros.Consensus.Ticked (VoidUntilTicked)
 import           Ouroboros.Consensus.Util (repeatedlyM, (..:), (.:))
 import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Consensus.Util.Orphans ()
@@ -102,11 +103,13 @@ data instance ConsensusConfig ProtocolA = CfgA {
 
 instance ConsensusProtocol ProtocolA where
   type ChainDepState ProtocolA = ()
-  type LedgerView    ProtocolA = ()
+  type LedgerView    ProtocolA = VoidUntilTicked
   type IsLeader      ProtocolA = ()
   type CanBeLeader   ProtocolA = ()
   type ValidateView  ProtocolA = ()
   type ValidationErr ProtocolA = Void
+
+  invariantLedgerViewEmpty _proxy = \case {}
 
   checkIsLeader CfgA{..} () slot _ =
       if slot `Set.member` cfgA_leadInSlots
@@ -241,8 +244,8 @@ instance BlockSupportsProtocol BlockA where
   validateView _ _ = ()
 
 instance LedgerSupportsProtocol BlockA where
-  protocolLedgerView   _ _  = TickedTrivial
-  ledgerViewForecastAt _    = trivialForecast
+  protocolLedgerView   _ _  = TickedVoid
+  ledgerViewForecastAt _    = trivialVoidForecast
 
 instance HasPartialConsensusConfig ProtocolA
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/B.hs
@@ -67,6 +67,7 @@ import           Ouroboros.Consensus.Node.Serialisation
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Storage.ImmutableDB (simpleChunkInfo)
 import           Ouroboros.Consensus.Storage.Serialisation
+import           Ouroboros.Consensus.Ticked (VoidUntilTicked)
 import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Consensus.Util.Orphans ()
 import           Ouroboros.Network.Block (Serialised, unwrapCBORinCBOR,
@@ -88,11 +89,13 @@ data instance ConsensusConfig ProtocolB = CfgB {
 
 instance ConsensusProtocol ProtocolB where
   type ChainDepState ProtocolB = ()
-  type LedgerView    ProtocolB = ()
+  type LedgerView    ProtocolB = VoidUntilTicked
   type IsLeader      ProtocolB = ()
   type CanBeLeader   ProtocolB = ()
   type ValidateView  ProtocolB = ()
   type ValidationErr ProtocolB = Void
+
+  invariantLedgerViewEmpty _proxy = \case {}
 
   checkIsLeader CfgB{..} () slot _ =
       if slot `Set.member` cfgB_leadInSlots
@@ -201,8 +204,8 @@ instance BlockSupportsProtocol BlockB where
   validateView _ _ = ()
 
 instance LedgerSupportsProtocol BlockB where
-  protocolLedgerView   _ _ = TickedTrivial
-  ledgerViewForecastAt _   = trivialForecast
+  protocolLedgerView   _ _ = TickedVoid
+  ledgerViewForecastAt _   = trivialVoidForecast
 
 instance HasPartialConsensusConfig ProtocolB
 

--- a/ouroboros-consensus-protocol/src/ouroboros-consensus-protocol/Ouroboros/Consensus/Protocol/Praos/Translate.hs
+++ b/ouroboros-consensus-protocol/src/ouroboros-consensus-protocol/Ouroboros/Consensus/Protocol/Praos/Translate.hs
@@ -19,10 +19,7 @@ import qualified Cardano.Protocol.TPraos.Rules.Tickn as SL
 import           Data.Coerce (coerce)
 import qualified Data.Map.Strict as Map
 import           Ouroboros.Consensus.Protocol.Praos (ConsensusConfig (..),
-                     Praos, PraosParams (..), PraosState (..),
-                     Ticked (TickedPraosLedgerView))
-import           Ouroboros.Consensus.Protocol.Praos.Views
-                     (LedgerView (lvMaxBodySize, lvMaxHeaderSize, lvProtocolVersion))
+                     Praos, PraosParams (..), PraosState (..))
 import qualified Ouroboros.Consensus.Protocol.Praos.Views as Views
 import           Ouroboros.Consensus.Protocol.TPraos (TPraos, TPraosParams (..),
                      TPraosState (tpraosStateChainDepState, tpraosStateLastSlot))
@@ -64,15 +61,15 @@ instance
         praosEpochInfo = tpraosEpochInfo
       }
 
-  translateTickedLedgerView (TPraos.TickedPraosLedgerView lv) =
-      TickedPraosLedgerView $ translateLedgerView lv
+  translateTickedLedgerView (TPraos.TickedTPraosLedgerView lv) =
+      translateLedgerView lv
     where
       translateLedgerView SL.LedgerView {SL.lvPoolDistr, SL.lvChainChecks} =
-        Views.LedgerView
+        Views.TickedPraosLedgerView
           { Views.lvPoolDistr = coercePoolDistr lvPoolDistr,
-            lvMaxHeaderSize = SL.ccMaxBHSize lvChainChecks,
-            lvMaxBodySize = SL.ccMaxBBSize lvChainChecks,
-            lvProtocolVersion = SL.ccProtocolVersion lvChainChecks
+            Views.lvMaxHeaderSize = SL.ccMaxBHSize lvChainChecks,
+            Views.lvMaxBodySize = SL.ccMaxBBSize lvChainChecks,
+            Views.lvProtocolVersion = SL.ccProtocolVersion lvChainChecks
           }
         where
           coercePoolDistr :: SL.PoolDistr c1 -> SL.PoolDistr c2

--- a/ouroboros-consensus-protocol/src/ouroboros-consensus-protocol/Ouroboros/Consensus/Protocol/Praos/Views.hs
+++ b/ouroboros-consensus-protocol/src/ouroboros-consensus-protocol/Ouroboros/Consensus/Protocol/Praos/Views.hs
@@ -1,8 +1,11 @@
-{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DataKinds      #-}
+{-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE TypeFamilies   #-}
 
 module Ouroboros.Consensus.Protocol.Praos.Views (
     HeaderView (..)
-  , LedgerView (..)
+  , PraosLedgerView
+  , Ticked (..)
   ) where
 
 import           Cardano.Crypto.KES (SignedKES)
@@ -17,6 +20,7 @@ import           Cardano.Slotting.Slot (SlotNo)
 import           Numeric.Natural (Natural)
 import           Ouroboros.Consensus.Protocol.Praos.Header (HeaderBody)
 import           Ouroboros.Consensus.Protocol.Praos.VRF (InputVRF)
+import           Ouroboros.Consensus.Ticked
 
 -- | View of the block header required by the Praos protocol.
 data HeaderView crypto = HeaderView
@@ -38,7 +42,10 @@ data HeaderView crypto = HeaderView
     hvSignature :: !(SignedKES (KES crypto) (HeaderBody crypto))
   }
 
-data LedgerView crypto = LedgerView
+data PraosLedgerView crypto
+
+-- | Ledger view at a particular slot
+data instance Ticked (PraosLedgerView crypto) = TickedPraosLedgerView
   { -- | Stake distribution
     lvPoolDistr       :: SL.PoolDistr crypto,
     -- | Maximum header size

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Forecast.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Forecast.hs
@@ -6,6 +6,7 @@ module Ouroboros.Consensus.Forecast (
   , constantForecastOf
   , mapForecast
   , trivialForecast
+  , trivialVoidForecast
     -- * Utilities for constructing forecasts
   , crossEraForecastBound
   ) where
@@ -39,6 +40,13 @@ mapForecast f (Forecast at for) = Forecast{
 -- Specialization of 'constantForecast'.
 trivialForecast :: GetTip b => b -> Forecast ()
 trivialForecast x = constantForecastOf TickedTrivial (getTipSlot x)
+
+-- | Trivial forecast of values of type @()@ performed by an instance of
+-- 'GetTip'.
+--
+-- Specialization of 'constantForecast'.
+trivialVoidForecast :: GetTip b => b -> Forecast VoidUntilTicked
+trivialVoidForecast x = constantForecastOf TickedVoid (getTipSlot x)
 
 -- | Forecast where the values are never changing
 --

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Embed/Unary.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Embed/Unary.hs
@@ -556,14 +556,6 @@ instance Isomorphic WrapForgeStateInfo where
       . OneEraForgeStateInfo
       . Z
 
-instance Isomorphic WrapLedgerView where
-  project = State.fromTZ . hardForkLedgerViewPerEra . unwrapLedgerView
-  inject  = WrapLedgerView
-          . HardForkLedgerView TransitionImpossible
-          . HardForkState
-          . Telescope.TZ
-          . Current History.initBound
-
 instance Isomorphic (SomeSecond (NestedCtxt f)) where
   project (SomeSecond ctxt) = SomeSecond $ projNestedCtxt ctxt
   inject  (SomeSecond ctxt) = SomeSecond $ injNestedCtxt  ctxt

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Protocol.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Protocol.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveAnyClass             #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE EmptyCase                  #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -23,7 +24,7 @@ module Ouroboros.Consensus.HardFork.Combinator.Protocol (
   , HardForkValidationErr (..)
     -- * Re-exports to keep 'Protocol.LedgerView' an internal module
   , HardForkLedgerView
-  , HardForkLedgerView_ (..)
+  , HardForkLedgerView_
     -- * Type family instances
   , Ticked (..)
   ) where
@@ -49,7 +50,7 @@ import           Ouroboros.Consensus.HardFork.Combinator.Info
 import           Ouroboros.Consensus.HardFork.Combinator.PartialConfig
 import           Ouroboros.Consensus.HardFork.Combinator.Protocol.ChainSel
 import           Ouroboros.Consensus.HardFork.Combinator.Protocol.LedgerView
-                     (HardForkLedgerView, HardForkLedgerView_ (..), Ticked (..))
+                     (HardForkLedgerView, HardForkLedgerView_, Ticked (..))
 import           Ouroboros.Consensus.HardFork.Combinator.State (HardForkState,
                      Translate (..))
 import qualified Ouroboros.Consensus.HardFork.Combinator.State as State
@@ -107,6 +108,8 @@ instance CanHardFork xs => ConsensusProtocol (HardForkProtocol xs) where
   --
   -- Straight-forward extensions
   --
+
+  invariantLedgerViewEmpty _proxy = \case {}
 
   -- Security parameter must be equal across /all/ eras
   protocolSecurityParam = hardForkConsensusConfigK

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Protocol/BFT.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Protocol/BFT.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE DeriveAnyClass            #-}
 {-# LANGUAGE DeriveGeneric             #-}
+{-# LANGUAGE EmptyCase                 #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleContexts          #-}
 {-# LANGUAGE FlexibleInstances         #-}
+{-# LANGUAGE LambdaCase                #-}
 {-# LANGUAGE MultiParamTypeClasses     #-}
 {-# LANGUAGE NamedFieldPuns            #-}
 {-# LANGUAGE RecordWildCards           #-}
@@ -124,10 +126,12 @@ data instance ConsensusConfig (Bft c) = BftConfig {
 instance BftCrypto c => ConsensusProtocol (Bft c) where
   type ValidationErr (Bft c) = BftValidationErr
   type ValidateView  (Bft c) = BftValidateView c
-  type LedgerView    (Bft c) = ()
+  type LedgerView    (Bft c) = VoidUntilTicked
   type IsLeader      (Bft c) = ()
   type ChainDepState (Bft c) = ()
   type CanBeLeader   (Bft c) = CoreNodeId
+
+  invariantLedgerViewEmpty _proxy = \case {}
 
   protocolSecurityParam = bftSecurityParam . bftParams
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Protocol/ModChainSel.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Protocol/ModChainSel.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE EmptyCase         #-}
+{-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeFamilies      #-}
 
@@ -8,6 +10,7 @@ module Ouroboros.Consensus.Protocol.ModChainSel (
   , ConsensusConfig (..)
   ) where
 
+import           Data.Proxy (Proxy (Proxy))
 import           Data.Typeable (Typeable)
 import           GHC.Generics (Generic)
 import           NoThunks.Class (NoThunks)
@@ -34,6 +37,11 @@ instance ( ConsensusProtocol p
     type LedgerView    (ModChainSel p s) = LedgerView    p
     type ValidationErr (ModChainSel p s) = ValidationErr p
     type ValidateView  (ModChainSel p s) = ValidateView  p
+
+    invariantLedgerViewEmpty = invariantLedgerViewEmpty . proxyP
+      where
+        proxyP :: Proxy (ModChainSel p s) -> Proxy p
+        proxyP Proxy = Proxy
 
     checkIsLeader         = checkIsLeader         . mcsConfigP
     tickChainDepState     = tickChainDepState     . mcsConfigP

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ticked.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ticked.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE EmptyDataDecls             #-}
 {-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE FlexibleInstances          #-}
@@ -6,7 +7,7 @@
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE TypeOperators              #-}
 
-module Ouroboros.Consensus.Ticked (Ticked (..)) where
+module Ouroboros.Consensus.Ticked (Ticked (..), VoidUntilTicked) where
 
 import           Data.Kind (Type)
 import           Data.SOP.BasicFunctors
@@ -36,6 +37,11 @@ data instance Ticked () = TickedTrivial
   deriving (Show)
 
 newtype instance Ticked (K a x) = TickedK { getTickedK :: Ticked a }
+
+data VoidUntilTicked
+
+data instance Ticked VoidUntilTicked = TickedVoid
+  deriving (Show)
 
 {-------------------------------------------------------------------------------
   Forwarding type class instances

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/TypeFamilyWrappers.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/TypeFamilyWrappers.hs
@@ -25,7 +25,7 @@ module Ouroboros.Consensus.TypeFamilyWrappers (
   , WrapChainDepState (..)
   , WrapConsensusConfig (..)
   , WrapIsLeader (..)
-  , WrapLedgerView (..)
+  , WrapLedgerView
   , WrapSelectView (..)
   , WrapValidateView (..)
   , WrapValidatedGenTx (..)
@@ -84,7 +84,7 @@ newtype WrapCanBeLeader     blk = WrapCanBeLeader     { unwrapCanBeLeader     ::
 newtype WrapChainDepState   blk = WrapChainDepState   { unwrapChainDepState   :: ChainDepState   (BlockProtocol blk) }
 newtype WrapConsensusConfig blk = WrapConsensusConfig { unwrapConsensusConfig :: ConsensusConfig (BlockProtocol blk) }
 newtype WrapIsLeader        blk = WrapIsLeader        { unwrapIsLeader        :: IsLeader        (BlockProtocol blk) }
-newtype WrapLedgerView      blk = WrapLedgerView      { unwrapLedgerView      :: LedgerView      (BlockProtocol blk) }
+data    WrapLedgerView      blk
 newtype WrapSelectView      blk = WrapSelectView      { unwrapSelectView      :: SelectView      (BlockProtocol blk) }
 newtype WrapValidateView    blk = WrapValidateView    { unwrapValidateView    :: ValidateView    (BlockProtocol blk) }
 newtype WrapValidationErr   blk = WrapValidationErr   { unwrapValidationErr   :: ValidationErr   (BlockProtocol blk) }
@@ -140,7 +140,6 @@ deriving instance Eq (ValidationErr (BlockProtocol blk)) => Eq (WrapValidationEr
 deriving instance Ord (SelectView (BlockProtocol blk)) => Ord (WrapSelectView blk)
 
 deriving instance Show (ChainDepState (BlockProtocol blk)) => Show (WrapChainDepState blk)
-deriving instance Show (LedgerView    (BlockProtocol blk)) => Show (WrapLedgerView    blk)
 deriving instance Show (SelectView    (BlockProtocol blk)) => Show (WrapSelectView    blk)
 deriving instance Show (ValidationErr (BlockProtocol blk)) => Show (WrapValidationErr blk)
 

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestBlock.hs
@@ -525,8 +525,8 @@ instance (PayloadSemantics ptype) => ValidateEnvelope (TestBlockWith ptype) wher
   -- Use defaults
 
 instance (PayloadSemantics ptype) => LedgerSupportsProtocol (TestBlockWith ptype) where
-  protocolLedgerView   _ _  = TickedTrivial
-  ledgerViewForecastAt _    = trivialForecast
+  protocolLedgerView   _ _  = TickedVoid
+  ledgerViewForecastAt _    = trivialVoidForecast
 
 singleNodeTestConfigWith ::
      CodecConfig (TestBlockWith ptype)

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Block/BFT.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Block/BFT.hs
@@ -104,8 +104,8 @@ instance ( SimpleCrypto c
          , BftCrypto c'
          , Signable (BftDSIGN c') (SignedSimpleBft c c')
          ) => LedgerSupportsProtocol (SimpleBftBlock c c') where
-  protocolLedgerView   _ _ = TickedTrivial
-  ledgerViewForecastAt _   = trivialForecast
+  protocolLedgerView   _ _ = TickedVoid
+  ledgerViewForecastAt _   = trivialVoidForecast
 
 {-------------------------------------------------------------------------------
   Forging

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Block/PBFT.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Block/PBFT.hs
@@ -90,7 +90,7 @@ _simplePBftHeader = simpleHeader
 instance (SimpleCrypto c, PBftCrypto c')
       => MockProtocolSpecific c (SimplePBftExt c c') where
   -- | PBFT requires the ledger view; for the mock ledger, this is constant
-  type MockLedgerConfig c (SimplePBftExt c c') = PBftLedgerView c'
+  type MockLedgerConfig c (SimplePBftExt c c') = Ticked (PBftLedgerView c')
 
 {-------------------------------------------------------------------------------
   Evidence that SimpleBlock can support PBFT
@@ -118,14 +118,10 @@ instance ( SimpleCrypto c
 instance ( SimpleCrypto c
          , Signable MockDSIGN (SignedSimplePBft c PBftMockCrypto)
          ) => LedgerSupportsProtocol (SimplePBftBlock c PBftMockCrypto) where
-  protocolLedgerView   cfg _  = pretendTicked $ simpleMockLedgerConfig cfg
+  protocolLedgerView   cfg _  = simpleMockLedgerConfig cfg
   ledgerViewForecastAt cfg st = constantForecastOf
-                                 (pretendTicked $ simpleMockLedgerConfig cfg)
+                                 (simpleMockLedgerConfig cfg)
                                  (getTipSlot st)
-
-pretendTicked :: PBftLedgerView PBftMockCrypto
-              -> Ticked (PBftLedgerView PBftMockCrypto)
-pretendTicked (PBftLedgerView ds) = TickedPBftLedgerView ds
 
 {-------------------------------------------------------------------------------
   Forging

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Block/Praos.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Block/Praos.hs
@@ -31,7 +31,6 @@ import           GHC.Generics (Generic)
 import           NoThunks.Class (NoThunks)
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Forecast
-import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Mock.Ledger.Address
 import           Ouroboros.Consensus.Mock.Ledger.Block
@@ -116,10 +115,8 @@ instance ( SimpleCrypto c
          , PraosCrypto c'
          , Signable (PraosKES c') (SignedSimplePraos c c')
          ) => LedgerSupportsProtocol (SimplePraosBlock c c') where
-  protocolLedgerView   _ _  = TickedTrivial
-  ledgerViewForecastAt _ st = constantForecastOf
-                                 TickedTrivial
-                                 (getTipSlot st)
+  protocolLedgerView   _ _  = TickedVoid
+  ledgerViewForecastAt _    = trivialVoidForecast
 
 {-------------------------------------------------------------------------------
   Forging

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Block/PraosRule.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Block/PraosRule.hs
@@ -95,8 +95,8 @@ instance
 instance
   ( SimpleCrypto c
   ) => LedgerSupportsProtocol (SimplePraosRuleBlock c) where
-  protocolLedgerView   _ _ = TickedTrivial
-  ledgerViewForecastAt _   = trivialForecast
+  protocolLedgerView   _ _ = TickedVoid
+  ledgerViewForecastAt _   = trivialVoidForecast
 
 {-------------------------------------------------------------------------------
   We don't need crypto for this protocol

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Node/PBFT.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Node/PBFT.hs
@@ -45,8 +45,8 @@ protocolInfoMockPBFT params eraParams =
                                          (genesisHeaderState S.empty)
       }
   where
-    ledgerView :: PBftLedgerView PBftMockCrypto
-    ledgerView = PBftLedgerView $ Bimap.fromList [
+    ledgerView :: Ticked (PBftLedgerView PBftMockCrypto)
+    ledgerView = TickedPBftLedgerView $ Bimap.fromList [
           (PBftMockVerKeyHash (verKey n), PBftMockVerKeyHash (verKey n))
         | n <- enumCoreNodes (pbftNumNodes params)
         ]

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Protocol/LeaderSchedule.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Protocol/LeaderSchedule.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE EmptyCase         #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE RecordWildCards   #-}
 {-# LANGUAGE TypeFamilies      #-}
 
@@ -39,11 +41,13 @@ instance ConsensusProtocol p => ConsensusProtocol (WithLeaderSchedule p) where
   type SelectView    (WithLeaderSchedule p) = SelectView p
 
   type ChainDepState (WithLeaderSchedule p) = ()
-  type LedgerView    (WithLeaderSchedule p) = ()
+  type LedgerView    (WithLeaderSchedule p) = VoidUntilTicked
   type ValidationErr (WithLeaderSchedule p) = ()
   type IsLeader      (WithLeaderSchedule p) = ()
   type ValidateView  (WithLeaderSchedule p) = ()
   type CanBeLeader   (WithLeaderSchedule p) = ()
+
+  invariantLedgerViewEmpty _proxy = \case {}
 
   protocolSecurityParam = protocolSecurityParam . wlsConfigP
 

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/TestBlock.hs
@@ -624,8 +624,8 @@ instance ValidateEnvelope TestBlock where
         $ cfg
 
 instance LedgerSupportsProtocol TestBlock where
-  protocolLedgerView   _ _  = TickedTrivial
-  ledgerViewForecastAt _    = trivialForecast
+  protocolLedgerView   _ _  = TickedVoid
+  ledgerViewForecastAt _    = trivialVoidForecast
 
 instance HasHardForkHistory TestBlock where
   type HardForkIndices TestBlock = '[TestBlock]


### PR DESCRIPTION
Enforcing this property as in this PR is not actually necessary, but we suspect it may prevent a good deal of confusion.