### PR TITLE
Build Haddocks on 9.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,7 @@ jobs:
       if: |
         github.event_name == 'push'
         && github.ref == 'refs/heads/main'
-        && matrix.ghc=='8.10.7'
+        && matrix.ghc=='9.2.8'
       run: |
         cabal build --dry-run --enable-tests all
         ./scripts/docs/haddocks.sh
@@ -200,7 +200,7 @@ jobs:
       if: |
         github.event_name == 'push'
         && github.ref == 'refs/heads/main'
-        && matrix.ghc=='8.10.7'
+        && matrix.ghc=='9.2.8'
       uses: actions/upload-artifact@v3
       with:
         name: haddocks


### PR DESCRIPTION
In contrast to 8.10, GHC ≥9.0 does no longer fail fatally on invalid Haddock markup.
