### PR TITLE
consensus: replace Ticked LedgerView with LedgerView

### DIFF
--- a/docs/website/contents/for-developers/AbstractProtocol.md
+++ b/docs/website/contents/for-developers/AbstractProtocol.md
@@ -201,7 +201,7 @@ Classes connected to ledgers:
 
   -- | Link protocol to ledger
   class (BlockSupportsProtocol b, UpdateLedger b, ValidateEnvelope b) => LedgerSupportsProtocol b where
-    protocolLedgerView   :: lc → Ticked l → Ticked ledvw   -- 'ledvw' ('LedgerView (BlockProtocol b)') extracted from the ledger
+    protocolLedgerView   :: lc → Ticked l → ledvw          -- 'ledvw' ('LedgerView (BlockProtocol b)') extracted from the ledger
     ledgerViewForecastAt :: lc → l → Forecast ledvw        -- get a forecast (of future 'ledvw's) from a given ledger state.
       
   class (UpdateLedger b) => LedgerSupportsMempool b where

--- a/ouroboros-consensus-cardano/changelog.d/20230922_102830_nick.frisby_simplify_ledger_view.md
+++ b/ouroboros-consensus-cardano/changelog.d/20230922_102830_nick.frisby_simplify_ledger_view.md
@@ -1,0 +1,22 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+### Breaking
+
+- Remove `Ticked (LedgerView X)` data family instances.
+- Remove `toTickedPBftLedgerView`.

--- a/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
+++ b/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
@@ -230,7 +230,7 @@ getProtocolParameters =
 
 instance LedgerSupportsProtocol ByronBlock where
   protocolLedgerView _cfg =
-        toTickedPBftLedgerView
+        toPBftLedgerView
       . CC.getDelegationMap
       . tickedByronLedgerState
 
@@ -250,7 +250,7 @@ instance LedgerSupportsProtocol ByronBlock where
   -- To create a forecast, take the delegation state from the given ledger
   -- state, and apply the updates that should be applied by the given slot.
   ledgerViewForecastAt cfg (ByronLedgerState _tipBlkNo st _) = Forecast at $ \for ->
-      toTickedPBftLedgerView <$> if
+      toPBftLedgerView <$> if
         | for == lastSlot ->
           return $ CC.getDelegationMap st
         | for < maxFor ->

--- a/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/PBFT.hs
+++ b/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/PBFT.hs
@@ -12,7 +12,6 @@ module Ouroboros.Consensus.Byron.Ledger.PBFT (
   , fromPBftLedgerView
   , mkByronContextDSIGN
   , toPBftLedgerView
-  , toTickedPBftLedgerView
   ) where
 
 import qualified Cardano.Chain.Block as CC
@@ -74,9 +73,6 @@ instance BlockSupportsProtocol ByronBlock where
 
 toPBftLedgerView :: Delegation.Map -> PBftLedgerView PBftByronCrypto
 toPBftLedgerView = PBftLedgerView . Delegation.unMap
-
-toTickedPBftLedgerView :: Delegation.Map -> Ticked (PBftLedgerView PBftByronCrypto)
-toTickedPBftLedgerView = TickedPBftLedgerView . Delegation.unMap
 
 fromPBftLedgerView :: PBftLedgerView PBftByronCrypto -> Delegation.Map
 fromPBftLedgerView = Delegation.Map . pbftDelegates

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/CanHardFork.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/CanHardFork.hs
@@ -482,11 +482,11 @@ crossEraForecastByronToShelleyWrapper =
       -> LedgerState ByronBlock
       -> Except
            OutsideForecastRange
-           (Ticked (WrapLedgerView (ShelleyBlock (TPraos c) (ShelleyEra c))))
+           (WrapLedgerView (ShelleyBlock (TPraos c) (ShelleyEra c)))
     forecast cfgShelley bound forecastFor currentByronState
         | forecastFor < maxFor
         = return $
-            WrapTickedLedgerView $ TickedPraosLedgerView $
+            WrapLedgerView $
               SL.mkInitialShelleyLedgerView
                 (toFromByronTranslationContext (shelleyLedgerGenesis cfgShelley))
         | otherwise

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
@@ -84,8 +84,7 @@ import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.CommonProtocolParams
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Protocol.Ledger.Util (isNewEpoch)
-import           Ouroboros.Consensus.Protocol.TPraos (MaxMajorProtVer (..),
-                     Ticked (TickedPraosLedgerView))
+import           Ouroboros.Consensus.Protocol.TPraos (MaxMajorProtVer (..))
 import           Ouroboros.Consensus.Shelley.Eras (EraCrypto)
 import           Ouroboros.Consensus.Shelley.Ledger.Block
 import           Ouroboros.Consensus.Shelley.Ledger.Config
