### PR TITLE
Enter block tree

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -516,6 +516,7 @@ test-suite infra-test
   main-is:        Main.hs
   other-modules:
     Ouroboros.Consensus.Util.Tests
+    Ouroboros.Network.AnchoredFragment.Extras
     Test.Ouroboros.Consensus.ChainGenerator.Tests
     Test.Ouroboros.Consensus.ChainGenerator.Tests.Adversarial
     Test.Ouroboros.Consensus.ChainGenerator.Tests.BitVector

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -519,13 +519,13 @@ test-suite infra-test
     Test.Ouroboros.Consensus.ChainGenerator.Tests
     Test.Ouroboros.Consensus.ChainGenerator.Tests.Adversarial
     Test.Ouroboros.Consensus.ChainGenerator.Tests.BitVector
+    Test.Ouroboros.Consensus.ChainGenerator.Tests.BlockTree
     Test.Ouroboros.Consensus.ChainGenerator.Tests.ChainDb
     Test.Ouroboros.Consensus.ChainGenerator.Tests.Counting
     Test.Ouroboros.Consensus.ChainGenerator.Tests.GenChain
     Test.Ouroboros.Consensus.ChainGenerator.Tests.GenesisTest
     Test.Ouroboros.Consensus.ChainGenerator.Tests.Honest
     Test.Ouroboros.Consensus.ChainGenerator.Tests.PointSchedule
-    Test.Ouroboros.Consensus.ChainGenerator.Tests.PointScheduleTest
     Test.Ouroboros.Consensus.ChainGenerator.Tests.Sync
     Test.Util.ChainUpdates.Tests
     Test.Util.Schedule.Tests

--- a/ouroboros-consensus/test/infra-test/Ouroboros/Network/AnchoredFragment/Extras.hs
+++ b/ouroboros-consensus/test/infra-test/Ouroboros/Network/AnchoredFragment/Extras.hs
@@ -1,0 +1,13 @@
+module Ouroboros.Network.AnchoredFragment.Extras (slotLength) where
+
+import           Cardano.Slotting.Slot (SlotNo (unSlotNo), withOrigin)
+import           Ouroboros.Network.AnchoredFragment (AnchoredFragment,
+                     HasHeader, anchor, anchorToSlotNo, headAnchor)
+
+-- | Number of slots on which the fragment spans. This is different from the
+-- 'length' which is the number of blocks in the fragment.
+slotLength :: HasHeader blk => AnchoredFragment blk -> Int
+slotLength fragment =
+  fromIntegral $ unSlotNo $
+    withOrigin 0 id (anchorToSlotNo $ headAnchor fragment)
+    - withOrigin 0 id (anchorToSlotNo $ anchor fragment)

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/BlockTree.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/BlockTree.hs
@@ -101,7 +101,7 @@ findFragment point blockTree =
     <&> fst
 
 -- | @findPath source target blockTree@ finds a path from the @source@ point to
--- the @target@ point in the @blockTree@, or return @Nothing@. A path is a
+-- the @target@ point in the @blockTree@, or returns @Nothing@. A path is a
 -- fragment anchored at the @source@ or an ancestor of the @source@. One can
 -- distinguish three cases:
 --

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/BlockTree.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/BlockTree.hs
@@ -102,8 +102,8 @@ findFragment point blockTree =
 
 -- | @findPath source target blockTree@ finds a path from the @source@ point to
 -- the @target@ point in the @blockTree@, or returns @Nothing@. A path is a
--- fragment anchored at the @source@ or an ancestor of the @source@. One can
--- distinguish three cases:
+-- fragment anchored at the youngest common ancestor of both @source@ and
+-- @target@. One can distinguish three cases:
 --
 -- - the fragment is anchored at the @source@: all the blocks are descendants of
 --   the source; serving this fragment would only require rolling forward;

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/BlockTree.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/BlockTree.hs
@@ -38,9 +38,9 @@ import           Text.Printf (printf)
 --
 -- - the full fragment, that is the prefix and suffix catenated.
 data BlockTreeBranch blk = BlockTreeBranch {
-    prefix :: AF.AnchoredFragment blk,
-    suffix :: AF.AnchoredFragment blk,
-    full   :: AF.AnchoredFragment blk
+    btbPrefix :: AF.AnchoredFragment blk,
+    btbSuffix :: AF.AnchoredFragment blk,
+    btbFull   :: AF.AnchoredFragment blk
   }
   deriving (Show)
 
@@ -69,10 +69,10 @@ mkTrunk trunk = BlockTree { trunk, branches = [] }
 -- the trunk.
 addBranch :: AF.HasHeader blk => AF.AnchoredFragment blk -> BlockTree blk -> Maybe (BlockTree blk)
 addBranch branch BlockTree{..} = do
-  (_, prefix, _, suffix) <- AF.intersect trunk branch
+  (_, btbPrefix, _, btbSuffix) <- AF.intersect trunk branch
   -- NOTE: We could use the monadic bind for @Maybe@ here but we would rather
   -- catch bugs quicker.
-  let full = fromJust $ AF.join prefix suffix
+  let btbFull = fromJust $ AF.join btbPrefix btbSuffix
   pure $ BlockTree { trunk, branches = BlockTreeBranch { .. } : branches }
 
 -- | Same as @addBranch@ but assumes that the precondition holds.
@@ -91,7 +91,7 @@ slotLength fragment =
 
 -- | Return all the full fragments from the root of the tree.
 allFragments :: BlockTree blk -> [AF.AnchoredFragment blk]
-allFragments BlockTree{..} = trunk : map full branches
+allFragments BlockTree{..} = trunk : map btbFull branches
 
 firstJust :: [Maybe a] -> Maybe a
 firstJust []               = Nothing
