### PR TITLE
Cross era ticking

### DIFF
--- a/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
+++ b/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
@@ -163,6 +163,7 @@ getByronTip state =
 -- | The ticked Byron ledger state
 data instance Ticked (LedgerState ByronBlock) = TickedByronLedgerState {
       tickedByronLedgerState        :: !CC.ChainValidationState
+    , untickedByronLedgerTipBlockNo :: !(WithOrigin BlockNo)
     , untickedByronLedgerTransition :: !ByronTransition
     }
   deriving (Generic, NoThunks)
@@ -179,6 +180,8 @@ instance IsLedger (LedgerState ByronBlock) where
             CC.applyChainTick cfg (toByronSlotNo slotNo) byronLedgerState
         , untickedByronLedgerTransition =
             byronLedgerTransition
+        , untickedByronLedgerTipBlockNo =
+            byronLedgerTipBlockNo
         }
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/CanHardFork.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/CanHardFork.hs
@@ -285,15 +285,15 @@ instance CardanoHardForkConstraints c => CanHardFork (CardanoEras c) where
         $ PCons crossEraTickLedgerStateAcrossTPraos
         $ PCons crossEraTickLedgerStateAcrossTPraos
         $ PCons crossEraTickLedgerStateAcrossTPraos
-        $ PCons crossEraTickLedgerStateTPraosToPraos
-        $ PCons crossEraTickLedgerStateAcrossPraos
+        $ PCons crossEraTickLedgerStateTPraosToPraos   -- TODO is there an Alonzo->Babbage bug wrt extraEntropy?
+        $ PCons crossEraTickLedgerStateAcrossPraos   -- TODO fix Babbage->Conway bug
         $ PNil
     , crossEraTickChainDepState =
           PCons crossEraTickChainDepStateByronToShelley
         $ PCons crossEraTickChainDepStateAcrossShelley
         $ PCons crossEraTickChainDepStateAcrossShelley
         $ PCons crossEraTickChainDepStateAcrossShelley
-        $ PCons crossEraTickChainDepStateAcrossShelley
+        $ PCons crossEraTickChainDepStateAcrossShelley   -- TODO is there an Alonzo->Babbage bug wrt extraEntropy?
         $ PCons crossEraTickChainDepStateAcrossShelley
         $ PNil
     , crossEraForecast =
@@ -301,7 +301,7 @@ instance CardanoHardForkConstraints c => CanHardFork (CardanoEras c) where
         $ PCons crossEraForecastAcrossShelley
         $ PCons crossEraForecastAcrossShelley
         $ PCons crossEraForecastAcrossShelley
-        $ PCons crossEraForecastAcrossShelley
+        $ PCons crossEraForecastAcrossShelley   -- TODO is there an Alonzo->Babbage bug wrt extraEntropy?
         $ PCons crossEraForecastAcrossShelley
         $ PNil
     }

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Node.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Node.hs
@@ -120,6 +120,8 @@ import           Ouroboros.Consensus.Storage.Serialisation
 import           Ouroboros.Consensus.Util.Assert
 import           Ouroboros.Consensus.Util.IOLike
 
+import           Ouroboros.Consensus.Shelley.Ledger.Ledger ()
+
 {-------------------------------------------------------------------------------
   SerialiseHFC
 -------------------------------------------------------------------------------}

--- a/ouroboros-consensus-cardano/src/unstable-cardano-testlib/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-testlib/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
@@ -37,7 +37,7 @@ import           Data.Void (Void)
 import           Ouroboros.Consensus.Block.Forging (BlockForging)
 import           Ouroboros.Consensus.Cardano.CanHardFork
                      (ShelleyPartialLedgerConfig (..), forecastAcrossShelley,
-                     translateChainDepStateAcrossShelley)
+                     crossEraTickChainDepStateAcrossShelley)
 import           Ouroboros.Consensus.Cardano.Node
                      (ProtocolTransitionParams (..), TriggerHardFork (..))
 import           Ouroboros.Consensus.HardFork.Combinator
@@ -45,7 +45,9 @@ import           Ouroboros.Consensus.HardFork.Combinator.Embed.Binary
 import           Ouroboros.Consensus.HardFork.Combinator.Serialisation
 import qualified Ouroboros.Consensus.HardFork.Combinator.State.Types as HFC
 import qualified Ouroboros.Consensus.HardFork.History as History