@@ -474,8 +473,8 @@ instance ShelleyCompatible proto era => ValidateEnvelope (ShelleyBlock proto era
   type OtherHeaderEnvelopeError (ShelleyBlock proto era) =
     EnvelopeCheckError proto
 
-  additionalEnvelopeChecks cfg tlv hdr =
-    envelopeChecks (configConsensus cfg) tlv (shelleyHeaderRaw hdr)
+  additionalEnvelopeChecks cfg lv hdr =
+    envelopeChecks (configConsensus cfg) lv (shelleyHeaderRaw hdr)
 
 {-------------------------------------------------------------------------------
   Auxiliary

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Protocol/Abstract.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Protocol/Abstract.hs
@@ -52,7 +52,6 @@ import           Ouroboros.Consensus.Protocol.Abstract (CanBeLeader,
                      IsLeader, LedgerView, ValidateView)
 import           Ouroboros.Consensus.Protocol.Ledger.HotKey (HotKey)
 import           Ouroboros.Consensus.Protocol.Signed (SignedHeader)
-import           Ouroboros.Consensus.Ticked (Ticked)
 import           Ouroboros.Consensus.Util.Condense (Condense (..))
 
 {-------------------------------------------------------------------------------
@@ -118,7 +117,7 @@ class
   -- check things like maximum header size.
   envelopeChecks ::
     ConsensusConfig proto ->
-    Ticked (LedgerView proto) ->
+    LedgerView proto ->
     ShelleyProtocolHeader proto ->
     Except (EnvelopeCheckError proto) ()
 

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Protocol/Praos.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Protocol/Praos.hs
@@ -63,7 +63,7 @@ instance PraosCrypto c => ProtocolHeaderSupportsEnvelope (Praos c) where
 
   type EnvelopeCheckError _ = PraosEnvelopeError
 
-  envelopeChecks cfg (TickedPraosLedgerView lv) hdr = do
+  envelopeChecks cfg lv hdr = do
     unless (m <= maxpv) $ throwError (ObsoleteNode m maxpv)
     unless (fromIntegral (bhviewHSize bhv) <= maxHeaderSize) $
       throwError $

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Protocol/TPraos.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Protocol/TPraos.hs
@@ -22,8 +22,8 @@ import           Ouroboros.Consensus.Protocol.Signed (Signed,
 import           Ouroboros.Consensus.Protocol.TPraos
                      (MaxMajorProtVer (MaxMajorProtVer), TPraos,
                      TPraosCannotForge, TPraosFields (..), TPraosToSign (..),
-                     Ticked (TickedPraosLedgerView), forgeTPraosFields,
-                     tpraosMaxMajorPV, tpraosParams, tpraosSlotsPerKESPeriod)
+                     forgeTPraosFields, tpraosMaxMajorPV, tpraosParams,
+                     tpraosSlotsPerKESPeriod)
 import           Ouroboros.Consensus.Shelley.Protocol.Abstract (ProtoCrypto,
                      ProtocolHeaderSupportsEnvelope (..),
                      ProtocolHeaderSupportsKES (..),
@@ -46,7 +46,7 @@ instance PraosCrypto c => ProtocolHeaderSupportsEnvelope (TPraos c) where
 
   type EnvelopeCheckError _ = ChainPredicateFailure
 
-  envelopeChecks cfg (TickedPraosLedgerView lv) hdr =
+  envelopeChecks cfg lv hdr =
     SL.chainChecks
       maxPV
       (SL.lvChainChecks lv)

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/ShelleyHFC.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/ShelleyHFC.hs
@@ -250,7 +250,7 @@ forecastAcrossShelley ::
   -> Bound  -- ^ Transition between the two eras
   -> SlotNo -- ^ Forecast for this slot
   -> LedgerState (ShelleyBlock protoFrom eraFrom)
-  -> Except OutsideForecastRange (Ticked (WrapLedgerView (ShelleyBlock protoTo eraTo)))
+  -> Except OutsideForecastRange (WrapLedgerView (ShelleyBlock protoTo eraTo))
 forecastAcrossShelley cfgFrom cfgTo transition forecastFor ledgerStateFrom
     | forecastFor < maxFor
     = return $ futureLedgerView forecastFor
@@ -263,12 +263,12 @@ forecastAcrossShelley cfgFrom cfgTo transition forecastFor ledgerStateFrom
   where
     -- | 'SL.futureLedgerView' imposes its own bounds. Those bounds could
     -- /exceed/ the 'maxFor' we have computed, but should never be /less/.
-    futureLedgerView :: SlotNo -> Ticked (WrapLedgerView (ShelleyBlock protoTo era))
+    futureLedgerView :: SlotNo -> WrapLedgerView (ShelleyBlock protoTo era)
     futureLedgerView =
-          WrapTickedLedgerView
+          WrapLedgerView
         . either
             (\e -> error ("futureLedgerView failed: " <> show e))
-            (Proto.translateTickedLedgerView @protoFrom @protoTo)
+            (Proto.translateLedgerView @protoFrom @protoTo)
         . runExcept
         . Forecast.forecastFor (ledgerViewForecastAt cfgFrom ledgerStateFrom)
 

--- a/ouroboros-consensus-diffusion/changelog.d/20230922_102829_nick.frisby_simplify_ledger_view.md
+++ b/ouroboros-consensus-diffusion/changelog.d/20230922_102829_nick.frisby_simplify_ledger_view.md
@@ -1,0 +1,22 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+### Patch
+
+- In tests only: replace all occurrences of `WrapTickedLedgerView` and `TickedTrivial` with `WrapLedgerView` and `()`.
+
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -310,7 +310,7 @@ forkBlockForging IS{..} blockForging =
 
         trace $ TraceLedgerState currentSlot bcPrevPoint
 
-        -- We require the ticked ledger view in order to construct the ticked
+        -- We require the ledger view in order to construct the ticked
         -- 'ChainDepState'.
         ledgerView <-
           case runExcept $ forecastFor

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator.hs
@@ -429,7 +429,7 @@ forecast_AtoB ::
         BlockA
         BlockB
 forecast_AtoB = InPairs.ignoringBoth $ CrossEraForecaster $ \_ _ _ -> return $
-    WrapTickedLedgerView TickedTrivial
+    WrapLedgerView ()
 
 injectTx_AtoB ::
      RequiringBoth

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/A.hs
@@ -241,7 +241,7 @@ instance BlockSupportsProtocol BlockA where
   validateView _ _ = ()
 
 instance LedgerSupportsProtocol BlockA where
-  protocolLedgerView   _ _  = TickedTrivial
+  protocolLedgerView   _ _  = ()
   ledgerViewForecastAt _    = trivialForecast
 
 instance HasPartialConsensusConfig ProtocolA

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/B.hs
@@ -201,7 +201,7 @@ instance BlockSupportsProtocol BlockB where
   validateView _ _ = ()
 
 instance LedgerSupportsProtocol BlockB where
-  protocolLedgerView   _ _ = TickedTrivial
+  protocolLedgerView   _ _ = ()
   ledgerViewForecastAt _   = trivialForecast
 
 instance HasPartialConsensusConfig ProtocolB

--- a/ouroboros-consensus-protocol/changelog.d/20230922_102829_nick.frisby_simplify_ledger_view.md
+++ b/ouroboros-consensus-protocol/changelog.d/20230922_102829_nick.frisby_simplify_ledger_view.md
@@ -1,0 +1,23 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+### Breaking
+
+- Replace all occurrences of `Ticked (LedgerView X)` with `LedgerView X`.
+- Remove `Ticked (LedgerView X)` data family instances.
+- Rename `translateTickedLedgerView` to `translateLedgerView`.

--- a/ouroboros-consensus-protocol/src/ouroboros-consensus-protocol/Ouroboros/Consensus/Protocol/Praos/Translate.hs
+++ b/ouroboros-consensus-protocol/src/ouroboros-consensus-protocol/Ouroboros/Consensus/Protocol/Praos/Translate.hs
@@ -19,14 +19,12 @@ import qualified Cardano.Protocol.TPraos.Rules.Tickn as SL
 import           Data.Coerce (coerce)
 import qualified Data.Map.Strict as Map
 import           Ouroboros.Consensus.Protocol.Praos (ConsensusConfig (..),
-                     Praos, PraosParams (..), PraosState (..),
-                     Ticked (TickedPraosLedgerView))
+                     Praos, PraosParams (..), PraosState (..))
 import           Ouroboros.Consensus.Protocol.Praos.Views
                      (LedgerView (lvMaxBodySize, lvMaxHeaderSize, lvProtocolVersion))
 import qualified Ouroboros.Consensus.Protocol.Praos.Views as Views
 import           Ouroboros.Consensus.Protocol.TPraos (TPraos, TPraosParams (..),
                      TPraosState (tpraosStateChainDepState, tpraosStateLastSlot))
-import qualified Ouroboros.Consensus.Protocol.TPraos as TPraos
 import           Ouroboros.Consensus.Protocol.Translate (TranslateProto (..))
 
 {-------------------------------------------------------------------------------
@@ -64,26 +62,23 @@ instance
         praosEpochInfo = tpraosEpochInfo
       }
 
-  translateTickedLedgerView (TPraos.TickedPraosLedgerView lv) =
-      TickedPraosLedgerView $ translateLedgerView lv
-    where
-      translateLedgerView SL.LedgerView {SL.lvPoolDistr, SL.lvChainChecks} =
-        Views.LedgerView
-          { Views.lvPoolDistr = coercePoolDistr lvPoolDistr,
-            lvMaxHeaderSize = SL.ccMaxBHSize lvChainChecks,
-            lvMaxBodySize = SL.ccMaxBBSize lvChainChecks,
-            lvProtocolVersion = SL.ccProtocolVersion lvChainChecks
-          }
-        where
-          coercePoolDistr :: SL.PoolDistr c1 -> SL.PoolDistr c2
-          coercePoolDistr (SL.PoolDistr m) =
-            SL.PoolDistr
-              . Map.mapKeysMonotonic coerce
-              . Map.map coerceIndividualPoolStake
-              $ m
-          coerceIndividualPoolStake :: SL.IndividualPoolStake c1 -> SL.IndividualPoolStake c2
-          coerceIndividualPoolStake (SL.IndividualPoolStake stake vrf) =
-            SL.IndividualPoolStake stake $ coerce vrf
+  translateLedgerView SL.LedgerView {SL.lvPoolDistr, SL.lvChainChecks} =
+      Views.LedgerView
+        { Views.lvPoolDistr = coercePoolDistr lvPoolDistr,
+          lvMaxHeaderSize = SL.ccMaxBHSize lvChainChecks,
+          lvMaxBodySize = SL.ccMaxBBSize lvChainChecks,
+          lvProtocolVersion = SL.ccProtocolVersion lvChainChecks
+        }
+      where
+        coercePoolDistr :: SL.PoolDistr c1 -> SL.PoolDistr c2
+        coercePoolDistr (SL.PoolDistr m) =
+          SL.PoolDistr
+            . Map.mapKeysMonotonic coerce
+            . Map.map coerceIndividualPoolStake
+            $ m
+        coerceIndividualPoolStake :: SL.IndividualPoolStake c1 -> SL.IndividualPoolStake c2
+        coerceIndividualPoolStake (SL.IndividualPoolStake stake vrf) =
+          SL.IndividualPoolStake stake $ coerce vrf
 
   translateChainDepState tpState =
     PraosState

--- a/ouroboros-consensus-protocol/src/ouroboros-consensus-protocol/Ouroboros/Consensus/Protocol/Translate.hs
+++ b/ouroboros-consensus-protocol/src/ouroboros-consensus-protocol/Ouroboros/Consensus/Protocol/Translate.hs
@@ -5,16 +5,15 @@
 module Ouroboros.Consensus.Protocol.Translate (TranslateProto (..)) where
 
 import           Ouroboros.Consensus.Protocol.Abstract
-import           Ouroboros.Consensus.Ticked (Ticked)
 
 -- | Translate across protocols
 class TranslateProto protoFrom protoTo
   where
   translateConsensusConfig ::
     ConsensusConfig protoFrom -> ConsensusConfig protoTo
-  -- | Translate the ticked ledger view.
-  translateTickedLedgerView ::
-    Ticked (LedgerView protoFrom) -> Ticked (LedgerView protoTo)
+  -- | Translate the ledger view.
+  translateLedgerView ::
+    LedgerView protoFrom -> LedgerView protoTo
   translateChainDepState ::
     ChainDepState protoFrom -> ChainDepState protoTo
 
@@ -22,5 +21,5 @@ class TranslateProto protoFrom protoTo
 instance TranslateProto singleProto singleProto
   where
   translateConsensusConfig = id
-  translateTickedLedgerView = id
+  translateLedgerView = id
   translateChainDepState = id

--- a/ouroboros-consensus/changelog.d/20230922_102829_nick.frisby_simplify_ledger_view.md
+++ b/ouroboros-consensus/changelog.d/20230922_102829_nick.frisby_simplify_ledger_view.md
@@ -1,0 +1,25 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+### Patch
+
+- Replace all occurrences of `Ticked (LedgerView X)` with `LedgerView X`.
+
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+
+### Breaking
+
+- Remove `Ticked` from the return type of `forecastFor`.
+- Remove `Ticked (LedgerView X)` data family instances.
+- Remove `Ticked (K a x)` data family instance.
+- Remove `WrapTickedLedgerView`.
+- Rename `tickedLedgerView` field of `TickedExtLedgerState` to `ledgerView`.
+

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Protocol.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Protocol.hs
@@ -50,7 +50,7 @@ import           Ouroboros.Consensus.HardFork.Combinator.Info
 import           Ouroboros.Consensus.HardFork.Combinator.PartialConfig
 import           Ouroboros.Consensus.HardFork.Combinator.Protocol.ChainSel
 import           Ouroboros.Consensus.HardFork.Combinator.Protocol.LedgerView
-                     (HardForkLedgerView, HardForkLedgerView_ (..), Ticked (..))
+                     (HardForkLedgerView, HardForkLedgerView_ (..))
 import           Ouroboros.Consensus.HardFork.Combinator.State (HardForkState,
                      Translate (..))
 import qualified Ouroboros.Consensus.HardFork.Combinator.State as State
@@ -142,19 +142,19 @@ data instance Ticked (HardForkChainDepState xs) =
         tickedHardForkChainDepStatePerEra ::
              HardForkState (Ticked :.: WrapChainDepState) xs
 
-        -- | 'EpochInfo' constructed from the ticked 'LedgerView'
+        -- | 'EpochInfo' constructed from the 'LedgerView'
       , tickedHardForkChainDepStateEpochInfo ::
              EpochInfo (Except PastHorizonException)
       }
 
 tick :: CanHardFork xs
      => ConsensusConfig (HardForkProtocol xs)
-     -> Ticked (HardForkLedgerView xs)
+     -> HardForkLedgerView xs
      -> SlotNo
      -> HardForkChainDepState xs
      -> Ticked (HardForkChainDepState xs)
 tick cfg@HardForkConsensusConfig{..}
-     (TickedHardForkLedgerView transition ledgerView)
+     (HardForkLedgerView transition ledgerView)
      slot
      chainDepState = TickedHardForkChainDepState {
       tickedHardForkChainDepStateEpochInfo = ei
@@ -174,14 +174,14 @@ tick cfg@HardForkConsensusConfig{..}
 
     tickOne :: SingleEraBlock                 blk
             => WrapPartialConsensusConfig     blk
-            -> (Ticked :.: WrapLedgerView)    blk
+            -> WrapLedgerView                 blk
             -> WrapChainDepState              blk
             -> (Ticked :.: WrapChainDepState) blk
-    tickOne cfg' (Comp ledgerView') chainDepState' = Comp $
+    tickOne cfg' ledgerView' chainDepState' = Comp $
         WrapTickedChainDepState $
           tickChainDepState
             (completeConsensusConfig' ei cfg')
-            (unwrapTickedLedgerView ledgerView')
+            (unwrapLedgerView ledgerView')
             slot
             (unwrapChainDepState chainDepState')
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Protocol/LedgerView.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Protocol/LedgerView.hs
@@ -42,15 +42,6 @@ deriving instance CanHardFork xs => Show (HardForkLedgerView_ WrapLedgerView xs)
 type HardForkLedgerView = HardForkLedgerView_ WrapLedgerView
 
 {-------------------------------------------------------------------------------
-  Ticked
--------------------------------------------------------------------------------}
-
-data instance Ticked (HardForkLedgerView_ f xs) = TickedHardForkLedgerView {
-      tickedHardForkLedgerViewTransition :: !TransitionInfo
-    , tickedHardForkLedgerViewPerEra     :: !(HardForkState (Ticked :.: f) xs)
-    }
-
-{-------------------------------------------------------------------------------
   Show instance for the benefit of tests
 -------------------------------------------------------------------------------}
 
@@ -67,21 +58,3 @@ instance (SListI xs, Show a) => Show (HardForkLedgerView_ (K a) xs) where
 
       dictCurrent :: Dict (All (Compose Show (Current (K a)))) xs
       dictCurrent = all_NP $ hpure Dict
-
-instance (SListI xs, Show (Ticked a)) => Show (Ticked (HardForkLedgerView_ (K a) xs)) where
-  show TickedHardForkLedgerView{..} =
-      case (dictPast, dictCurrent) of
-        (Dict, Dict) -> show (
-            tickedHardForkLedgerViewTransition
-          , getHardForkState tickedHardForkLedgerViewPerEra
-          )
-    where
-      dictPast :: Dict (All (Compose Show (K Past))) xs
-      dictPast = all_NP $ hpure Dict
-
-      dictCurrent :: Dict (All (Compose Show (Current (Ticked :.: K a)))) xs
-      dictCurrent = all_NP $ hpure dictCurrentOne
-
-dictCurrentOne :: forall blk a. Show (Ticked a)
-               => Dict (Compose Show (Current (Ticked :.: K a))) blk
-dictCurrentOne = Dict

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/State.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/State.hs
@@ -155,7 +155,7 @@ epochInfoLedger cfg st =
 -- | Construct 'EpochInfo' given precomputed 'TransitionInfo'
 --
 -- The transition and state arguments are acquired either from a ticked ledger
--- state or a ticked ledger view.
+-- state or a ledger view.
 epochInfoPrecomputedTransitionInfo ::
      History.Shape xs
   -> TransitionInfo

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/State/Types.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/State/Types.hs
@@ -27,7 +27,6 @@ import           NoThunks.Class (NoThunks (..))
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Forecast
 import           Ouroboros.Consensus.HardFork.History (Bound)
-import           Ouroboros.Consensus.Ticked
 import           Prelude
 
 {-------------------------------------------------------------------------------
@@ -116,8 +115,7 @@ newtype Translate f x y = Translate {
       translateWith :: EpochNo -> f x -> f y
     }
 
--- | Forecast a @'Ticked' (view y)@ from a @state x@ across an
--- era transition.
+-- | Forecast a @view y@ from a @state x@ across an era transition.
 --
 -- In addition to the 'Bound' of the transition, this is also told the
 -- 'SlotNo' we're constructing a forecast for. This enables the translation
@@ -128,7 +126,7 @@ newtype CrossEraForecaster state view x y = CrossEraForecaster {
            Bound    -- 'Bound' of the transition (start of the new era)
         -> SlotNo   -- 'SlotNo' we're constructing a forecast for
         -> state x
-        -> Except OutsideForecastRange (Ticked (view y))
+        -> Except OutsideForecastRange (view y)
     }
 
 -- | Knowledge in a particular era of the transition to the next era

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HeaderStateHistory.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HeaderStateHistory.hs
@@ -126,18 +126,18 @@ rewind p (HeaderStateHistory history) = HeaderStateHistory <$>
 validateHeader ::
      forall blk. (BlockSupportsProtocol blk, ValidateEnvelope blk)
   => TopLevelConfig blk
-  -> Ticked (LedgerView (BlockProtocol blk))
+  -> LedgerView (BlockProtocol blk)
   -> Header blk
   -> HeaderStateHistory blk
   -> Except (HeaderError blk) (HeaderStateHistory blk)
-validateHeader cfg ledgerView hdr history = do
-    st' <- HeaderValidation.validateHeader cfg ledgerView hdr st
+validateHeader cfg lv hdr history = do
+    st' <- HeaderValidation.validateHeader cfg lv hdr st
     return $ append st' history
   where
     st :: Ticked (HeaderState blk)
     st = tickHeaderState
            (configConsensus cfg)
-           ledgerView
+           lv
            (blockSlot hdr)
            (current history)
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HeaderValidation.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HeaderValidation.hs
@@ -188,7 +188,7 @@ data instance Ticked (HeaderState blk) = TickedHeaderState {
 -- | Tick the 'ChainDepState' inside the 'HeaderState'
 tickHeaderState :: ConsensusProtocol (BlockProtocol blk)
                 => ConsensusConfig (BlockProtocol blk)
-                -> Ticked (LedgerView (BlockProtocol blk))
+                -> LedgerView (BlockProtocol blk)
                 -> SlotNo
                 -> HeaderState blk -> Ticked (HeaderState blk)
 tickHeaderState cfg ledgerView slot HeaderState {..} = TickedHeaderState {
@@ -291,7 +291,7 @@ class ( BasicEnvelopeValidation blk
 
   -- | Do additional envelope checks
   additionalEnvelopeChecks :: TopLevelConfig blk
-                           -> Ticked (LedgerView (BlockProtocol blk))
+                           -> LedgerView (BlockProtocol blk)
                            -> Header blk
                            -> Except (OtherHeaderEnvelopeError blk) ()
   additionalEnvelopeChecks _ _ _ = return ()
@@ -299,7 +299,7 @@ class ( BasicEnvelopeValidation blk
 -- | Validate the header envelope
 validateEnvelope :: forall blk. (ValidateEnvelope blk)
                  => TopLevelConfig blk
-                 -> Ticked (LedgerView (BlockProtocol blk))
+                 -> LedgerView (BlockProtocol blk)
                  -> WithOrigin (AnnTip blk) -- ^ Old tip
                  -> Header blk
                  -> Except (HeaderEnvelopeError blk) ()
@@ -415,7 +415,7 @@ castHeaderError (HeaderEnvelopeError e) = HeaderEnvelopeError $
 -- entire block (not just the block body).
 validateHeader :: (BlockSupportsProtocol blk, ValidateEnvelope blk)
                => TopLevelConfig blk
-               -> Ticked (LedgerView (BlockProtocol blk))
+               -> LedgerView (BlockProtocol blk)
                -> Header blk
                -> Ticked (HeaderState blk)
                -> Except (HeaderError blk) (HeaderState blk)
@@ -444,7 +444,7 @@ validateHeader cfg ledgerView hdr st = do
 revalidateHeader ::
      forall blk. (BlockSupportsProtocol blk, ValidateEnvelope blk, HasCallStack)
   => TopLevelConfig blk
-  -> Ticked (LedgerView (BlockProtocol blk))
+  -> LedgerView (BlockProtocol blk)
   -> Header blk
   -> Ticked (HeaderState blk)
   -> HeaderState blk

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Extended.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Extended.hs
@@ -84,7 +84,7 @@ deriving instance ( LedgerSupportsProtocol blk
 
 data instance Ticked (ExtLedgerState blk) = TickedExtLedgerState {
       tickedLedgerState :: Ticked (LedgerState blk)
-    , tickedLedgerView  :: Ticked (LedgerView (BlockProtocol blk))
+    , ledgerView        :: LedgerView (BlockProtocol blk)
     , tickedHeaderState :: Ticked (HeaderState blk)
     }
 
@@ -123,14 +123,14 @@ instance ( LedgerSupportsProtocol blk
 
   applyChainTickLedgerResult cfg slot (ExtLedgerState ledger header) =
       castLedgerResult ledgerResult <&> \tickedLedgerState ->
-      let tickedLedgerView :: Ticked (LedgerView (BlockProtocol blk))
-          tickedLedgerView = protocolLedgerView lcfg tickedLedgerState
+      let ledgerView :: LedgerView (BlockProtocol blk)
+          ledgerView = protocolLedgerView lcfg tickedLedgerState
 
           tickedHeaderState :: Ticked (HeaderState blk)
           tickedHeaderState =
               tickHeaderState
                 (configConsensus $ getExtLedgerCfg cfg)
-                tickedLedgerView
+                ledgerView
                 slot
                 header
       in TickedExtLedgerState {..}
@@ -152,7 +152,7 @@ instance LedgerSupportsProtocol blk => ApplyBlock (ExtLedgerState blk) blk where
         withExcept ExtValidationErrorHeader
       $ validateHeader @blk
           (getExtLedgerCfg cfg)
-          tickedLedgerView
+          ledgerView
           (getHeader blk)
           tickedHeaderState
     pure $ (\l -> ExtLedgerState l hdr) <$> castLedgerResult ledgerResult
@@ -168,7 +168,7 @@ instance LedgerSupportsProtocol blk => ApplyBlock (ExtLedgerState blk) blk where
       hdr      =
         revalidateHeader
           (getExtLedgerCfg cfg)
-          tickedLedgerView
+          ledgerView
           (getHeader blk)
           tickedHeaderState
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/SupportsProtocol.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/SupportsProtocol.hs
@@ -16,13 +16,13 @@ class ( BlockSupportsProtocol blk
       , UpdateLedger          blk
       , ValidateEnvelope      blk
       ) => LedgerSupportsProtocol blk where
-  -- | Extract ticked ledger view from ticked ledger state
+  -- | Extract the ledger view from the given ticked ledger state
   --
   -- See 'ledgerViewForecastAt' for a discussion and precise definition of the
   -- relation between this and forecasting.
   protocolLedgerView :: LedgerConfig blk
                      -> Ticked (LedgerState blk)
-                     -> Ticked (LedgerView (BlockProtocol blk))
+                     -> LedgerView (BlockProtocol blk)
 
   -- | Get a forecast at the given ledger state.
   --
@@ -68,8 +68,7 @@ class ( BlockSupportsProtocol blk
 -- | Relation between 'ledgerViewForecastAt' and 'applyChainTick'
 _lemma_ledgerViewForecastAt_applyChainTick
   :: ( LedgerSupportsProtocol blk
-     , Eq   (Ticked (LedgerView (BlockProtocol blk)))
-     , Show (Ticked (LedgerView (BlockProtocol blk)))
+     , Eq (LedgerView (BlockProtocol blk))
      )
   => LedgerConfig blk
   -> LedgerState blk

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -1044,7 +1044,7 @@ data IntersectCheck blk =
     -- the header 'rollForward' received.
   | Intersects
       (KnownIntersectionState blk)
-      (Ticked (LedgerView (BlockProtocol blk)))
+      (LedgerView (BlockProtocol blk))
 
 {-------------------------------------------------------------------------------
   Explicit state

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Protocol/Abstract.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Protocol/Abstract.hs
@@ -132,12 +132,11 @@ class ( Show (ChainDepState   p)
 
   -- | Tick the 'ChainDepState'
   --
-  -- We pass the ticked 'LedgerView' to 'tickChainDepState'. Functions that
-  -- /take/ a ticked 'ChainDepState' are not separately passed a ticked ledger
-  -- view; protocols that require it, can include it in their ticked
-  -- 'ChainDepState' type.
+  -- We pass the 'LedgerView' to 'tickChainDepState'. Functions that /take/ a
+  -- ticked 'ChainDepState' are not separately passed a ledger view; protocols
+  -- that require it, can include it in their ticked 'ChainDepState' type.
   tickChainDepState :: ConsensusConfig p
-                    -> Ticked (LedgerView p)
+                    -> LedgerView p
                     -> SlotNo
                     -> ChainDepState p
                     -> Ticked (ChainDepState p)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Protocol/PBFT.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Protocol/PBFT.hs
@@ -194,11 +194,6 @@ newtype PBftLedgerView c = PBftLedgerView {
     }
   deriving (Generic)
 
-newtype instance Ticked (PBftLedgerView c) = TickedPBftLedgerView {
-      -- | The updated delegates
-      tickedPBftDelegates :: Bimap (PBftVerKeyHash c) (PBftVerKeyHash c)
-    }
-
 deriving instance PBftCrypto c => NoThunks (PBftLedgerView c)
   -- use generic instance
 
@@ -276,10 +271,10 @@ newtype instance ConsensusConfig (PBft c) = PBftConfig {
     }
   deriving (Generic, NoThunks)
 
--- Ticking has no effect on the PBFtState, but we do need the ticked ledger view
+-- Ticking has no effect on the PBFtState, but we do need the ledger view
 data instance Ticked (PBftState c) = TickedPBftState {
-      tickedPBftLedgerView :: Ticked (LedgerView (PBft c))
-    , getTickedPBftState   :: PBftState c
+      getPBftLedgerView   :: LedgerView (PBft c)
+    , getTickedPBftState  :: PBftState c
     }
 
 instance PBftCrypto c => ConsensusProtocol (PBft c) where
@@ -321,7 +316,7 @@ instance PBftCrypto c => ConsensusProtocol (PBft c) where
   updateChainDepState cfg
                       toValidate
                       slot
-                      (TickedPBftState (TickedPBftLedgerView dms) state) =
+                      (TickedPBftState (PBftLedgerView dms) state) =
       case toValidate of
         PBftValidateBoundary ->
           return state
@@ -358,7 +353,7 @@ instance PBftCrypto c => ConsensusProtocol (PBft c) where
   reupdateChainDepState cfg
                         toValidate
                         slot
-                        (TickedPBftState (TickedPBftLedgerView dms) state) =
+                        (TickedPBftState (PBftLedgerView dms) state) =
       case toValidate of
         PBftValidateBoundary -> state
         PBftValidateRegular PBftFields{pbftIssuer} _ _ ->
@@ -487,7 +482,7 @@ pbftCheckCanForge cfg PBftCanBeLeader{..} slot tickedChainDepState =
     dlgKeyHash :: PBftVerKeyHash c
     dlgKeyHash = hashVerKey . dlgCertDlgVerKey $ pbftCanBeLeaderDlgCert
 
-    TickedPBftState (TickedPBftLedgerView dms) cds = tickedChainDepState
+    TickedPBftState (PBftLedgerView dms) cds = tickedChainDepState
 
 {-------------------------------------------------------------------------------
   Condense

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ticked.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ticked.hs
@@ -16,11 +16,22 @@ import           NoThunks.Class (NoThunks)
   Ticked state
 -------------------------------------------------------------------------------}
 
--- | " Ticked " piece of state ('LedgerState', 'LedgerView', 'ChainIndepState')
+-- | " Ticked " piece of state, either 'LedgerState' or 'ChainDepState'
 --
 -- Ticking refers to the passage of time (the ticking of the clock). When a
--- piece of state is marked as ticked, it means that time-related
--- changes have been applied to the state (or forecast).
+-- piece of state is marked as ticked, it means that time-related changes have
+-- been applied to the state. There are exactly two methods in the interface
+-- that do that: 'Ouroboros.Consensus.Protocol.Abstract.tickChainDepState' and
+-- 'Ouroboros.Consensus.Ledger.Basics.applyChainTickLedgerResult'.
+--
+-- Also note that a successful forecast
+-- @'Ouroboros.Consensus.Forecast.forecastFor'
+-- ('Ouroboros.Consensus.Ledger.SupportsProtocol.ledgerViewForecastAt' cfg st)
+-- slot@ must equal
+-- @'Ouroboros.Consensus.Ledger.SupportsProtocol.protocolLedgerView' cfg
+-- ('Ouroboros.Consensus.Ledger.Basics.applyChainTick' cfg slot st)@. Thus a
+-- 'Ouroboros.Consensus.Protocol.Abstract.LedgerView' can only be projected
+-- from a 'Ticked' state, but cannot itself be ticked.
 --
 -- Some examples of time related changes:
 --
@@ -35,15 +46,9 @@ data family Ticked st :: Type
 data instance Ticked () = TickedTrivial
   deriving (Show)
 
-newtype instance Ticked (K a x) = TickedK { getTickedK :: Ticked a }
-
 {-------------------------------------------------------------------------------
   Forwarding type class instances
 -------------------------------------------------------------------------------}
-
-deriving instance
-     Show (Ticked a)
-  => Show (Ticked (K a x))
 
 deriving newtype instance {-# OVERLAPPING #-}
      Show (Ticked (f a))

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/TypeFamilyWrappers.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/TypeFamilyWrappers.hs
@@ -174,10 +174,6 @@ deriving instance Serialise (TipInfo                      blk)  => Serialise (Wr
   These are just forwarding instances
 -------------------------------------------------------------------------------}
 
-newtype instance Ticked (WrapLedgerView blk) = WrapTickedLedgerView {
-      unwrapTickedLedgerView :: Ticked (LedgerView (BlockProtocol blk))
-    }
-
 newtype instance Ticked (WrapChainDepState blk) = WrapTickedChainDepState {
       unwrapTickedChainDepState :: Ticked (ChainDepState (BlockProtocol blk))
     }

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestBlock.hs
@@ -525,7 +525,7 @@ instance (PayloadSemantics ptype) => ValidateEnvelope (TestBlockWith ptype) wher
   -- Use defaults
 
 instance (PayloadSemantics ptype) => LedgerSupportsProtocol (TestBlockWith ptype) where
-  protocolLedgerView   _ _  = TickedTrivial
+  protocolLedgerView   _ _  = ()
   ledgerViewForecastAt _    = trivialForecast
 
 singleNodeTestConfigWith ::

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Block/BFT.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Block/BFT.hs
@@ -104,7 +104,7 @@ instance ( SimpleCrypto c
          , BftCrypto c'
          , Signable (BftDSIGN c') (SignedSimpleBft c c')
          ) => LedgerSupportsProtocol (SimpleBftBlock c c') where
-  protocolLedgerView   _ _ = TickedTrivial
+  protocolLedgerView   _ _ = ()
   ledgerViewForecastAt _   = trivialForecast
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Block/PBFT.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Block/PBFT.hs
@@ -118,14 +118,10 @@ instance ( SimpleCrypto c
 instance ( SimpleCrypto c
          , Signable MockDSIGN (SignedSimplePBft c PBftMockCrypto)
          ) => LedgerSupportsProtocol (SimplePBftBlock c PBftMockCrypto) where
-  protocolLedgerView   cfg _  = pretendTicked $ simpleMockLedgerConfig cfg
+  protocolLedgerView   cfg _  = simpleMockLedgerConfig cfg
   ledgerViewForecastAt cfg st = constantForecastOf
-                                 (pretendTicked $ simpleMockLedgerConfig cfg)
+                                 (simpleMockLedgerConfig cfg)
                                  (getTipSlot st)
-
-pretendTicked :: PBftLedgerView PBftMockCrypto
-              -> Ticked (PBftLedgerView PBftMockCrypto)
-pretendTicked (PBftLedgerView ds) = TickedPBftLedgerView ds
 
 {-------------------------------------------------------------------------------
   Forging

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Block/Praos.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Block/Praos.hs
@@ -116,10 +116,8 @@ instance ( SimpleCrypto c
          , PraosCrypto c'
          , Signable (PraosKES c') (SignedSimplePraos c c')
          ) => LedgerSupportsProtocol (SimplePraosBlock c c') where
-  protocolLedgerView   _ _  = TickedTrivial
-  ledgerViewForecastAt _ st = constantForecastOf
-                                 TickedTrivial
-                                 (getTipSlot st)
+  protocolLedgerView   _ _  = ()
+  ledgerViewForecastAt _ st = constantForecastOf () (getTipSlot st)
 
 {-------------------------------------------------------------------------------
   Forging

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Block/PraosRule.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Block/PraosRule.hs
@@ -95,7 +95,7 @@ instance
 instance
   ( SimpleCrypto c
   ) => LedgerSupportsProtocol (SimplePraosRuleBlock c) where
-  protocolLedgerView   _ _ = TickedTrivial
+  protocolLedgerView   _ _ = ()
   ledgerViewForecastAt _   = trivialForecast
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Protocol/Praos.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Protocol/Praos.hs
@@ -434,8 +434,7 @@ infosEta l@PraosConfig{praosParams = PraosParams{..}} xs e =
 --
 -- We do however need access to the ticked stake distribution.
 data instance Ticked (PraosChainDepState c) = TickedPraosChainDepState {
-      tickedPraosLedgerView      :: Ticked (LedgerView (Praos c))
-      -- ^ The ticked ledger view.
+      praosLedgerView            :: LedgerView (Praos c)
     , untickedPraosChainDepState :: PraosChainDepState c
       -- ^ The unticked chain dependent state, containing the full history.
     }
@@ -471,7 +470,7 @@ instance PraosCrypto c => ConsensusProtocol (Praos c) where
   updateChainDepState cfg@PraosConfig{..}
                       (PraosValidateView PraosFields{..} toSign)
                       slot
-                      (TickedPraosChainDepState TickedTrivial cds) = do
+                      (TickedPraosChainDepState () cds) = do
     let PraosExtraFields {..} = praosExtraFields
         nid = praosCreator
 
@@ -534,7 +533,7 @@ instance PraosCrypto c => ConsensusProtocol (Praos c) where
   reupdateChainDepState _
                         (PraosValidateView PraosFields{..} _)
                         slot
-                        (TickedPraosChainDepState TickedTrivial cds) =
+                        (TickedPraosChainDepState () cds) =
     let PraosExtraFields{..} = praosExtraFields
         !bi = BlockInfo
             { biSlot  = slot

--- a/ouroboros-consensus/src/unstable-tutorials/Ouroboros/Consensus/Tutorial/Simple.lhs
+++ b/ouroboros-consensus/src/unstable-tutorials/Ouroboros/Consensus/Tutorial/Simple.lhs
@@ -667,14 +667,13 @@ Note that since a block is associated with one and only one protocol, we can use
 the block to index both the ledger and the protocol.
 
 > instance LedgerSupportsProtocol BlockC where
->   protocolLedgerView _lcfg  _tl = TickedTrivial
+>   protocolLedgerView _lcfg  _tl = ()
 >   ledgerViewForecastAt _lccf = trivialForecast
 
 The `protocolLedgerView` function describes how to project the
 consensus-specific `LedgerView` out of `LedgerState` and `LedgerCfg` together -
 however `SP` does not use any information from the ledger to make any decisions
-and since `LedgerView SP` is simply `()` - we use `TickedTrivial` here for the
-implementation of protocolLedgerView which constructs a `Ticked ()` value.
+and since `LedgerView SP` is simply `()`.
 
 `ledgerViewForecastAt` returns a `Forecast` (defined in
 `Ouroboros.Consensus.Forecast`) of a `LedgerView` - where a `Forecast` is a

--- a/ouroboros-consensus/src/unstable-tutorials/Ouroboros/Consensus/Tutorial/WithEpoch.lhs
+++ b/ouroboros-consensus/src/unstable-tutorials/Ouroboros/Consensus/Tutorial/WithEpoch.lhs
@@ -475,12 +475,6 @@ just as easily used a `Bool` representing the parity):
 >   deriving stock (Show, Eq, Generic)
 >   deriving newtype (Serialise, NoThunks)
 
-We also define a trivial `Ticked LedgerViewD` instance:
-
-> newtype instance Ticked LedgerViewD = TickedLedgerViewD LedgerViewD
->   deriving stock (Show, Eq, Generic)
->   deriving newtype (Serialise, NoThunks)
-
 The parity of the epoch snapshot and the slot are together _sufficient_ to
 determine the leadership schedule.  As such, we do not need any notion of state
 specific to `PrtclD`:
@@ -547,9 +541,7 @@ functions defined above:
 >
 >   protocolSecurityParam = ccpd_securityParam
 >
->   tickChainDepState _cfg tlv _slot _cds = TickedChainDepStateD lv
->     where
->       TickedLedgerViewD lv = tlv
+>   tickChainDepState _cfg lv _slot _cds = TickedChainDepStateD lv
 >
 >   -- | apply the header (hdrView) and do a header check.
 >   --
@@ -596,7 +588,7 @@ ledger view: (1) the slot (`for` in the code below) is in the current epoch and
 
 > instance LedgerSupportsProtocol BlockD where
 >   protocolLedgerView _ldgrCfg (TickedLedgerStateD ldgrSt) =
->     TickedLedgerViewD (LVD $ lsbd_snapshot2 ldgrSt)
+>     LVD $ lsbd_snapshot2 ldgrSt
 >       -- note that we use the snapshot from 2 epochs ago.
 >
 >   -- | Borrowing somewhat from Ouroboros/Consensus/Byron/Ledger/Ledger.hs
@@ -614,7 +606,7 @@ ledger view: (1) the slot (`for` in the code below) is in the current epoch and
 >                         }
 >                  else
 >                    return
->                      $ TickedLedgerViewD $ LVD
+>                      $ LVD
 >                      $ if for < nextEpochStartSlot at then
 >                          lsbd_snapshot2 ldgrSt
 >                            -- for the rest of the current epoch,

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/HardFork/History.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/HardFork/History.hs
@@ -820,11 +820,11 @@ hardForkEpochInfo ArbitraryChain{..} for =
            , "<out of range>"
            , "<out of range>"
            )
-         Right view@TickedHardForkLedgerView{..} ->
+         Right view@HardForkLedgerView{..} ->
            let reconstructed = State.reconstructSummary
                                  arbitraryChainShape
-                                 tickedHardForkLedgerViewTransition
-                                 tickedHardForkLedgerViewPerEra
+                                 hardForkLedgerViewTransition
+                                 hardForkLedgerViewPerEra
            in (
              HF.toPureEpochInfo (HF.summaryToEpochInfo reconstructed)
            , show view
@@ -840,8 +840,7 @@ mockHardForkLedgerView :: SListI xs
                        -> Forecast (HardForkLedgerView_ (K ()) xs)
 mockHardForkLedgerView = \(HF.Shape pss) (HF.Transitions ts) (Chain ess) ->
     mkHardForkForecast
-      (InPairs.hpure $ CrossEraForecaster $ \_epoch _slot _ -> return $
-         TickedK TickedTrivial)
+      (InPairs.hpure $ CrossEraForecaster $ \_epoch _slot _ -> return $ K ())
       (HardForkState (mockState HF.initBound pss ts ess))
   where
     mockState :: HF.Bound
@@ -853,7 +852,7 @@ mockHardForkLedgerView = \(HF.Shape pss) (HF.Transitions ts) (Chain ess) ->
         TZ $ Current start $ AnnForecast {
             annForecast      = Forecast {
                 forecastAt  = tip es -- forecast at tip of ledger
-              , forecastFor = \_for -> return $ TickedK TickedTrivial
+              , forecastFor = \_for -> return $ K ()
               }
           , annForecastState = K ()
           , annForecastTip   = tip es

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/TestBlock.hs
@@ -624,7 +624,7 @@ instance ValidateEnvelope TestBlock where
         $ cfg
 
 instance LedgerSupportsProtocol TestBlock where
-  protocolLedgerView   _ _  = TickedTrivial
+  protocolLedgerView   _ _  = ()
   ledgerViewForecastAt _    = trivialForecast
 
 instance HasHardForkHistory TestBlock where


### PR DESCRIPTION
Single commit PR; see its message.

This entire diff results from simply replacing every occurrence of `Ticked (LedgerView T)` with `LedgerView T` and then fixing type errors and updating any identifiers that referred to a "ticked ledger view".