@@ -127,7 +127,7 @@ findPath source target blockTree = do
 prettyPrint :: AF.HasHeader blk => BlockTree blk -> [String]
 prettyPrint blockTree = do
   let honestFragment = trunk blockTree
-  let advFragment = suffix $ head $ branches blockTree
+  let advFragment = btbSuffix $ head $ branches blockTree
 
   let (oSlotNo, oBlockNo) = slotAndBlockNoFromAnchor $ AF.anchor honestFragment
   let (hSlotNo, _) = slotAndBlockNoFromAnchor $ AF.headAnchor honestFragment

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/BlockTree.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/BlockTree.hs
@@ -63,10 +63,13 @@ data BlockTree blk = BlockTree {
 mkTrunk :: AF.AnchoredFragment blk -> BlockTree blk
 mkTrunk btTrunk = BlockTree { btTrunk, btBranches = [] }
 
--- | Add a branch to a block tree. The given fragment has to be anchored in
+-- | Add a branch to an existing block tree.
 --
--- PRECONDITION: The given fragment intersects with the trunk or the anchor of
--- the trunk.
+-- PRECONDITION: The given fragment intersects with the trunk or its anchor.
+--
+-- FIXME: this would be a good place to check consistency of the hashes with the
+-- current branches, that is we should use this function to ensure that no two
+-- branches leave the trunk at the same slot with the same fork number.
 addBranch :: AF.HasHeader blk => AF.AnchoredFragment blk -> BlockTree blk -> Maybe (BlockTree blk)
 addBranch branch BlockTree{..} = do
   (_, btbPrefix, _, btbSuffix) <- AF.intersect btTrunk branch

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/BlockTree.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/BlockTree.hs
@@ -11,8 +11,10 @@ module Test.Ouroboros.Consensus.ChainGenerator.Tests.BlockTree (
   , addBranch
   , addBranch'
   , mkTrunk
+  , slotLength
   ) where
 
+import           Cardano.Slotting.Slot (SlotNo (unSlotNo), withOrigin)
 import           Data.Maybe (fromJust, fromMaybe)
 import qualified Ouroboros.Network.AnchoredFragment as AF
 
@@ -64,3 +66,12 @@ addBranch branch BlockTree{..} = do
 addBranch' :: AF.HasHeader blk => AF.AnchoredFragment blk -> BlockTree blk -> BlockTree blk
 addBranch' branch blockTree =
   fromMaybe (error "addBranch': precondition does not hold") $ addBranch branch blockTree
+
+-- | Number of slots on which the fragment span.
+--
+-- REVIEW: Should be put somewhere else but is here in lack of a better place.
+slotLength :: AF.HasHeader blk => AF.AnchoredFragment blk -> Int
+slotLength fragment =
+  fromIntegral $ unSlotNo $
+    withOrigin 0 id (AF.anchorToSlotNo $ AF.headAnchor fragment)
+    - withOrigin 0 id (AF.anchorToSlotNo $ AF.anchor fragment)

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/BlockTree.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/BlockTree.hs
@@ -16,11 +16,10 @@ module Test.Ouroboros.Consensus.ChainGenerator.Tests.BlockTree (
   , findPath
   , mkTrunk
   , prettyPrint
-  , slotLength
   ) where
 
 import           Cardano.Slotting.Block (BlockNo)
-import           Cardano.Slotting.Slot (SlotNo (unSlotNo), withOrigin)
+import           Cardano.Slotting.Slot (SlotNo (unSlotNo))
 import           Data.Function ((&))
 import           Data.Maybe (fromJust, fromMaybe)
 import qualified Data.Vector as Vector
@@ -85,15 +84,6 @@ addBranch branch BlockTree{..} = do
 addBranch' :: AF.HasHeader blk => AF.AnchoredFragment blk -> BlockTree blk -> BlockTree blk
 addBranch' branch blockTree =
   fromMaybe (error "addBranch': precondition does not hold") $ addBranch branch blockTree
-
--- | Number of slots on which the fragment span.
---
--- REVIEW: Should be put somewhere else but is here in lack of a better place.
-slotLength :: AF.HasHeader blk => AF.AnchoredFragment blk -> Int
-slotLength fragment =
-  fromIntegral $ unSlotNo $
-    withOrigin 0 id (AF.anchorToSlotNo $ AF.headAnchor fragment)
-    - withOrigin 0 id (AF.anchorToSlotNo $ AF.anchor fragment)
 
 -- | Return all the full fragments from the root of the tree.
 allFragments :: BlockTree blk -> [AF.AnchoredFragment blk]

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/BlockTree.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/BlockTree.hs
@@ -120,6 +120,13 @@ findPath source target blockTree = do
   (_, _, _, targetSuffix) <- AF.intersect sourceFragment targetFragment
   pure targetSuffix
 
+-- | Pretty prints a block tree for human readability. For instance:
+--
+--     slots:  0  1  2  3  4  5  6  7  8  9
+--     trunk:  0─────1──2──3──4─────5──6──7
+--                      ╰─────3──4─────5
+--
+-- Returns a list of strings intended to be catenated with a newline.
 prettyPrint :: AF.HasHeader blk => BlockTree blk -> [String]
 prettyPrint blockTree = do
   let honestFragment = btTrunk blockTree

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/BlockTree.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/BlockTree.hs
@@ -106,7 +106,8 @@ newtype PathAnchoredAtSource = PathAnchoredAtSource Bool
 
 -- | @findPath source target blockTree@ finds a path from the @source@ point to
 -- the @target@ point in the @blockTree@ and returns it as an anchored fragment
--- or returns @Nothing@. There are two interesting properties on this fragment:
+-- It returns @Nothing@ when either of @source@ are @target@ are not in the
+-- 'BlockTree'. There are two interesting properties on this fragment:
 --
 --   1. Whether the returned fragment is anchored at the @source@.
 --   2. Whether the returned fragment is empty.

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/BlockTree.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/BlockTree.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE NamedFieldPuns  #-}
+{-# LANGUAGE RecordWildCards #-}
+
+-- REVIEW: There is a `BlockTree` in `Test.Utils.TestBlock`. It relies on
+-- different mechanisms but maybe we should rely on that instead to avoid
+-- duplication.
+
+module Test.Ouroboros.Consensus.ChainGenerator.Tests.BlockTree (
+    BlockTree (..)
+  , BlockTreeBranch (..)
+  , addBranch
+  , addBranch'
+  , mkTrunk
+  ) where
+
+import           Data.Maybe (fromJust, fromMaybe)
+import qualified Ouroboros.Network.AnchoredFragment as AF
+
+-- | Represent a branch of a block tree. We provide:
+--
+-- - its prefix, whose anchor is the same as the trunk and whose head is the
+--   intersection point for this specific branch.
+--
+-- - its suffix, whose anchor is the intersection point.
+--
+-- - the full fragment, that is the prefix and suffix catenated.
+data BlockTreeBranch blk = BlockTreeBranch {
+    prefix :: AF.AnchoredFragment blk,
+    suffix :: AF.AnchoredFragment blk,
+    full   :: AF.AnchoredFragment blk
+  }
+
+-- | Represent a block tree with a main trunk and branches leaving from the
+-- trunk in question. All the branches are represented by their prefix to and
+-- suffix from the intersection point.
+--
+-- INVARIANT: The branches are anchored in a block of the trunk or have the same
+-- anchor as the trunk.
+--
+-- INVARIANT: The branches do not contain any block (beside the anchor) that is
+-- present in the trunk.
+data BlockTree blk = BlockTree {
+    trunk    :: AF.AnchoredFragment blk,
+    branches :: [BlockTreeBranch blk]
+  }
+
+-- | Make a block tree made of only a trunk.
+mkTrunk :: AF.AnchoredFragment blk -> BlockTree blk
+mkTrunk trunk = BlockTree { trunk, branches = [] }
+
+-- | Add a branch to a block tree. The given fragment has to be anchored in
+--
+-- PRECONDITION: The given fragment intersects with the trunk or the anchor of
+-- the trunk.
+addBranch :: AF.HasHeader blk => AF.AnchoredFragment blk -> BlockTree blk -> Maybe (BlockTree blk)
+addBranch branch BlockTree{..} = do
+  (_, prefix, _, suffix) <- AF.intersect trunk branch
+  -- NOTE: We could use the monadic bind for @Maybe@ here but we would rather
+  -- catch bugs quicker.
+  let full = fromJust $ AF.join prefix suffix
+  pure $ BlockTree { trunk, branches = BlockTreeBranch { .. } : branches }
+
+-- | Same as @addBranch@ but assumes that the precondition holds.
+addBranch' :: AF.HasHeader blk => AF.AnchoredFragment blk -> BlockTree blk -> BlockTree blk
+addBranch' branch blockTree =
+  fromMaybe (error "addBranch': precondition does not hold") $ addBranch branch blockTree

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/GenChain.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/GenChain.hs
@@ -25,6 +25,14 @@ import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TestBlock (TestBlock, TestBlockWith (tbSlot),
                      firstBlock, forkBlock, successorBlock)
 
+-- | Generates a block tree randomly from an adversarial recipe. The block tree
+-- contains one trunk (the “good chain”) and one branch (the “bad chain”). For
+-- instance, one such tree could be graphically represented as:
+--
+--     slots:    1  2  3  4  5  6  7  8  9
+--     good:  O─────1──2──3──4─────5──6──7
+--     bad:            ╰─────3──4─────5
+--
 genChains ::
   Asc ->
   A.AdversarialRecipe base hon ->

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/GenChain.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/GenChain.hs
@@ -7,13 +7,11 @@
 
 module Test.Ouroboros.Consensus.ChainGenerator.Tests.GenChain (module Test.Ouroboros.Consensus.ChainGenerator.Tests.GenChain) where
 
+import           Cardano.Slotting.Slot (SlotNo)
 import           Data.List (foldl')
 import qualified Data.Vector.Unboxed as Vector
-import           Ouroboros.Consensus.Block (BlockNo)
-import           Ouroboros.Consensus.Block.Abstract (SlotNo (SlotNo))
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import qualified Ouroboros.Network.AnchoredFragment as AF
-import           Ouroboros.Network.Block (blockNo)
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Adversarial as A
 import           Test.Ouroboros.Consensus.ChainGenerator.Counting
                      (Count (Count), getVector)
@@ -21,36 +19,24 @@ import qualified Test.Ouroboros.Consensus.ChainGenerator.Honest as H
 import           Test.Ouroboros.Consensus.ChainGenerator.Params (Asc)
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Slot as S
 import           Test.Ouroboros.Consensus.ChainGenerator.Slot (S)
+import qualified Test.Ouroboros.Consensus.ChainGenerator.Tests.BlockTree as BT
 import           Test.QuickCheck.Random (QCGen)
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TestBlock (TestBlock, TestBlockWith (tbSlot),
                      firstBlock, forkBlock, successorBlock)
 
--- | Returns the good chain, bad chain, block number of the last common block,
--- slot number of the last common block, and the total number of slots in the
--- adversarial chain.
 genChains ::
   Asc ->
   A.AdversarialRecipe base hon ->
   A.SomeCheckedAdversarialRecipe base hon ->
   QCGen ->
-  (AF.AnchoredFragment TestBlock, AF.AnchoredFragment TestBlock, BlockNo, SlotNo, SlotNo)
+  BT.BlockTree TestBlock
 genChains ascA A.AdversarialRecipe {A.arHonest, A.arPrefix = Count prefixCount} (A.SomeCheckedAdversarialRecipe _ recipeA') seed =
-  -- trace ("honest block count: " ++ show (length goodBlocks)) $
-  -- trace ("honest slot count: " ++ show (length slotsH)) $
-  -- trace ("prefix: " ++ show prefixCount) $
-  -- trace ("good: " ++ show (S.test S.notInverted <$> slotsH)) $
-  -- trace ("bad: " ++ show (S.test S.notInverted <$> (Vector.toList (getVector vA)))) $
-  (goodChain, badChain, prefixBlockNo, prefixSlotNo, SlotNo (fromIntegral (length slotsA)))
+  BT.addBranch' badChain $ BT.mkTrunk goodChain
   where
     goodChain = mkTestFragment goodBlocks
 
     badChain = mkTestFragment (mkTestBlocks False prefix slotsA)
-
-    (prefixBlockNo, prefixSlotNo) =
-      case prefix of
-        h : _ -> (blockNo h, tbSlot h)
-        []    -> (0, 0)
 
     -- blocks in the common prefix in reversed order
     prefix = drop (length goodBlocks - prefixCount) goodBlocks

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/GenesisTest.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/GenesisTest.hs
@@ -74,25 +74,18 @@ exampleTestSetup params seed =
     fast = True
     advId = PeerId "adversary"
     HonestRecipe (Kcp k) (Scg scg) _ (Len len) = testRecipeH params
+
     genesisAcrossIntersection = not genesisAfterIntersection && len > scg
-    -- TODO: also need: at least k+1 blocks after the intersection
-    genesisAfterIntersection =
-         fragLenA > fromIntegral scg
-      && advLenAfterIntersection >= fromIntegral k
-    advLenAfterIntersection =
-      withOrigin 0 unBlockNo (AF.headBlockNo badChain)
-        - withOrigin 0 unBlockNo prefixBlockNo
+    genesisAfterIntersection = fragLenA > scg && advLenAfterIntersection > k
+
+    fragLenA = BT.slotLength badChain
+    advLenAfterIntersection = AF.length badChainSuffix
 
     blockTree = genChains (testAscA params) (testRecipeA params) (testRecipeA' params) seed
     goodChain = BT.trunk blockTree
 
-    BT.BlockTreeBranch { prefix = badChainPrefix, full = badChain } =
+    BT.BlockTreeBranch { suffix = badChainSuffix, full = badChain } =
       head $ BT.branches blockTree
-
-    prefixBlockNo = AF.anchorToBlockNo $ AF.headAnchor badChainPrefix
-    fragLenA =
-      withOrigin 0 id (AF.anchorToSlotNo $ AF.headAnchor badChain)
-        - withOrigin 0 id (AF.anchorToSlotNo $ AF.anchor badChain)
 
 stripBlockBodies :: TestFrag -> TestFragH
 stripBlockBodies = AF.bimap AF.castAnchor getHeader

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/GenesisTest.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/GenesisTest.hs
@@ -20,6 +20,8 @@ import           Test.Ouroboros.Consensus.ChainGenerator.Params
 import           Test.Ouroboros.Consensus.ChainGenerator.Tests.Adversarial hiding
                      (tests)
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Tests.BlockTree as BT
+import           Test.Ouroboros.Consensus.ChainGenerator.Tests.BlockTree
+                     (BlockTreeBranch (btbFull))
 import           Test.Ouroboros.Consensus.ChainGenerator.Tests.GenChain
                      (genChains)
 import           Test.Ouroboros.Consensus.ChainGenerator.Tests.PointSchedule
@@ -82,7 +84,7 @@ exampleTestSetup params seed =
     blockTree = genChains (testAscA params) (testRecipeA params) (testRecipeA' params) seed
     goodChain = BT.trunk blockTree
 
-    BT.BlockTreeBranch { suffix = badChainSuffix, full = badChain } =
+    BT.BlockTreeBranch { btbSuffix = badChainSuffix, btbFull = badChain } =
       head $ BT.branches blockTree
 
 runTest ::

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/GenesisTest.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/GenesisTest.hs
@@ -82,10 +82,10 @@ exampleTestSetup params seed =
     advLenAfterIntersection = AF.length badChainSuffix
 
     blockTree = genChains (testAscA params) (testRecipeA params) (testRecipeA' params) seed
-    goodChain = BT.trunk blockTree
+    goodChain = BT.btTrunk blockTree
 
     BT.BlockTreeBranch { btbSuffix = badChainSuffix, btbFull = badChain } =
-      head $ BT.branches blockTree
+      head $ BT.btBranches blockTree
 
 runTest ::
   forall m.

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/GenesisTest.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/GenesisTest.hs
@@ -14,6 +14,7 @@ import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Network.AnchoredFragment (headAnchor)
 import qualified Ouroboros.Network.AnchoredFragment as AF
+import qualified Ouroboros.Network.AnchoredFragment.Extras as AF
 import           Test.Ouroboros.Consensus.ChainGenerator.Honest
                      (HonestRecipe (HonestRecipe))
 import           Test.Ouroboros.Consensus.ChainGenerator.Params
@@ -78,7 +79,7 @@ exampleTestSetup params seed =
     genesisAcrossIntersection = not genesisAfterIntersection && len > scg
     genesisAfterIntersection = fragLenA > scg && advLenAfterIntersection > k
 
-    fragLenA = BT.slotLength badChain
+    fragLenA = AF.slotLength badChain
     advLenAfterIntersection = AF.length badChainSuffix
 
     blockTree = genChains (testAscA params) (testRecipeA params) (testRecipeA' params) seed

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/Sync.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/Sync.hs
@@ -430,15 +430,17 @@ mkCdbTracer tracer =
     ChainDB.Impl.TraceAddBlockEvent event ->
       case event of
         AddedToCurrentChain _ NewTipInfo {newTipPoint} _ newFragment -> do
-          traceUnitWith tracer "ChainDB" "Added to current chain"
-          traceUnitWith tracer "ChainDB" $ "New tip: " ++ condense newTipPoint
-          traceUnitWith tracer "ChainDB" $ "New fragment: " ++ condense newFragment
+          trace "Added to current chain"
+          trace $ "New tip: " ++ condense newTipPoint
+          trace $ "New fragment: " ++ condense newFragment
         SwitchedToAFork _ NewTipInfo {newTipPoint} _ newFragment -> do
-          traceUnitWith tracer "ChainDB" "Switched to a fork"
-          traceUnitWith tracer "ChainDB" $ "New tip: " ++ condense newTipPoint
-          traceUnitWith tracer "ChainDB" $ "New fragment: " ++ condense newFragment
+          trace "Switched to a fork"
+          trace $ "New tip: " ++ condense newTipPoint
+          trace $ "New fragment: " ++ condense newFragment
         _ -> pure ()
     _ -> pure ()
+  where
+    trace = traceUnitWith tracer "ChainDB"
 
 mkChainSyncClientTracer ::
   IOLike m =>
@@ -447,10 +449,12 @@ mkChainSyncClientTracer ::
 mkChainSyncClientTracer tracer =
   Tracer $ \case
     TraceRolledBack point ->
-      traceUnitWith tracer "ChainSyncClient" $ "Rolled back to: " ++ condense point
+      trace $ "Rolled back to: " ++ condense point
     TraceFoundIntersection point _ourTip _theirTip ->
-      traceUnitWith tracer "ChainSyncClient" $ "Found intersection at: " ++ condense point
+      trace $ "Found intersection at: " ++ condense point
     _ -> pure ()
+  where
+    trace = traceUnitWith tracer "ChainSyncClient"
 
 -- | Trace using the given tracer, printing the current time (typically the time
 -- of the simulation) and the unit name.

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/Sync.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/Sync.hs
@@ -195,7 +195,7 @@ serveHeader MockedChainSyncServer{..} points = do
   let HeaderPoint header' = header points
       headerPoint = AF.castPoint $ blockPoint header'
   case BT.findPath intersection headerPoint mcssBlockTree of
-    Nothing -> error "There should always be a path"
+    Nothing -> error "serveHeader: intersection and and headerPoint should always be in the block tree"
     Just findPathResult ->
       case findPathResult of
         -- If the anchor is the intersection (the source of the path-finding)

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/Sync.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/Sync.hs
@@ -9,26 +9,24 @@
 module Test.Ouroboros.Consensus.ChainGenerator.Tests.Sync where
 
 import           Cardano.Crypto.DSIGN (SignKeyDSIGN (..), VerKeyDSIGN (..))
-import           Cardano.Slotting.Slot (SlotNo (unSlotNo))
 import           Cardano.Slotting.Time (SlotLength, slotLengthFromSec)
-import           Control.Monad (forever)
 import           Control.Monad.State.Strict (StateT, evalStateT, get, gets,
                      lift, modify')
 import           Control.Tracer (Tracer (Tracer), nullTracer, traceWith)
 import           Data.Coerce (coerce)
-import           Data.Foldable (for_)
-import           Data.Function ((&))
+import           Data.Foldable (for_, traverse_)
 import           Data.Functor (void)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (fromJust)
 import           Data.Monoid (First (First, getFirst))
 import           Data.Time.Clock (diffTimeToPicoseconds)
-import qualified Data.Vector as Vector
 import           Network.TypedProtocol.Channel (createConnectedChannels)
 import           Network.TypedProtocol.Driver.Simple
                      (runConnectedPeersPipelined)
-import           Ouroboros.Consensus.Block.Abstract (Header, Point (..))
+import           Ouroboros.Consensus.Block (WithOrigin (Origin))
+import           Ouroboros.Consensus.Block.Abstract (Header, Point (..),
+                     getHeader)
 import           Ouroboros.Consensus.Config (SecurityParam, TopLevelConfig (..))
 import qualified Ouroboros.Consensus.HardFork.History.EraParams as HardFork
                      (EraParams, defaultEraParams)
@@ -59,11 +57,9 @@ import           Ouroboros.Consensus.Util.IOLike (IOLike, MonadMonotonicTime,
                      writeTQueue, writeTVar)
 import           Ouroboros.Consensus.Util.ResourceRegistry
 import           Ouroboros.Consensus.Util.STM (blockUntilChanged)
-import           Ouroboros.Network.AnchoredFragment (AnchoredFragment,
-                     toOldestFirst)
+import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import qualified Ouroboros.Network.AnchoredFragment as AF
-import           Ouroboros.Network.Block (BlockNo (unBlockNo), Tip (..),
-                     blockHash, blockNo, blockPoint, blockSlot)
+import           Ouroboros.Network.Block (Tip (..), blockPoint, getTipPoint)
 import           Ouroboros.Network.ControlMessage (ControlMessage (..))
 import           Ouroboros.Network.Protocol.ChainSync.ClientPipelined
                      (ChainSyncClientPipelined, chainSyncClientPeerPipelined)
@@ -76,13 +72,14 @@ import           Ouroboros.Network.Protocol.ChainSync.Server
                      ServerStIntersect (SendMsgIntersectFound, SendMsgIntersectNotFound),
                      ServerStNext (SendMsgRollForward), chainSyncServerPeer)
 import           Prelude hiding (log)
+import qualified Test.Ouroboros.Consensus.ChainGenerator.Tests.BlockTree as BT
 import           Test.Ouroboros.Consensus.ChainGenerator.Tests.PointSchedule
 import           Test.Util.ChainDB
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TestBlock (BlockConfig (TestBlockConfig),
                      CodecConfig (TestBlockCodecConfig), Header (..),
                      StorageConfig (TestBlockStorageConfig), TestBlock,
-                     testInitExtLedger, unTestHash)
+                     testInitExtLedger)
 import           Text.Printf (printf)
 
 data SyncPeer m =
@@ -128,91 +125,86 @@ defaultCfg secParam = TopLevelConfig {
 
 data MockedChainSyncServer m =
   MockedChainSyncServer {
-    mcssPeerId            :: PeerId,
-    mcssStateQueue        :: TQueue m NodeState,
-    mcssCurrentState      :: StrictTVar m NodeState,
-    mcssCandidateFragment :: StrictTVar m TestFragH,
-    mcssUnservedFragment  :: StrictTVar m TestFragH,
-    mcssTracer            :: Tracer m String
+    mcssPeerId              :: PeerId,
+    mcssStateQueue          :: TQueue m NodeState,
+    mcssCurrentState        :: StrictTVar m NodeState,
+    mcssCandidateFragment   :: StrictTVar m TestFragH,
+    mcssCurrentIntersection :: StrictTVar m (AF.Point TestBlock),
+    mcssBlockTree           :: BT.BlockTree TestBlock,
+    mcssTracer              :: Tracer m String
   }
 
 makeMockedChainSyncServer ::
   IOLike m =>
   PeerId ->
-  TestFragH ->
   Tracer m String ->
+  BT.BlockTree TestBlock ->
   m (MockedChainSyncServer m)
-makeMockedChainSyncServer mcssPeerId unservedFragment tracer = do
+makeMockedChainSyncServer mcssPeerId tracer mcssBlockTree = do
   mcssStateQueue <- newTQueueIO
   mcssCurrentState <- uncheckedNewTVarM NodeOffline
   mcssCandidateFragment <- uncheckedNewTVarM $ AF.Empty AF.AnchorGenesis
-  mcssUnservedFragment <- uncheckedNewTVarM unservedFragment
+  mcssCurrentIntersection <- uncheckedNewTVarM $ AF.Point Origin
   let mcssTracer = Tracer $ traceUnitWith tracer ("MockedChainSyncServer " ++ condense mcssPeerId)
   pure MockedChainSyncServer {..}
 
 waitNodeState ::
   IOLike m =>
   MockedChainSyncServer m ->
-  m (AdvertisedPoints, TestFragH)
+  m AdvertisedPoints
 waitNodeState server@MockedChainSyncServer{..} = do
   newState <- atomically $ do
     newState <- readTQueue mcssStateQueue
     writeTVar mcssCurrentState newState
     pure newState
   case newState of
-    NodeOffline -> waitNodeState server
-    NodeOnline advertisedPoints -> do
-      unservedFragment <- readTVarIO mcssUnservedFragment
-      pure (advertisedPoints, unservedFragment)
+    NodeOffline                 -> waitNodeState server
+    NodeOnline advertisedPoints -> pure advertisedPoints
 
 checkCurrent ::
   IOLike m =>
   MockedChainSyncServer m ->
-  m (AdvertisedPoints, TestFragH)
+  m AdvertisedPoints
 checkCurrent server@MockedChainSyncServer{..} =
   readTVarIO mcssCurrentState >>= \case
     NodeOffline -> waitNodeState server
-    NodeOnline s -> do
-      frag <- readTVarIO mcssUnservedFragment
-      pure (s, frag)
-
--- | Whether the advertised points allow serving at least one header in the
--- fragment.
---
--- FIXME: `HeaderPoint` in `PointSchedule` is a header and not a point; what the
--- hell?
-canServeHeader ::
-  AdvertisedPoints ->
-  TestFragH ->
-  Bool
-canServeHeader AdvertisedPoints{header = HeaderPoint point} fragment =
-  AF.pointOnFragment (blockPoint point) fragment
+    NodeOnline advertisedPoints -> pure advertisedPoints
 
 serveHeader ::
   IOLike m =>
   MockedChainSyncServer m ->
   AdvertisedPoints ->
-  TestFragH ->
   m (Maybe (Tip TestBlock, Header TestBlock))
-serveHeader MockedChainSyncServer{..} points = \case
-  AF.Empty _ -> pure Nothing
-  next AF.:< rest -> do
-    atomically (writeTVar mcssUnservedFragment rest)
-    pure $ Just (coerce $ tip points, next)
+serveHeader MockedChainSyncServer{..} points = do
+  intersection <- readTVarIO mcssCurrentIntersection
+  traceWith mcssTracer $ "  last intersection is " ++ condense intersection
+  let HeaderPoint header' = header points
+      headerPoint = AF.castPoint $ blockPoint header'
+  case BT.findPath intersection headerPoint mcssBlockTree of
+    Nothing -> error "There should always be a path"
+    Just (involvesRollback, fragmentAhead) -> do
+      traceWith mcssTracer $ "  fragment ahead: " ++ condense fragmentAhead
+      case involvesRollback of
+        BT.InvolvesRollback True -> error "Rollback not supported in MockedChainSyncServer"
+        _ -> pure ()
+      case fragmentAhead of
+        AF.Empty _ -> pure Nothing
+        next AF.:< _ -> do
+          atomically $ writeTVar mcssCurrentIntersection $ blockPoint next
+          pure $ Just (coerce (tip points), getHeader next)
 
 intersectWith ::
   AnchoredFragment TestBlock ->
   [Point TestBlock] ->
-  Maybe (AnchoredFragment TestBlock)
+  Maybe (Point TestBlock)
 intersectWith fullFrag pts =
-  snd <$> getFirst (foldMap (First . AF.splitAfterPoint fullFrag) pts)
+  AF.anchorPoint . snd <$> getFirst (foldMap (First . AF.splitAfterPoint fullFrag) pts)
 
 runMockedChainSyncServer ::
   IOLike m =>
   MockedChainSyncServer m ->
-  TestFrag ->
   ChainSyncServer (Header TestBlock) (Point TestBlock) (Tip TestBlock) m ()
-runMockedChainSyncServer server@MockedChainSyncServer{..} fullFrag =
+runMockedChainSyncServer server@MockedChainSyncServer{..} =
   go
   where
     go =
@@ -223,56 +215,40 @@ runMockedChainSyncServer server@MockedChainSyncServer{..} fullFrag =
       }
 
     recvMsgRequestNext = do
-      (advertisedPoints, fragment) <- checkCurrent server
-      () <- if canServeHeader advertisedPoints fragment
-        then pure ()
-        else do
-          trace "waiting for node state..."
-          void $ waitNodeState server
+      advertisedPoints <- checkCurrent server
       trace "handling MsgRequestNext"
       trace $ "  points are " ++ condense advertisedPoints
-      trace $ "  fragment is " ++ condense fragment
-      serveHeader server advertisedPoints fragment >>= \case
-        Just (tip, h) -> do
-          trace $ "  gotta serve " ++ condense h
+      serveHeader server advertisedPoints >>= \case
+        Just (tip, headerToServe) -> do
+          trace $ "  gotta serve " ++ condense headerToServe
           trace $ "  tip is      " ++ condense tip
           trace "done handling MsgRequestNext"
-          pure $ Left $ SendMsgRollForward h tip go
+          pure $ Left $ SendMsgRollForward headerToServe tip go
         Nothing -> do
-          trace "  no more blocks to serve; done forever!"
-          trace "done handling MsgRequestNext"
-          pure $ Right stall
+          trace "  cannot serve at this point; waiting for node state and starting again"
+          void $ waitNodeState server
+          recvMsgRequestNext
 
     recvMsgFindIntersect pts = do
-      (points, _) <- checkCurrent server
+      points <- checkCurrent server
       trace "handling MsgFindIntersect"
-      let theTip = coerce $ tip points
-      case intersectWith fullFrag pts of
+      let TipPoint tip' = tip points
+          tipPoint = Ouroboros.Network.Block.getTipPoint tip'
+          fragment = fromJust $ BT.findFragment tipPoint mcssBlockTree
+      case intersectWith fragment pts of
         Nothing -> do
           trace "  no intersection found"
           trace "done handling MsgFindIntersect"
-          pure $ SendMsgIntersectNotFound theTip go
-        Just frag -> do
-          unservedFragment <- readTVarIO mcssUnservedFragment
-          trace $ "  unserved fragment is: " ++ condense unservedFragment
-          let intersection = AF.anchorPoint frag
+          pure $ SendMsgIntersectNotFound tip' go
+        Just intersection -> do
           trace $ "  intersection found: " ++ condense intersection
-          case AF.splitAfterPoint unservedFragment intersection of
-            Nothing -> do
-              trace "  intersection is not in the unserved fragment"
-              pure ()
-            Just (_dropped, unservedFragment') -> do
-              trace "  intersection was in the unserved fragment"
-              atomically $ writeTVar mcssUnservedFragment unservedFragment'
-              trace $ "  unserved fragment is now: " ++ condense unservedFragment'
+          atomically $ writeTVar mcssCurrentIntersection intersection
           trace "done handling MsgFindIntersect"
-          pure $ SendMsgIntersectFound (AF.anchorPoint frag) theTip go
+          pure $ SendMsgIntersectFound intersection tip' go
 
     recvMsgDoneClient = do
       trace "received MsgDoneClient"
       pure ()
-
-    stall = forever $ threadDelay 1000
 
     trace = traceWith mcssTracer
 
@@ -298,14 +274,12 @@ syncWith ::
   IOLike m =>
   Tracer m String ->
   ChainDbView m TestBlock ->
-  Peers TestFrag ->
-  PeerId ->
   MockedChainSyncServer m ->
   StateT (SyncTest m) m ()
-syncWith tracer chainDbView frags pid server@MockedChainSyncServer{..} = do
+syncWith tracer chainDbView server@MockedChainSyncServer{..} = do
   cfg <- gets topConfig
   handle <- lift $ async $ do
-    let s = runMockedChainSyncServer server (fromJust (getPeer pid frags))
+    let s = runMockedChainSyncServer server
     runConnectedPeersPipelined
       createConnectedChannels
       nullTracer
@@ -384,72 +358,6 @@ syncTest tracer k pointSchedule peers setup continuation =
       b <- lift $ continuation a
       pure (b <$ res)
 
-slotAndBlockNoFromAnchor :: AF.Anchor b -> (SlotNo, BlockNo)
-slotAndBlockNoFromAnchor = \case
-  AF.AnchorGenesis -> (0, 0)
-  AF.Anchor slotNo _ blockNumber -> (slotNo, blockNumber)
-
-prettyPrintFragments ::
-  MonadMonotonicTime m =>
-  Tracer m String ->
-  Map PeerId TestFragH ->
-  m ()
-prettyPrintFragments tracer fragments = do
-  let honestFragment = fromJust $ fragments Map.!? HonestPeer
-  let advFragment = reanchorAdversary $ fromJust $ fragments Map.!? PeerId "adversary"
-
-  let (oSlotNo, oBlockNo) = slotAndBlockNoFromAnchor $ AF.anchor honestFragment
-  let (hSlotNo, _) = slotAndBlockNoFromAnchor $ AF.headAnchor honestFragment
-
-  let (aoSlotNo, _) = slotAndBlockNoFromAnchor $ AF.anchor advFragment
-  let (ahSlotNo, _) = slotAndBlockNoFromAnchor $ AF.headAnchor advFragment
-
-  let firstSlotNo = min oSlotNo aoSlotNo
-  let lastSlotNo = max hSlotNo ahSlotNo
-
-  traceWith tracer "Fragments:"
-
-  [firstSlotNo .. lastSlotNo]
-    & map (printf "%2d" . unSlotNo)
-    & unwords
-    & ("  slots:  " ++)
-    & traceWith tracer
-
-  honestFragment
-    & toOldestFirst
-    & map (\block -> (fromIntegral (unSlotNo (blockSlot block) - 1), Just (unBlockNo (blockNo block))))
-    & Vector.toList . (Vector.replicate (fromIntegral (unSlotNo hSlotNo - unSlotNo oSlotNo)) Nothing Vector.//)
-    & map (maybe "  " (printf "%2d"))
-    & unwords
-    & map (\c -> if c == ' ' then '─' else c)
-    & ("─" ++)
-    & (printf "%2d" (unBlockNo oBlockNo) ++)
-    & ("  honest: " ++)
-    & traceWith tracer
-
-  advFragment
-    & toOldestFirst
-    & map (\block -> (fromIntegral (unSlotNo (blockSlot block) - unSlotNo aoSlotNo - 1), Just (unBlockNo (blockNo block))))
-    & Vector.toList . (Vector.replicate (fromIntegral (unSlotNo ahSlotNo - unSlotNo aoSlotNo)) Nothing Vector.//)
-    & map (maybe "  " (printf "%2d"))
-    & unwords
-    & map (\c -> if c == ' ' then '─' else c)
-    & (" ╰─" ++)
-    & (replicate (3 * fromIntegral (unSlotNo (aoSlotNo - oSlotNo))) ' ' ++)
-    & ("  advers: " ++)
-    & traceWith tracer
-
-  pure ()
-
-  where
-    reanchorAdversary :: TestFragH -> TestFragH
-    reanchorAdversary fragment@(AF.Empty _) = fragment
-    reanchorAdversary fragment@(block AF.:< restFragment) =
-      if all (0 ==) $ unTestHash $ blockHash block then
-        reanchorAdversary restFragment
-      else
-        fragment
-
 syncPeers ::
   IOLike m =>
   SecurityParam ->
@@ -462,14 +370,9 @@ syncPeers k pointSchedule peers tracer =
     (do
       st <- get
       lift $ traceWith tracer $ "Security param k = " ++ show k
-      fragments <- lift $ traverse (readTVarIO . mcssUnservedFragment) peers
-      lift $ prettyPrintFragments tracer fragments
-      lift $ for_ peers $ \ MockedChainSyncServer {mcssPeerId, mcssUnservedFragment} -> do
-        unservedFragment <- readTVarIO mcssUnservedFragment
-        traceWith tracer $ condense mcssPeerId ++ " fragment: " ++ condense unservedFragment
       chainDb <- lift $ mkRealChainDb tracer (mcssCandidateFragment <$> peers) (topConfig st) (registry st)
       let chainDbView = defaultChainDbView chainDb
-      void (Map.traverseWithKey (syncWith tracer chainDbView (frags pointSchedule)) peers)
+      traverse_ (syncWith tracer chainDbView) peers
       pure chainDb)
     (atomically . ChainDB.getCurrentChain)
 

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/Sync.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/Sync.hs
@@ -123,15 +123,29 @@ defaultCfg secParam = TopLevelConfig {
 
     numCoreNodes = NumCoreNodes 2
 
+-- | The mutable state of a mocked ChainSync server.
+--
+-- REVIEW: This type name is misleading and should probably be renamed
+-- 'MockedChainSyncServerState'; the other functions 'makeMocked...' and
+-- 'runMocked...' should also be renamed.
 data MockedChainSyncServer m =
   MockedChainSyncServer {
     mcssPeerId              :: PeerId,
+    -- ^ REVIEW: Not sure this is the right place for it.
     mcssStateQueue          :: TQueue m NodeState,
+    -- ^ A queue of node states coming from the scheduler.
     mcssCurrentState        :: StrictTVar m NodeState,
+    -- ^ The current node state, popped from 'mcssStateQueue'.
     mcssCandidateFragment   :: StrictTVar m TestFragH,
+    -- ^ REVIEW: Not sure why we need this.
     mcssCurrentIntersection :: StrictTVar m (AF.Point TestBlock),
+    -- ^ The current known intersection with the chain of the client.
     mcssBlockTree           :: BT.BlockTree TestBlock,
+    -- ^ The block tree in which the test is taking place. In combination to
+    -- 'mcssCurrentState' and 'mcssCurrentIntersection', it allows to define
+    -- which blocks to serve to the client.
     mcssTracer              :: Tracer m String
+    -- ^ A tracer for this specific instance of the server.
   }
 
 makeMockedChainSyncServer ::


### PR DESCRIPTION
_This PR is only relevant for the Genesis test project._

This PR introduces a type for block trees and uses that type in two places:

- The chain generator now returns a block tree; this change is rather minimal.

- The `MockedChainSyncServer` now relies on the block tree to decide which blocks to serve. This makes for a big difference compared to the previous implementation that relied on knowing in advance which fragment precisely was going to be served to the client. The current implementation only needs to track the advertised points, the last known intersection with the client, and have knowledge of the block tree.

WDYT @facundominguez?