-import           Ouroboros.Consensus.Ledger.Basics (LedgerConfig)
+import           Ouroboros.Consensus.Ledger.Basics
+                    (LedgerConfig, applyChainTickLedgerResult,
+                    pureLedgerResult)
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
                      (LedgerSupportsProtocol)
 import           Ouroboros.Consensus.Mempool (TxLimits)
@@ -146,24 +148,22 @@ instance ShelleyBasedHardForkConstraints proto1 era1 proto2 era2
 instance ShelleyBasedHardForkConstraints proto1 era1 proto2 era2
       => CanHardFork (ShelleyBasedHardForkEras proto1 era1 proto2 era2) where
   hardForkEraTranslation = EraTranslation {
-        translateLedgerState   = PCons translateLedgerState                PNil
-      , translateChainDepState = PCons translateChainDepStateAcrossShelley PNil
-      , crossEraForecast       = PCons forecastAcrossShelleyWrapper        PNil
+        crossEraTickLedgerState   = PCons crossEraTickLedgerStateAcrossShelley   PNil
+      , crossEraTickChainDepState = PCons crossEraTickChainDepStateAcrossShelley PNil
+      , crossEraForecast          = PCons forecastAcrossShelleyWrapper           PNil
       }
     where
-      translateLedgerState ::
-           InPairs.RequiringBoth
-             WrapLedgerConfig
-             (HFC.Translate LedgerState)
+      crossEraTickLedgerStateAcrossShelley ::
+           HFC.CrossEraTickLedgerState
              (ShelleyBlock proto1 era1)
              (ShelleyBlock proto2 era2)
-      translateLedgerState =
-          InPairs.RequireBoth
-        $ \_cfg1 cfg2 -> HFC.Translate
-        $ \_epochNo ->
-              unComp
-            . SL.translateEra'
-                (shelleyLedgerTranslationContext (unwrapLedgerConfig cfg2))
+      crossEraTickLedgerStateAcrossShelley =
+          HFC.CrossEraTickLedgerState
+        $ \_cfg1 cfg2 _epochNo sno ->
+              pureLedgerResult
+            . applyChainTickLedgerResult cfg2 sno
+            . unComp
+            . SL.translateEra' (shelleyLedgerTranslationContext cfg2)
             . Comp
 
       forecastAcrossShelleyWrapper ::

--- a/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/TxGen.hs
+++ b/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/TxGen.hs
@@ -23,6 +23,7 @@ import           Ouroboros.Consensus.HardFork.Combinator
 import qualified Ouroboros.Consensus.HardFork.Combinator.State as State
 import           Ouroboros.Consensus.Node.ProtocolInfo (NumCoreNodes (..))
 import           Ouroboros.Consensus.NodeId (CoreNodeId)
+import           Ouroboros.Consensus.Ticked (WhetherTickedOrNot (..))
 import           Test.QuickCheck (Gen)
 
 {-------------------------------------------------------------------------------
@@ -90,7 +91,8 @@ testGenTxsHfc coreNodeId numCoreNodes curSlotNo cfg extras state =
     cfgs = distribTopLevelConfig ei cfg
     ei   = State.epochInfoLedger
              (configLedger cfg)
-             (hardForkLedgerStatePerEra state)
+         $ hmap (Comp . NoTicked)
+         $ hardForkLedgerStatePerEra state
 
     aux ::
          forall blk. TxGen blk

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/A.hs
@@ -80,6 +80,7 @@ import           Ouroboros.Consensus.Node.Serialisation
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Storage.ImmutableDB (simpleChunkInfo)
 import           Ouroboros.Consensus.Storage.Serialisation
+import           Ouroboros.Consensus.Ticked (WhetherTickedOrNot (..))
 import           Ouroboros.Consensus.Util (repeatedlyM, (..:), (.:))
 import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Consensus.Util.Orphans ()
@@ -431,7 +432,9 @@ instance SingleEraBlock BlockA where
   singleEraInfo _ = SingleEraInfo "A"
 
   singleEraTransition cfg EraParams{..} eraStart st = do
-      (confirmedInSlot, confirmationDepth) <- getConfirmationDepth st
+      (confirmedInSlot, confirmationDepth) <- getConfirmationDepth $ case st of
+        NoTicked x                       -> x
+        YesTicked (TickedLedgerStateA x) -> x
 
       -- The ledger must report the scheduled transition to the next era as soon
       -- as the block containing this transaction is immutable (that is, at

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/B.hs
@@ -31,6 +31,7 @@ module Test.Consensus.HardFork.Combinator.B (
   , LedgerState (..)
   , NestedCtxt_ (..)
   , StorageConfig (..)
+  , Ticked (..)
   , TxId (..)
   ) where
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Abstract/SingleEraBlock.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Abstract/SingleEraBlock.hs
@@ -46,6 +46,7 @@ import           Ouroboros.Consensus.Ledger.SupportsPeerSelection
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Node.InitStorage
 import           Ouroboros.Consensus.Storage.Serialisation
+import           Ouroboros.Consensus.Ticked (WhetherTickedOrNot)
 import           Ouroboros.Consensus.Util.Condense
 
 {-------------------------------------------------------------------------------
@@ -92,7 +93,7 @@ class ( LedgerSupportsProtocol blk
   singleEraTransition :: PartialLedgerConfig blk
                       -> EraParams -- ^ Current era parameters
                       -> Bound     -- ^ Start of this era
-                      -> LedgerState blk
+                      -> WhetherTickedOrNot (LedgerState blk)
                       -> Maybe EpochNo
 
   -- | Era information (for use in error messages)
@@ -105,7 +106,7 @@ singleEraTransition' :: SingleEraBlock blk
                      => WrapPartialLedgerConfig blk
                      -> EraParams
                      -> Bound
-                     -> LedgerState blk -> Maybe EpochNo
+                     -> WhetherTickedOrNot (LedgerState blk) -> Maybe EpochNo
 singleEraTransition' = singleEraTransition . unwrapPartialLedgerConfig
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Abstract/SingleEraBlock.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Abstract/SingleEraBlock.hs
@@ -46,7 +46,6 @@ import           Ouroboros.Consensus.Ledger.SupportsPeerSelection
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Node.InitStorage
 import           Ouroboros.Consensus.Storage.Serialisation
-import           Ouroboros.Consensus.Ticked (Ticked)
 import           Ouroboros.Consensus.Util.Condense
 
 {-------------------------------------------------------------------------------
@@ -93,7 +92,7 @@ class ( LedgerSupportsProtocol blk
   singleEraTransition :: PartialLedgerConfig blk
                       -> EraParams -- ^ Current era parameters
                       -> Bound     -- ^ Start of this era
-                      -> Ticked (LedgerState blk)
+                      -> LedgerState blk
                       -> Maybe EpochNo
 
   -- | Era information (for use in error messages)
@@ -106,8 +105,7 @@ singleEraTransition' :: SingleEraBlock blk
                      => WrapPartialLedgerConfig blk
                      -> EraParams
                      -> Bound
-                     -> Ticked (LedgerState blk)
-                     -> Maybe EpochNo
+                     -> LedgerState blk -> Maybe EpochNo
 singleEraTransition' = singleEraTransition . unwrapPartialLedgerConfig
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Abstract/SingleEraBlock.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Abstract/SingleEraBlock.hs
@@ -46,6 +46,7 @@ import           Ouroboros.Consensus.Ledger.SupportsPeerSelection
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Node.InitStorage
 import           Ouroboros.Consensus.Storage.Serialisation
+import           Ouroboros.Consensus.Ticked (Ticked)
 import           Ouroboros.Consensus.Util.Condense
 
 {-------------------------------------------------------------------------------
@@ -92,7 +93,7 @@ class ( LedgerSupportsProtocol blk
   singleEraTransition :: PartialLedgerConfig blk
                       -> EraParams -- ^ Current era parameters
                       -> Bound     -- ^ Start of this era
-                      -> LedgerState blk
+                      -> Ticked (LedgerState blk)
                       -> Maybe EpochNo
 
   -- | Era information (for use in error messages)
@@ -105,7 +106,8 @@ singleEraTransition' :: SingleEraBlock blk
                      => WrapPartialLedgerConfig blk
                      -> EraParams
                      -> Bound
-                     -> LedgerState blk -> Maybe EpochNo
+                     -> Ticked (LedgerState blk)
+                     -> Maybe EpochNo
 singleEraTransition' = singleEraTransition . unwrapPartialLedgerConfig
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Embed/Nary.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Embed/Nary.hs
@@ -36,6 +36,7 @@ import           Ouroboros.Consensus.HeaderValidation (AnnTip, HeaderState (..),
                      genesisHeaderState)
 import           Ouroboros.Consensus.Ledger.Extended (ExtLedgerState (..))
 import           Ouroboros.Consensus.Storage.Serialisation
+import           Ouroboros.Consensus.Ticked (WhetherTickedOrNot (..))
 import           Ouroboros.Consensus.TypeFamilyWrappers
 import           Ouroboros.Consensus.Util ((.:))
 
@@ -198,20 +199,22 @@ injectInitialExtLedgerState cfg extLedgerState0 =
     cfgs :: NP TopLevelConfig (x ': xs)
     cfgs =
         distribTopLevelConfig
-          (State.epochInfoLedger
-             (configLedger cfg)
-             (hardForkLedgerStatePerEra targetEraLedgerState))
+          ( State.epochInfoLedger (configLedger cfg)
+          $ hmap (Comp . NoTicked)
+          $ hardForkLedgerStatePerEra targetEraLedgerState
+          )
           cfg
 
     targetEraLedgerState :: LedgerState (HardForkBlock (x ': xs))
     targetEraLedgerState =
         HardForkLedgerState $
+          undefined cfgs {-
           -- We can immediately extend it to the right slot, executing any
           -- scheduled hard forks in the first slot
           State.extendToSlot
             (configLedger cfg)
             (SlotNo 0)
-            (initHardForkState (ledgerState extLedgerState0))
+            (initHardForkState (ledgerState extLedgerState0)) -}
 
     firstEraChainDepState :: HardForkChainDepState (x ': xs)
     firstEraChainDepState =
@@ -222,6 +225,8 @@ injectInitialExtLedgerState cfg extLedgerState0 =
 
     targetEraChainDepState :: HardForkChainDepState (x ': xs)
     targetEraChainDepState =
+        undefined InPairs.requiringBoth firstEraChainDepState {-
+
         -- Align the 'ChainDepState' with the ledger state of the target era.
         State.align
           (InPairs.requiringBoth
@@ -229,7 +234,7 @@ injectInitialExtLedgerState cfg extLedgerState0 =
             (translateChainDepState hardForkEraTranslation))
           (hpure (fn_2 (\_ st -> st)))
           (hardForkLedgerStatePerEra targetEraLedgerState)
-          firstEraChainDepState
+          firstEraChainDepState -}
 
     targetEraHeaderState :: HeaderState (HardForkBlock (x ': xs))
     targetEraHeaderState = genesisHeaderState targetEraChainDepState

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Ledger/Query.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Ledger/Query.hs
@@ -69,6 +69,7 @@ import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.Query
 import           Ouroboros.Consensus.Node.Serialisation (Some (..))
+import           Ouroboros.Consensus.Ticked (WhetherTickedOrNot (..))
 import           Ouroboros.Consensus.TypeFamilyWrappers (WrapChainDepState (..))
 import           Ouroboros.Consensus.Util (ShowProxy)
 
@@ -134,7 +135,7 @@ instance All SingleEraBlock xs => QueryLedger (HardForkBlock xs) where
     where
       cfgs = hmap ExtLedgerCfg $ distribTopLevelConfig ei cfg
       lcfg = configLedger cfg
-      ei   = State.epochInfoLedger lcfg hardForkState
+      ei   = State.epochInfoLedger lcfg $ hmap (Comp . NoTicked) hardForkState
 
 -- | Precondition: the 'ledgerState' and 'headerState' should be from the same
 -- era. In practice, this is _always_ the case, unless the 'ExtLedgerState' was
@@ -300,7 +301,7 @@ answerQueryAnytime HardForkLedgerConfig{..} =
           (unwrapPartialLedgerConfig c)
           ps
           (currentStart cur)
-          (currentState cur)
+          (NoTicked $ currentState cur)
 
 {-------------------------------------------------------------------------------
   Hard fork queries

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Protocol.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Protocol.hs
@@ -375,18 +375,7 @@ reupdateEra ei slot cfg (Pair view (Comp chainDepState)) =
 chainDepStateInfo :: forall blk. SingleEraBlock blk
                   => (Ticked :.: WrapChainDepState) blk -> SingleEraInfo blk
 chainDepStateInfo _ = singleEraInfo (Proxy @blk)
-{-
-translateConsensus :: forall xs. CanHardFork xs
-                   => EpochInfo (Except PastHorizonException)
-                   -> ConsensusConfig (HardForkProtocol xs)
-                   -> InPairs (Translate WrapChainDepState) xs
-translateConsensus ei HardForkConsensusConfig{..} =
-    InPairs.requiringBoth cfgs $
-       translateChainDepState hardForkEraTranslation
-  where
-    pcfgs = getPerEraConsensusConfig hardForkConsensusConfigPerEra
-    cfgs  = hcmap proxySingle (completeConsensusConfig'' ei) pcfgs
--}
+
 injectValidationErr :: Index xs blk
                     -> ValidationErr (BlockProtocol blk)
                     -> HardForkValidationErr xs

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/State.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/State.hs
@@ -17,7 +17,7 @@
 module Ouroboros.Consensus.HardFork.Combinator.State (
     module X
     -- * Support for defining instances
-  , getTip
+  , Ouroboros.Consensus.HardFork.Combinator.State.getTip
     -- * Serialisation support
   , recover
     -- * EpochInfo
@@ -48,7 +48,7 @@ import           Ouroboros.Consensus.HardFork.Combinator.State.Instances as X ()
 import           Ouroboros.Consensus.HardFork.Combinator.State.Types as X
 import           Ouroboros.Consensus.HardFork.Combinator.Translation
 import qualified Ouroboros.Consensus.HardFork.History as History
-import           Ouroboros.Consensus.Ledger.Abstract hiding (getTip)
+import           Ouroboros.Consensus.Ledger.Abstract as Ledger
 import           Ouroboros.Consensus.Ticked (Ticked)
 import           Ouroboros.Consensus.TypeFamilyWrappers (WrapLedgerConfig (..))
 import           Ouroboros.Consensus.Util ((.:))
@@ -126,8 +126,8 @@ mostRecentTransitionInfo HardForkLedgerConfig{..} st =
                   -> Current (Ticked :.: LedgerState) blk
                   -> K TransitionInfo                 blk
     getTransition cfg (K eraParams) Current{..} = K $
-        case singleEraTransition' cfg eraParams currentStart currentState of
-          Nothing -> TransitionUnknown (ledgerTipSlot currentState)
+        case singleEraTransition' cfg eraParams currentStart (unComp currentState) of
+          Nothing -> TransitionUnknown (pointSlot $ Ledger.getTip (unComp currentState))
           Just e  -> TransitionKnown e
 
 reconstructSummaryLedger :: All SingleEraBlock xs

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/State.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/State.hs
@@ -25,8 +25,6 @@ module Ouroboros.Consensus.HardFork.Combinator.State (
   , epochInfoPrecomputedTransitionInfo
   , mostRecentTransitionInfo
   , reconstructSummaryLedger
-    -- * Ledger specific functionality
-  , extendToSlot
   ) where
 
 import           Control.Monad (guard)
@@ -35,7 +33,7 @@ import           Data.Proxy
 import           Data.SOP.BasicFunctors
 import           Data.SOP.Constraint
 import           Data.SOP.Counting (getExactly)
-import           Data.SOP.InPairs (InPairs, Requiring (..))
+import           Data.SOP.InPairs (InPairs)
 import qualified Data.SOP.InPairs as InPairs
 import           Data.SOP.Strict
 import           Data.SOP.Telescope (Extend (..), ScanNext (..), Telescope)
@@ -51,6 +49,8 @@ import           Ouroboros.Consensus.HardFork.Combinator.State.Types as X
 import           Ouroboros.Consensus.HardFork.Combinator.Translation
 import qualified Ouroboros.Consensus.HardFork.History as History
 import           Ouroboros.Consensus.Ledger.Abstract hiding (getTip)
+import           Ouroboros.Consensus.Ticked (Ticked)
+import           Ouroboros.Consensus.TypeFamilyWrappers (WrapLedgerConfig (..))
 import           Ouroboros.Consensus.Util ((.:))
 import           Prelude hiding (sequence)
 
@@ -107,7 +107,7 @@ recover =
 
 mostRecentTransitionInfo :: All SingleEraBlock xs
                          => HardForkLedgerConfig xs
-                         -> HardForkState LedgerState xs
+                         -> HardForkState (Ticked :.: LedgerState) xs
                          -> TransitionInfo
 mostRecentTransitionInfo HardForkLedgerConfig{..} st =
     hcollapse $
@@ -120,11 +120,11 @@ mostRecentTransitionInfo HardForkLedgerConfig{..} st =
   where
     cfgs = getPerEraLedgerConfig hardForkLedgerConfigPerEra
 
-    getTransition :: SingleEraBlock          blk
-                  => WrapPartialLedgerConfig blk
-                  -> K History.EraParams     blk
-                  -> Current LedgerState     blk
-                  -> K TransitionInfo        blk
+    getTransition :: SingleEraBlock                   blk
+                  => WrapPartialLedgerConfig          blk
+                  -> K History.EraParams              blk
+                  -> Current (Ticked :.: LedgerState) blk
+                  -> K TransitionInfo                 blk
     getTransition cfg (K eraParams) Current{..} = K $
         case singleEraTransition' cfg eraParams currentStart currentState of
           Nothing -> TransitionUnknown (ledgerTipSlot currentState)
@@ -132,7 +132,7 @@ mostRecentTransitionInfo HardForkLedgerConfig{..} st =
 
 reconstructSummaryLedger :: All SingleEraBlock xs
                          => HardForkLedgerConfig xs
-                         -> HardForkState LedgerState xs
+                         -> HardForkState (Ticked :.: LedgerState) xs
                          -> History.Summary xs
 reconstructSummaryLedger cfg@HardForkLedgerConfig{..} st =
     reconstructSummary
@@ -146,7 +146,7 @@ reconstructSummaryLedger cfg@HardForkLedgerConfig{..} st =
 -- It should not be stored.
 epochInfoLedger :: All SingleEraBlock xs
                 => HardForkLedgerConfig xs
-                -> HardForkState LedgerState xs
+                -> HardForkState (Ticked :.: LedgerState) xs
                 -> EpochInfo (Except PastHorizonException)
 epochInfoLedger cfg st =
     History.summaryToEpochInfo $
@@ -164,71 +164,3 @@ epochInfoPrecomputedTransitionInfo ::
 epochInfoPrecomputedTransitionInfo shape transition st =
     History.summaryToEpochInfo $
       reconstructSummary shape transition st
-
-{-------------------------------------------------------------------------------
-  Extending
--------------------------------------------------------------------------------}
-
--- | Extend the telescope until the specified slot is within the era at the tip
-extendToSlot :: forall xs. CanHardFork xs
-             => HardForkLedgerConfig xs
-             -> SlotNo
-             -> HardForkState LedgerState xs -> HardForkState LedgerState xs
-extendToSlot ledgerCfg@HardForkLedgerConfig{..} slot ledgerSt@(HardForkState st) =
-      HardForkState . unI
-    . Telescope.extend
-        ( InPairs.hmap (\f -> Require $ \(K t)
-                           -> Extend  $ \cur
-                           -> I $ howExtend f t cur)
-        $ translate
-        )
-        (hczipWith
-           proxySingle
-           (fn .: whenExtend)
-           pcfgs
-           (getExactly (History.getShape hardForkLedgerConfigShape)))
-    $ st
-  where
-    pcfgs = getPerEraLedgerConfig hardForkLedgerConfigPerEra
-    cfgs  = hcmap proxySingle (completeLedgerConfig'' ei) pcfgs
-    ei    = epochInfoLedger ledgerCfg ledgerSt
-
-    -- Return the end of this era if we should transition to the next
-    whenExtend :: SingleEraBlock              blk
-               => WrapPartialLedgerConfig     blk
-               -> K History.EraParams         blk
-               -> Current LedgerState         blk
-               -> (Maybe :.: K History.Bound) blk
-    whenExtend pcfg (K eraParams) cur = Comp $ K <$> do
-        transition <- singleEraTransition'
-                        pcfg
-                        eraParams
-                        (currentStart cur)
-                        (currentState cur)
-        let endBound = History.mkUpperBound
-                         eraParams
-                         (currentStart cur)
-                         transition
-        guard (slot >= History.boundSlot endBound)
-        return endBound
-
-    howExtend :: Translate LedgerState blk blk'
-              -> History.Bound
-              -> Current LedgerState blk
-              -> (K Past blk, Current LedgerState blk')
-    howExtend f currentEnd cur = (
-          K Past {
-              pastStart    = currentStart cur
-            , pastEnd      = currentEnd
-            }
-        , Current {
-              currentStart = currentEnd
-            , currentState = translateWith f
-                               (History.boundEpoch currentEnd)
-                               (currentState cur)
-            }
-        )
-
-    translate :: InPairs (Translate LedgerState) xs
-    translate = InPairs.requiringBoth cfgs $
-                  translateLedgerState hardForkEraTranslation

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/State.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/State.hs
@@ -27,16 +27,14 @@ module Ouroboros.Consensus.HardFork.Combinator.State (
   , reconstructSummaryLedger
   ) where
 
-import           Control.Monad (guard)
 import           Data.Functor.Product
 import           Data.Proxy
 import           Data.SOP.BasicFunctors
 import           Data.SOP.Constraint
 import           Data.SOP.Counting (getExactly)
-import           Data.SOP.InPairs (InPairs)
 import qualified Data.SOP.InPairs as InPairs
 import           Data.SOP.Strict
-import           Data.SOP.Telescope (Extend (..), ScanNext (..), Telescope)
+import           Data.SOP.Telescope (ScanNext (..), Telescope)
 import qualified Data.SOP.Telescope as Telescope
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HardFork.Combinator.Abstract
@@ -46,12 +44,9 @@ import           Ouroboros.Consensus.HardFork.Combinator.PartialConfig
 import           Ouroboros.Consensus.HardFork.Combinator.State.Infra as X
 import           Ouroboros.Consensus.HardFork.Combinator.State.Instances as X ()
 import           Ouroboros.Consensus.HardFork.Combinator.State.Types as X
-import           Ouroboros.Consensus.HardFork.Combinator.Translation
 import qualified Ouroboros.Consensus.HardFork.History as History
 import           Ouroboros.Consensus.Ledger.Abstract as Ledger
-import           Ouroboros.Consensus.Ticked (Ticked, WhetherTickedOrNot (..))
-import           Ouroboros.Consensus.TypeFamilyWrappers (WrapLedgerConfig (..))
-import           Ouroboros.Consensus.Util ((.:))
+import           Ouroboros.Consensus.Ticked (WhetherTickedOrNot (..))
 import           Prelude hiding (sequence)
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/State/Types.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/State/Types.hs
@@ -155,7 +155,7 @@ data TransitionInfo =
   | TransitionImpossible
   deriving (Show, Generic, NoThunks)
 
-type CrossEraTickChainDepState' x y =                            (ConsensusConfig x -> ConsensusConfig y -> Ticked (LedgerView y)  -> EpochNo -> SlotNo -> ChainDepState x ->                                                             Ticked (ChainDepState y))
-data CrossEraTickLedgerState    x y = CrossEraTickLedgerState    (LedgerConfig    x -> LedgerConfig    y ->                           EpochNo -> SlotNo -> LedgerState   x -> LedgerResult (LedgerState x) (LedgerResult (LedgerState y) (Ticked (LedgerState   y))))
+type CrossEraTickChainDepState' x y =                         (ConsensusConfig x -> ConsensusConfig y -> Ticked (LedgerView y)  -> EpochNo -> SlotNo -> ChainDepState x ->                                                             Ticked (ChainDepState y))
+data CrossEraTickLedgerState    x y = CrossEraTickLedgerState (LedgerConfig    x -> LedgerConfig    y ->                           EpochNo -> SlotNo -> LedgerState   x -> LedgerResult (LedgerState x) (LedgerResult (LedgerState y) (Ticked (LedgerState   y))))
 
 data CrossEraTickChainDepState x y = CrossEraTickChainDepState (Proxy x -> Proxy y -> CrossEraTickChainDepState' (BlockProtocol x) (BlockProtocol y))

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Translation.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Translation.hs
@@ -10,23 +10,24 @@ module Ouroboros.Consensus.HardFork.Combinator.Translation (
 import           Data.SOP.InPairs (InPairs (..), RequiringBoth (..))
 import           NoThunks.Class (NoThunks, OnlyCheckWhnfNamed (..))
 import           Ouroboros.Consensus.HardFork.Combinator.State.Types
-import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.Abstract (LedgerState)
 import           Ouroboros.Consensus.TypeFamilyWrappers
+
 {-------------------------------------------------------------------------------
   Translate from one era to the next
 -------------------------------------------------------------------------------}
 
 data EraTranslation xs = EraTranslation {
-      translateLedgerState   :: InPairs (RequiringBoth WrapLedgerConfig    (Translate LedgerState))       xs
-    , translateChainDepState :: InPairs (RequiringBoth WrapConsensusConfig (Translate WrapChainDepState)) xs
-    , crossEraForecast       :: InPairs (RequiringBoth WrapLedgerConfig    (CrossEraForecaster LedgerState WrapLedgerView)) xs
+      crossEraForecast          :: InPairs (RequiringBoth WrapLedgerConfig (CrossEraForecaster LedgerState WrapLedgerView)) xs
+    , crossEraTickChainDepState :: InPairs CrossEraTickChainDepState xs
+    , crossEraTickLedgerState   :: InPairs CrossEraTickLedgerState   xs
     }
   deriving NoThunks
        via OnlyCheckWhnfNamed "EraTranslation" (EraTranslation xs)
 
 trivialEraTranslation :: EraTranslation '[blk]
 trivialEraTranslation = EraTranslation {
-      translateLedgerState   = PNil
-    , crossEraForecast       = PNil
-    , translateChainDepState = PNil
+      crossEraForecast          = PNil
+    , crossEraTickChainDepState = PNil
+    , crossEraTickLedgerState   = PNil
     }

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Basics.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Basics.hs
@@ -19,6 +19,7 @@ module Ouroboros.Consensus.Ledger.Basics (
   , VoidLedgerEvent
   , castLedgerResult
   , embedLedgerResult
+  , joinLedgerResult
   , pureLedgerResult
     -- * Definition of a ledger independent of a choice of block
   , IsLedger (..)
@@ -85,6 +86,19 @@ embedLedgerResult ::
   -> LedgerResult l  a
   -> LedgerResult l' a
 embedLedgerResult inj lr = lr{lrEvents = inj `map` lrEvents lr}
+
+joinLedgerResult ::
+     (AuxLedgerEvent l1 -> AuxLedgerEvent l')
+  -> (AuxLedgerEvent l2 -> AuxLedgerEvent l')
+  -> LedgerResult l1 (LedgerResult l2 a)
+  -> LedgerResult l' a
+joinLedgerResult inj1 inj2 outer =
+  LedgerResult {
+      lrEvents = map inj1 (lrEvents outer) <> map inj2 (lrEvents inner)
+    , lrResult = lrResult inner
+    }
+  where
+    inner = lrResult outer
 
 pureLedgerResult :: a -> LedgerResult l a
 pureLedgerResult a = LedgerResult {

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ticked.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ticked.hs
@@ -6,7 +6,10 @@
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE TypeOperators              #-}
 
-module Ouroboros.Consensus.Ticked (Ticked (..)) where
+module Ouroboros.Consensus.Ticked (
+  Ticked (..),
+  WhetherTickedOrNot (..),
+  ) where
 
 import           Data.Kind (Type)
 import           Data.SOP.BasicFunctors
@@ -36,6 +39,8 @@ data instance Ticked () = TickedTrivial
   deriving (Show)
 
 newtype instance Ticked (K a x) = TickedK { getTickedK :: Ticked a }
+
+data WhetherTickedOrNot x = YesTicked !(Ticked x) | NoTicked !x
 
 {-------------------------------------------------------------------------------
   Forwarding type class instances

--- a/sop-extras/src/Data/SOP/InPairs.hs
+++ b/sop-extras/src/Data/SOP/InPairs.hs
@@ -27,10 +27,9 @@ module Data.SOP.InPairs (
   , hpure
     -- * Functions
   , type (--.-->) (..)
-  , (:**:) (..)
   , Le (..)
   , Ri (..)
-  , Comp2 (..)
+  , (:..:) (..)
   , apNP
     -- * Requiring
   , Requiring (..)
@@ -106,13 +105,11 @@ hcpure _ f =
   RequiringBoth
 -------------------------------------------------------------------------------}
 
+infixr 2 :..:
+newtype (:..:) f g x y = Comp2 {unComp2 :: f (g x y)}
+
 infixr 0 --.-->
-
-newtype Comp2 f g x y = Comp2 {unComp2 :: f (g x y)}
-
 newtype (--.-->) f g x y = DoubleFun {apDoubleFun :: f x y -> g x y}
-
-data (:**:) f g x y = DoublePair (f x y) (g x y)
 
 newtype Le f x y = Le (f x)
 newtype Ri f x y = Ri (f y)


### PR DESCRIPTION
This PR replaces the ledger state translation function and chain-dependent state translation function with corresponding _tick_ functions instead.

The major improvement is that the Hard Fork Combinator no longer imposes a particular scheme for ticking across era boundaries (eg it was only ever using the new era's rules to do so). In particular, this makes it straight-forward to adjust the code to prevent https://github.com/input-output-hk/cardano-ledger/issues/3491.

Closes #345.