### PR TITLE
Pass continuation for handling ledger events

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,9 +14,9 @@ repository cardano-haskell-packages
 -- update either of these.
 index-state:
   -- Bump this if you need newer packages from Hackage
-  , hackage.haskell.org 2023-04-26T22:25:13Z
+  , hackage.haskell.org 2023-05-10T10:34:57Z
   -- Bump this if you need newer packages from CHaP
-  , cardano-haskell-packages 2023-05-23T16:25:08Z
+  , cardano-haskell-packages 2023-07-21T13:00:00Z
 
 packages:
   ./ouroboros-consensus

--- a/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBAnalyser/Run.hs
+++ b/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBAnalyser/Run.hs
@@ -16,6 +16,7 @@ import qualified Debug.Trace as Debug
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
 import qualified Ouroboros.Consensus.Fragment.InFuture as InFuture
+import           Ouroboros.Consensus.Ledger.Basics
 import           Ouroboros.Consensus.Ledger.Extended
 import qualified Ouroboros.Consensus.Ledger.SupportsMempool as LedgerSupportsMempool
                      (HasTxs)
@@ -105,7 +106,7 @@ analyse DBAnalyserConfig{analysis, confLimit, dbDir, selectDB, validation, verbo
             putStrLn $ "ImmutableDB tip: " ++ show tipPoint
             pure result
         SelectChainDB ->
-          ChainDB.withDB chainDbArgs $ \chainDB -> do
+          ChainDB.withDB discardEvent chainDbArgs $ \chainDB -> do
             result <- runAnalysis analysis $ AnalysisEnv {
                 cfg
               , initLedger = genesisLedger

--- a/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBSynthesizer/Run.hs
+++ b/ouroboros-consensus-cardano/src/tools/Cardano/Tools/DBSynthesizer/Run.hs
@@ -23,6 +23,7 @@ import           Data.Bool (bool)
 import           Data.ByteString as BS (ByteString, readFile)
 import           Ouroboros.Consensus.Config (configSecurityParam, configStorage)
 import qualified Ouroboros.Consensus.Fragment.InFuture as InFuture (dontCheck)
+import           Ouroboros.Consensus.Ledger.Basics (discardEvent)
 import qualified Ouroboros.Consensus.Node as Node (mkChainDbArgs,
                      stdMkChainDbHasFS)
 import qualified Ouroboros.Consensus.Node.InitStorage as Node
@@ -131,7 +132,7 @@ synthesize DBSynthesizerConfig{confOptions, confShelleyGenesis, confDbDir} (Some
                 putStrLn $ "--> opening ChainDB on file system with mode: " ++ show synthOpenMode
                 preOpenChainDB synthOpenMode confDbDir
                 let dbTracer = nullTracer
-                ChainDB.withDB dbArgs {ChainDB.cdbTracer = dbTracer} $ \chainDB -> do
+                ChainDB.withDB discardEvent dbArgs {ChainDB.cdbTracer = dbTracer} $ \chainDB -> do
                     slotNo <- do
                         tip <- atomically (ChainDB.getTipPoint chainDB)
                         pure $ case pointSlot tip of

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -112,7 +112,7 @@ library
     , io-classes                   ^>=1.1
     , mtl                          ^>=2.2
     , ouroboros-consensus          ^>=0.7
-    , ouroboros-network            ^>=0.8
+    , ouroboros-network            ^>=0.7
     , ouroboros-network-api        ^>=0.5
     , ouroboros-network-framework  ^>=0.6
     , ouroboros-network-protocols  ^>=0.5

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -112,7 +112,7 @@ library
     , io-classes                   ^>=1.1
     , mtl                          ^>=2.2
     , ouroboros-consensus          ^>=0.7
-    , ouroboros-network            ^>=0.7
+    , ouroboros-network            ^>=0.8
     , ouroboros-network-api        ^>=0.5
     , ouroboros-network-framework  ^>=0.6
     , ouroboros-network-protocols  ^>=0.5

--- a/ouroboros-consensus-diffusion/src/diffusion-testlib/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-diffusion/src/diffusion-testlib/Test/ThreadNet/Network.hs
@@ -800,7 +800,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
             nodeInfoDBs
             coreNodeId
       chainDB <- snd <$>
-        allocate registry (const (ChainDB.openDB chainDbArgs)) ChainDB.closeDB
+        allocate registry (const (ChainDB.openDB discardEvent chainDbArgs)) ChainDB.closeDB
 
       let customForgeBlock ::
                BlockForging m blk

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
@@ -71,6 +71,7 @@ import           Ouroboros.Consensus.Config.SupportsNode
 import           Ouroboros.Consensus.Fragment.InFuture (CheckInFuture,
                      ClockSkew)
 import qualified Ouroboros.Consensus.Fragment.InFuture as InFuture
+import           Ouroboros.Consensus.Ledger.Basics (AuxLedgerEvent (..))
 import           Ouroboros.Consensus.Ledger.Extended (ExtLedgerState (..))
 import qualified Ouroboros.Consensus.Network.NodeToClient as NTC
 import qualified Ouroboros.Consensus.Network.NodeToNode as NTN
@@ -180,6 +181,9 @@ data RunNodeArgs m addrNTN addrNTC blk (p2p :: Diffusion.P2P) = RunNodeArgs {
 
       -- | Network PeerSharing miniprotocol willingness flag
     , rnPeerSharing :: PeerSharing
+
+      -- | An event handler to trigger custom action when ledger events are emitted.
+    , rnHandleLedgerEvent :: AuxLedgerEvent (ExtLedgerState blk) -> m ()
     }
 
 -- | Arguments that usually only tests /directly/ specify.
@@ -342,8 +346,13 @@ runWith RunNodeArgs{..} encAddrNtN decAddrNtN LowLevelRunNodeArgs{..} =
                   , ChainDB.cdbVolatileDbValidation  = ValidateAll
                   }
 
-        chainDB <- openChainDB registry inFuture cfg initLedger
-                  llrnChainDbArgsDefaults customiseChainDbArgs'
+        chainDB <- openChainDB rnHandleLedgerEvent
+                               registry
+                               inFuture
+                               cfg
+                               initLedger
+                               llrnChainDbArgsDefaults
+                               customiseChainDbArgs'
 
         continueWithCleanChainDB chainDB $ do
           btime <-
@@ -567,7 +576,8 @@ stdWithCheckedDB pb databasePath networkMagic body = do
 
 openChainDB
   :: forall m blk. (RunNode blk, IOLike m)
-  => ResourceRegistry m
+  => (AuxLedgerEvent (ExtLedgerState blk) -> m ())
+  -> ResourceRegistry m
   -> CheckInFuture m blk
   -> TopLevelConfig blk
   -> ExtLedgerState blk
@@ -576,8 +586,8 @@ openChainDB
   -> (ChainDbArgs Identity m blk -> ChainDbArgs Identity m blk)
       -- ^ Customise the 'ChainDbArgs'
   -> m (ChainDB m blk)
-openChainDB registry inFuture cfg initLedger defArgs customiseArgs =
-    ChainDB.openDB args
+openChainDB handleLedgerEvent registry inFuture cfg initLedger defArgs customiseArgs =
+    ChainDB.openDB handleLedgerEvent args
   where
     args :: ChainDbArgs Identity m blk
     args = customiseArgs $

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
@@ -71,7 +71,7 @@ import           Ouroboros.Consensus.Config.SupportsNode
 import           Ouroboros.Consensus.Fragment.InFuture (CheckInFuture,
                      ClockSkew)
 import qualified Ouroboros.Consensus.Fragment.InFuture as InFuture
-import           Ouroboros.Consensus.Ledger.Basics (AuxLedgerEvent (..))
+import           Ouroboros.Consensus.Ledger.Basics (LedgerEventHandler)
 import           Ouroboros.Consensus.Ledger.Extended (ExtLedgerState (..))
 import qualified Ouroboros.Consensus.Network.NodeToClient as NTC
 import qualified Ouroboros.Consensus.Network.NodeToNode as NTN
@@ -183,7 +183,7 @@ data RunNodeArgs m addrNTN addrNTC blk (p2p :: Diffusion.P2P) = RunNodeArgs {
     , rnPeerSharing :: PeerSharing
 
       -- | An event handler to trigger custom action when ledger events are emitted.
-    , rnHandleLedgerEvent :: AuxLedgerEvent (ExtLedgerState blk) -> m ()
+    , rnHandleLedgerEvent :: LedgerEventHandler m (ExtLedgerState blk)
     }
 
 -- | Arguments that usually only tests /directly/ specify.
@@ -576,7 +576,7 @@ stdWithCheckedDB pb databasePath networkMagic body = do
 
 openChainDB
   :: forall m blk. (RunNode blk, IOLike m)
-  => (AuxLedgerEvent (ExtLedgerState blk) -> m ())
+  => LedgerEventHandler m (ExtLedgerState blk)
   -> ResourceRegistry m
   -> CheckInFuture m blk
   -> TopLevelConfig blk

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Basics.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Basics.hs
@@ -171,13 +171,14 @@ applyChainTick = lrResult ..: applyChainTickLedgerResult
 
 
 -- | Handler for ledger events
-newtype LedgerEventHandler m l = LedgerEventHandler { handleLedgerEvent :: AuxLedgerEvent l -> m () }
+newtype LedgerEventHandler m l =
+  LedgerEventHandler { handleLedgerEvent :: HeaderHash l -> SlotNo -> AuxLedgerEvent l -> m () }
 
 natHandler :: (m () -> n ()) -> LedgerEventHandler m l -> LedgerEventHandler n l
-natHandler nat LedgerEventHandler{handleLedgerEvent} = LedgerEventHandler (nat . handleLedgerEvent)
+natHandler nat LedgerEventHandler{handleLedgerEvent} = LedgerEventHandler (\ h s -> nat . handleLedgerEvent h s)
 
 discardEvent :: Applicative m => LedgerEventHandler m l
-discardEvent = LedgerEventHandler { handleLedgerEvent = const $ pure () }
+discardEvent = LedgerEventHandler { handleLedgerEvent = \ _ _ _ -> pure () }
 
 {-------------------------------------------------------------------------------
   Link block to its ledger

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Basics.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Basics.hs
@@ -172,13 +172,13 @@ applyChainTick = lrResult ..: applyChainTickLedgerResult
 
 -- | Handler for ledger events
 newtype LedgerEventHandler m l =
-  LedgerEventHandler { handleLedgerEvent :: HeaderHash l -> SlotNo -> AuxLedgerEvent l -> m () }
+  LedgerEventHandler { handleLedgerEvent :: ChainHash l -> HeaderHash l -> SlotNo -> AuxLedgerEvent l -> m () }
 
 natHandler :: (m () -> n ()) -> LedgerEventHandler m l -> LedgerEventHandler n l
-natHandler nat LedgerEventHandler{handleLedgerEvent} = LedgerEventHandler (\ h s -> nat . handleLedgerEvent h s)
+natHandler nat LedgerEventHandler{handleLedgerEvent} = LedgerEventHandler (\ph h s -> nat . handleLedgerEvent ph h s)
 
 discardEvent :: Applicative m => LedgerEventHandler m l
-discardEvent = LedgerEventHandler { handleLedgerEvent = \ _ _ _ -> pure () }
+discardEvent = LedgerEventHandler { handleLedgerEvent = \_ _ _ _ -> pure () }
 
 {-------------------------------------------------------------------------------
   Link block to its ledger

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
@@ -87,7 +87,7 @@ withDB
      , ConvertRawHash blk
      , SerialiseDiskConstraints blk
      )
-  => (AuxLedgerEvent (ExtLedgerState blk) -> m ())
+  => LedgerEventHandler m (ExtLedgerState blk)
   -> ChainDbArgs Identity m blk
   -> (ChainDB m blk -> m a)
   -> m a
@@ -102,7 +102,7 @@ openDB
      , ConvertRawHash blk
      , SerialiseDiskConstraints blk
      )
-  => (AuxLedgerEvent (ExtLedgerState blk) -> m ())
+  => LedgerEventHandler m (ExtLedgerState blk)
   -> ChainDbArgs Identity m blk
   -> m (ChainDB m blk)
 openDB handleLedgerEvent args =
@@ -117,7 +117,7 @@ openDBInternal
      , ConvertRawHash blk
      , SerialiseDiskConstraints blk
      )
-  => (AuxLedgerEvent (ExtLedgerState blk) -> m ())
+  => LedgerEventHandler m (ExtLedgerState blk)
   -> ChainDbArgs Identity m blk
   -> Bool -- ^ 'True' = Launch background tasks
   -> m (ChainDB m blk, Internal m blk)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
@@ -88,7 +88,7 @@ launchBgTasks
      , HasHardForkHistory blk
      , LgrDbSerialiseConstraints blk
      )
-  => (AuxLedgerEvent (ExtLedgerState blk) -> m ())
+  => LedgerEventHandler m (ExtLedgerState blk)
   -> ChainDbEnv m blk
   -> Word64 -- ^ Number of immutable blocks replayed on ledger DB startup
   -> m ()
@@ -528,7 +528,7 @@ addBlockRunner
      , HasHardForkHistory blk
      , HasCallStack
      )
-  => (AuxLedgerEvent (ExtLedgerState blk) -> m ())
+  => LedgerEventHandler m (ExtLedgerState blk)
   -> ChainDbEnv m blk
   -> m Void
 addBlockRunner handleLedgerEvent cdb@CDB{..} = forever $ do

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
@@ -54,6 +54,7 @@ import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.HardFork.Abstract
 import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.Inspect
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Protocol.Abstract
@@ -87,12 +88,13 @@ launchBgTasks
      , HasHardForkHistory blk
      , LgrDbSerialiseConstraints blk
      )
-  => ChainDbEnv m blk
+  => (AuxLedgerEvent (ExtLedgerState blk) -> m ())
+  -> ChainDbEnv m blk
   -> Word64 -- ^ Number of immutable blocks replayed on ledger DB startup
   -> m ()
-launchBgTasks cdb@CDB{..} replayed = do
+launchBgTasks handleLedgerEvent cdb@CDB{..} replayed = do
     !addBlockThread <- launch "ChainDB.addBlockRunner" $
-      addBlockRunner cdb
+      addBlockRunner handleLedgerEvent cdb
     gcSchedule <- newGcSchedule
     !gcThread <- launch "ChainDB.gcScheduleRunner" $
       gcScheduleRunner gcSchedule $ garbageCollect cdb
@@ -526,12 +528,13 @@ addBlockRunner
      , HasHardForkHistory blk
      , HasCallStack
      )
-  => ChainDbEnv m blk
+  => (AuxLedgerEvent (ExtLedgerState blk) -> m ())
+  -> ChainDbEnv m blk
   -> m Void
-addBlockRunner cdb@CDB{..} = forever $ do
+addBlockRunner handleLedgerEvent cdb@CDB{..} = forever $ do
     let trace = traceWith cdbTracer . TraceAddBlockEvent
     trace $ PoppedBlockFromQueue RisingEdge
     blkToAdd <- getBlockToAdd cdbBlocksToAdd
     trace $ PoppedBlockFromQueue $ FallingEdgeWith $
       blockRealPoint $ blockToAdd blkToAdd
-    addBlockSync cdb blkToAdd
+    addBlockSync handleLedgerEvent cdb blkToAdd

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
@@ -1060,7 +1060,7 @@ ledgerValidateCandidate
   -> ChainDiff (Header blk)
   -> m (ValidatedChainDiff (Header blk) (LedgerDB' blk))
 ledgerValidateCandidate chainSelEnv chainDiff@(ChainDiff rollback suffix) =
-    LgrDB.validate lgrDB curLedger blockCache rollback traceUpdate newBlocks >>= \case
+    LgrDB.validate lgrDB curLedger (const (pure ())) blockCache rollback traceUpdate newBlocks >>= \case
       LgrDB.ValidateExceededRollBack {} ->
         -- Impossible: we asked the LgrDB to roll back past the immutable tip,
         -- which is impossible, since the candidates we construct must connect

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
@@ -190,7 +190,7 @@ initialChainSelection immutableDB volatileDB lgrDB tracer cfg varInvalid
                     candidates) $
         assert (all (preferAnchoredCandidate bcfg curChain) candidates) $ do
           cse <- chainSelEnv
-          chainSelection (const $ pure ()) cse (Diff.extend <$> candidates)
+          chainSelection discardEvent cse (Diff.extend <$> candidates)
       where
         curChain = VF.validatedFragment curChainAndLedger
         ledger   = VF.validatedLedger   curChainAndLedger
@@ -261,7 +261,7 @@ addBlockSync
      , HasHardForkHistory blk
      , HasCallStack
      )
-  => (AuxLedgerEvent (ExtLedgerState blk) -> m ())
+  => LedgerEventHandler m (ExtLedgerState blk)
   -> ChainDbEnv m blk
   -> BlockToAdd m blk
   -> m ()
@@ -403,7 +403,7 @@ chainSelectionForFutureBlocks cdb@CDB{..} blockCache = do
       return $ Map.elems futureBlocks
     forM_ futureBlockHeaders $ \(hdr, punish) -> do
       traceWith tracer $ ChainSelectionForFutureBlock (headerRealPoint hdr)
-      chainSelectionForBlock (const $ pure ()) cdb blockCache hdr punish
+      chainSelectionForBlock discardEvent cdb blockCache hdr punish
     atomically $ Query.getTipPoint cdb
   where
     tracer = TraceAddBlockEvent >$< cdbTracer
@@ -448,7 +448,7 @@ chainSelectionForBlock
      , HasHardForkHistory blk
      , HasCallStack
      )
-  => (AuxLedgerEvent (ExtLedgerState blk) -> m ())
+  => LedgerEventHandler m (ExtLedgerState blk)
   -> ChainDbEnv m blk
   -> BlockCache blk
   -> Header blk
@@ -881,7 +881,7 @@ chainSelection
      , LedgerSupportsProtocol blk
      , HasCallStack
      )
-  => (AuxLedgerEvent (ExtLedgerState blk) -> m ())
+  => LedgerEventHandler m (ExtLedgerState blk)
   -> ChainSelEnv m blk
   -> NonEmpty (ChainDiff (Header blk))
   -> m (Maybe (ValidatedChainDiff (Header blk) (LedgerDB' blk)))
@@ -1061,7 +1061,7 @@ ledgerValidateCandidate
      , LedgerSupportsProtocol blk
      , HasCallStack
      )
-  => (AuxLedgerEvent (ExtLedgerState blk) -> m ())
+  => LedgerEventHandler m (ExtLedgerState blk)
   -> ChainSelEnv m blk
   -> ChainDiff (Header blk)
   -> m (ValidatedChainDiff (Header blk) (LedgerDB' blk))
@@ -1223,7 +1223,7 @@ validateCandidate
      , LedgerSupportsProtocol blk
      , HasCallStack
      )
-  => (AuxLedgerEvent (ExtLedgerState blk) -> m ())
+  => LedgerEventHandler m (ExtLedgerState blk)
   -> ChainSelEnv m blk
   -> ChainDiff (Header blk)
   -> m (ValidationResult blk)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/LgrDB.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/LgrDB.hs
@@ -327,16 +327,12 @@ data ValidateResult blk =
   | ValidateLedgerError      (LedgerDB.AnnLedgerError' blk)
   | ValidateExceededRollBack LedgerDB.ExceededRollback
 
-validate :: forall m blk.
-	    ( IOLike m
-	    , LedgerSupportsProtocol blk
-	    , HasCallStack
-	    )
+validate :: forall m blk. (IOLike m, LedgerSupportsProtocol blk, HasCallStack)
          => LgrDB m blk
          -> LedgerDB' blk
             -- ^ This is used as the starting point for validation, not the one
             -- in the 'LgrDB'.
-	 -> (AuxLedgerEvent (ExtLedgerState blk) -> m ())
+         -> (AuxLedgerEvent (ExtLedgerState blk) -> m ())
          -> BlockCache blk
          -> Word64  -- ^ How many blocks to roll back
          -> (LedgerDB.UpdateLedgerDbTraceEvent blk -> m ())
@@ -347,7 +343,7 @@ validate LgrDB{..} ledgerDB handleLedgerEvent blockCache numRollbacks trace = \h
     res <- fmap rewrap $ LedgerDB.defaultResolveWithErrors resolveBlock $
              LedgerDB.ledgerDbSwitch
                (LedgerDB.configLedgerDb cfg)
-	       (lift . lift . handleLedgerEvent)
+               (lift . lift . handleLedgerEvent)
                numRollbacks
                (lift . lift . trace)
                aps

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/LgrDB.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/LgrDB.hs
@@ -327,7 +327,11 @@ data ValidateResult blk =
   | ValidateLedgerError      (LedgerDB.AnnLedgerError' blk)
   | ValidateExceededRollBack LedgerDB.ExceededRollback
 
-validate :: forall m blk. (IOLike m, LedgerSupportsProtocol blk, HasCallStack)
+validate :: forall m blk.
+            ( IOLike m
+	    , LedgerSupportsProtocol blk
+	    , HasCallStack
+	    )
          => LgrDB m blk
          -> LedgerDB' blk
             -- ^ This is used as the starting point for validation, not the one

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/LgrDB.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/LgrDB.hs
@@ -327,16 +327,12 @@ data ValidateResult blk =
   | ValidateLedgerError      (LedgerDB.AnnLedgerError' blk)
   | ValidateExceededRollBack LedgerDB.ExceededRollback
 
-validate :: forall m blk.
-            ( IOLike m
-	    , LedgerSupportsProtocol blk
-	    , HasCallStack
-	    )
+validate :: forall m blk. (IOLike m, LedgerSupportsProtocol blk, HasCallStack)
          => LgrDB m blk
          -> LedgerDB' blk
             -- ^ This is used as the starting point for validation, not the one
             -- in the 'LgrDB'.
-         -> (AuxLedgerEvent (ExtLedgerState blk) -> m ())
+         -> LedgerEventHandler m (ExtLedgerState blk)
          -> BlockCache blk
          -> Word64  -- ^ How many blocks to roll back
          -> (LedgerDB.UpdateLedgerDbTraceEvent blk -> m ())
@@ -347,7 +343,7 @@ validate LgrDB{..} ledgerDB handleLedgerEvent blockCache numRollbacks trace = \h
     res <- fmap rewrap $ LedgerDB.defaultResolveWithErrors resolveBlock $
              LedgerDB.ledgerDbSwitch
                (LedgerDB.configLedgerDb cfg)
-               (lift . lift . handleLedgerEvent)
+               (natHandler lift $ natHandler lift $ handleLedgerEvent)
                numRollbacks
                (lift . lift . trace)
                aps

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Init.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Init.hs
@@ -208,7 +208,7 @@ initStartingWith tracer cfg streamAPI initDb = do
   where
     push :: blk -> (LedgerDB' blk, Word64) -> m (LedgerDB' blk, Word64)
     push blk !(!db, !replayed) = do
-        !db' <- ledgerDbPush cfg (ReapplyVal blk) db
+        !db' <- ledgerDbPush cfg (const $ pure ()) (ReapplyVal blk) db
 
         let replayed' :: Word64
             !replayed' = replayed + 1

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Init.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Init.hs
@@ -208,7 +208,7 @@ initStartingWith tracer cfg streamAPI initDb = do
   where
     push :: blk -> (LedgerDB' blk, Word64) -> m (LedgerDB' blk, Word64)
     push blk !(!db, !replayed) = do
-        !db' <- ledgerDbPush cfg (const $ pure ()) (ReapplyVal blk) db
+        !db' <- ledgerDbPush cfg discardEvent (ReapplyVal blk) db
 
         let replayed' :: Word64
             !replayed' = replayed + 1

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Update.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Update.hs
@@ -124,7 +124,7 @@ applyBlock cfg eventHandler@LedgerEventHandler{handleLedgerEvent} ap db = case a
     ApplyVal b -> do
       result <- either (throwLedgerError db (blockRealPoint b)) return $ runExcept $
         tickThenApplyLedgerResult cfg b l
-      mapM_ handleLedgerEvent (lrEvents result)
+      mapM_ (handleLedgerEvent (headerFieldHash $ getHeaderFields b) (headerFieldSlot $ getHeaderFields b)) (lrEvents result)
       return (lrResult result)
     ReapplyRef r  -> do
       b <- doResolveBlock r

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Update.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Update.hs
@@ -124,7 +124,11 @@ applyBlock cfg eventHandler@LedgerEventHandler{handleLedgerEvent} ap db = case a
     ApplyVal b -> do
       result <- either (throwLedgerError db (blockRealPoint b)) return $ runExcept $
         tickThenApplyLedgerResult cfg b l
-      mapM_ (handleLedgerEvent (headerFieldHash $ getHeaderFields b) (headerFieldSlot $ getHeaderFields b)) (lrEvents result)
+      forM_ (lrEvents result) $
+        handleLedgerEvent
+          (headerPrevHash b) -- TODO This line doesn't work with: "Reduction stack overflow; size = 201"
+          (headerFieldHash $ getHeaderFields b)
+          (headerFieldSlot $ getHeaderFields b)
       return (lrResult result)
     ReapplyRef r  -> do
       b <- doResolveBlock r

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/BlockFetch/Client.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/BlockFetch/Client.hs
@@ -34,6 +34,7 @@ import           Data.Traversable (for)
 import           Network.TypedProtocol.Codec (AnyMessageAndAgency (..))
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
+import           Ouroboros.Consensus.Ledger.Basics (discardEvent)
 import qualified Ouroboros.Consensus.MiniProtocol.BlockFetch.ClientInterface as BlockFetchClientInterface
 import           Ouroboros.Consensus.Node.ProtocolInfo (NumCoreNodes (..))
 import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
@@ -248,7 +249,7 @@ runBlockFetchTest BlockFetchClientTestSetup{..} = withRegistry \registry -> do
         (_, (chainDB, ChainDBImpl.Internal{intAddBlockRunner})) <-
           allocate
             registry
-            (\_ -> ChainDBImpl.openDBInternal chainDbArgs False)
+            (\_ -> ChainDBImpl.openDBInternal discardEvent chainDbArgs False)
             (ChainDB.closeDB . fst)
         _ <- forkLinkedThread registry "AddBlockRunner" intAddBlockRunner
 

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
@@ -193,7 +193,7 @@ initLgrDB k chain = do
     varDB          <- newTVarIO genesisLedgerDB
     varPrevApplied <- newTVarIO mempty
     let lgrDB = mkLgrDB varDB varPrevApplied resolve args
-    LgrDB.validate lgrDB genesisLedgerDB BlockCache.empty 0 noopTrace
+    LgrDB.validate lgrDB genesisLedgerDB (const $ pure ()) BlockCache.empty 0 noopTrace
       (map getHeader (Chain.toOldestFirst chain)) >>= \case
         LgrDB.ValidateExceededRollBack _ ->
           error "impossible: rollback was 0"

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
@@ -29,6 +29,7 @@ import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config
 import qualified Ouroboros.Consensus.HardFork.History as HardFork
 import           Ouroboros.Consensus.Ledger.Extended
+import           Ouroboros.Consensus.Ledger.Basics(discardEvent)
 import           Ouroboros.Consensus.Ledger.Query (Query (..))
 import           Ouroboros.Consensus.MiniProtocol.LocalStateQuery.Server
 import           Ouroboros.Consensus.Node.ProtocolInfo (NumCoreNodes (..))
@@ -193,7 +194,7 @@ initLgrDB k chain = do
     varDB          <- newTVarIO genesisLedgerDB
     varPrevApplied <- newTVarIO mempty
     let lgrDB = mkLgrDB varDB varPrevApplied resolve args
-    LgrDB.validate lgrDB genesisLedgerDB (const $ pure ()) BlockCache.empty 0 noopTrace
+    LgrDB.validate lgrDB genesisLedgerDB discardEvent BlockCache.empty 0 noopTrace
       (map getHeader (Chain.toOldestFirst chain)) >>= \case
         LgrDB.ValidateExceededRollBack _ ->
           error "impossible: rollback was 0"

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/FollowerPromptness.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/FollowerPromptness.hs
@@ -30,6 +30,7 @@ import qualified Data.Set as Set
 import           Data.Time.Clock (secondsToDiffTime)
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
+import           Ouroboros.Consensus.Ledger.Basics (discardEvent)
 import           Ouroboros.Consensus.Storage.ChainDB.API (ChainDB)
 import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
 import qualified Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment as Punishment
@@ -178,7 +179,7 @@ runFollowerPromptnessTest FollowerPromptnessTestSetup{..} = withRegistry \regist
         (_, (chainDB, ChainDBImpl.Internal{intAddBlockRunner})) <-
           allocate
             registry
-            (\_ -> ChainDBImpl.openDBInternal chainDbArgs False)
+            (\_ -> ChainDBImpl.openDBInternal discardEvent chainDbArgs False)
             (ChainDB.closeDB . fst)
         _ <- forkLinkedThread registry "AddBlockRunner" intAddBlockRunner
         pure chainDB

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -107,6 +107,7 @@ import qualified Ouroboros.Consensus.Fragment.InFuture as InFuture
 import           Ouroboros.Consensus.HardFork.Abstract
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.Basics
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.Inspect
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
@@ -365,7 +366,7 @@ open
   :: (IOLike m, TestConstraints blk)
   => ChainDbArgs Identity m blk -> m (ChainDBState m blk)
 open args = do
-    (chainDB, internal) <- openDBInternal args False
+    (chainDB, internal) <- openDBInternal discardEvent args False
     addBlockAsync       <- async (intAddBlockRunner internal)
     link addBlockAsync
     return ChainDBState { chainDB, internal, addBlockAsync }

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
@@ -62,6 +62,7 @@ import           GHC.Generics (Generic)
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.Basics
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Storage.LedgerDB
 import           Ouroboros.Consensus.Util
@@ -734,6 +735,7 @@ runDB standalone@DB{..} cmd =
             defaultThrowLedgerErrors $
               ledgerDbPush
                 dbLedgerDbCfg
+                discardEvent
                 (ApplyVal b)
                 db
     go _ (Switch n bs) = do
@@ -744,7 +746,7 @@ runDB standalone@DB{..} cmd =
             defaultResolveWithErrors dbResolve $
               ledgerDbSwitch
                 dbLedgerDbCfg
-                (const $ pure ())
+                discardEvent
                 n
                 (const $ pure ())
                 (map ApplyVal bs)

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
@@ -744,6 +744,7 @@ runDB standalone@DB{..} cmd =
             defaultResolveWithErrors dbResolve $
               ledgerDbSwitch
                 dbLedgerDbCfg
+                (const $ pure ())
                 n
                 (const $ pure ())
                 (map ApplyVal bs)


### PR DESCRIPTION
## Problem

The Cardano ledger rules are complex and aren't getting easier. This complexity stems from the rules themselves and the various patches that occurred during the development lifecycle (e.g. intra-era hard forks). Some of the information computed by the ledger is made readily available to client applications through the [local-state-query protocol](https://github.com/input-output-hk/ouroboros-network/blob/d2fdcd0ca03dacec156f49d8932e511625938e7b/ouroboros-network-protocols/src/Ouroboros/Network/Protocol/LocalStateQuery/Type.hs#L27-L33).

However, this comes with a few limitations:

1. The local-state query can only query information that the ledger has. Yet, the ledger can only rewind up to $\frac{3 \times k}{f}$ slots in the past. This pertains to the security of the consensus protocol and the need to roll back to some old state -- but not too old. Accessing historical data from the ledger is, therefore, not possible.

2. The information exposed via the `local-state-query` protocol is already aggregated in a way suitable for the ledger but not necessarily for client applications.

To cope with (1) and (2), the ledger eventually introduced [Ledger Events](https://github.com/input-output-hk/cardano-ledger/blob/065f467ab1827549af051a43cb0677cbe7b81d51/docs/LedgerEvents.md) into the small-steps semantic. For a couple of eras, the ledger emits them as it validates blocks. Events contain various kinds of **useful** information. However, at the moment, ledger events are only available to clients who have access to the entire ledger state in a fold-like Haskell API: [`foldBlocks`](https://github.com/input-output-hk/cardano-api/blob/7fe34eb80e3af2bc3ebcc7160bb178d0af874a43/cardano-api/internal/Cardano/Api/LedgerState.hs#L347-L359). This is, in particular, used by [`cardano-db-sync`](https://github.com/input-output-hk/cardano-db-sync).

Yet, this method is inconvenient for it requires client applications to hold a copy of the ledger state in memory and redo all calculations. This is rather inconvenient, even for Haskell applications, as it dramatically increases the resources needed by that application (as of today, the ledger-state(s) on mainnet requires 13-15GB of RAM!). Moreover, it is simply unusable outside of the Haskell landscape, for it is a Haskell-only interface.

## Solution

### Command-sourcing vs. Event-sourcing

From the point of view of software architecture, the Cardano ledger (and node) are designed as a _Command-sourced_ system: What's persisted is a sequence of _blocks_ which act as _commands_ whereby each block applied on _ledger state_ yields a new version of the ledger state. This works because the rules that govern application of blocks on ledger state are _deterministic_ thus guaranteeing application of the same sequence of blocks on the same starting point will yield the same final state on any system running nodes with the same version.

This is great but is has one drawback: In order to compute the state-transition function, fully or partially, one has to _know_ the exact set of rules to implement, eg. one has to run a ledger which is not a trivial thing to do as it requires a lot of resources (see above) and is not easily portable.

_Events_ on the other hand, do not require such knowledge because they are its results: There's nothing more to compute, they are the direct result of the consensus and do not need to be verified. They are therefore intrinsically easier to understand, more portable, can be interpreted partially in any way the client sees fit, etc.

The proposed change combines the benefits of both approaches **making Cardano even more flexible and open**.

### State of affairs

Since the ledger/node already calculates and emits those events -- since, by nature, it has access to the ledger state, our idea is to bubble up those events into a language-agnostic interface usable by local clients. We observed that events were currently discarded by the consensus layer, which remains the main driver of the block application. From the _Abstract_ API of the consensus, we see the following:

https://github.com/input-output-hk/ouroboros-consensus/blob/49c7f76175b431ba4e9d16aa959db234cc6772bd/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Basics.hs#L71-L75

https://github.com/input-output-hk/ouroboros-consensus/blob/49c7f76175b431ba4e9d16aa959db234cc6772bd/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Abstract.hs#L80-L89

`LedgerResult` contains both the new ledger state (`a`, instantiated later) and a list of all events resulting from this block application. However, those events are, in fact, discarded by the actual implementation of the abstract interface:

https://github.com/input-output-hk/ouroboros-consensus/blob/49c7f76175b431ba4e9d16aa959db234cc6772bd/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Update.hs#L114-L127

https://github.com/input-output-hk/ouroboros-consensus/blob/49c7f76175b431ba4e9d16aa959db234cc6772bd/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Abstract.hs#L160-L166

### Ledger events continuation

Using a continuation-passing style approach, we want to provide a handler which can be executed for each event. Using a continuation, we can easily turn off any event handling in situations where it does not matter or could even be harmful to performances (e.g. block producers). It also strikes the right balance between flexibility and intrusiveness as it only requires threading a simple function from the top-level of the call stack down to `applyBlock`.

So, we introduce the following continuation:

```hs
Monad m => AuxLedgerEvent l -> m ()
```

Where `m` is eventually `IO` and `AuxLedgerEvent l` a multi-era ledger event GADT from the `cardano-ledger`. From the consensus standpoint, this bubbles up to the `NodeArgs` record object into a new field:

```hs
rnHandleLedgerEvent :: AuxLedgerEvent (ExtLedgerState blk) -> m ()
```

The `NodeArgs` is ultimately created by the `cardano-node` wrapper, where the consensus, ledger, networking and plutus layers get stitched together.

### Cardano-node event hook

From there, it becomes straightforward to expose the ledger events in the cardano-node directly by hooking into [`handleNodeWithTracers`](https://github.com/CardanoSolutions/cardano-node/blob/a01ee644a8eb25ac027ca3a7b625ea9584fcd2f2/cardano-node/src/Cardano/Node/Run.hs#L209) and [`runNode`](https://github.com/CardanoSolutions/cardano-node/blob/a01ee644a8eb25ac027ca3a7b625ea9584fcd2f2/cardano-node/src/Cardano/Node/Run.hs#L176-L185).

At the moment, our proof of concept mounts a superficial server listening on a TCP socket and streaming all events back to a client application. All events are _indexed_ by the slot number and the header hash of the block which "produced" them. This index is necessary to allow clients to detect and deal with chain switches (a.k.a. rollbacks). With such an interface, filtering and aggregating events is thus the client's responsibility.

To make the event handler optional, we've integrated the handler up inside the cardano-node command line with a new optional flag, `--ledger-event-handler TCP/PORT`. When present, the option should point to a port that the cardano-node will bind to and stream events. If omitted, we fall back to the original behaviour of the node, which is to ignore all ledger events.

### Ledger event serialization

We have to settle on a transport format to write events to a socket/file and stream them to a client. Hence, we've opted for CBOR, which is already pervasive across the Cardano interfaces and suitable for networking serialization. We have, therefore, added CBOR encoders and decoders for most ledger events. This currently lives in [a fork of the cardano-node](https://github.com/CardanoSolutions/cardano-node/blob/a01ee644a8eb25ac027ca3a7b625ea9584fcd2f2/cardano-node/src/Cardano/Node/LedgerEvent.hs) with the intention to eventually live in the cardano-ledger itself.

> **Note** 
> 
> To ease the manipulation of the ledger events, we map them into a custom, era-independent, `LedgerEvent` data-type. However, we preserve the era during serialization since it is known from the `BlockType` GADTs coming with each block.
>
> https://github.com/CardanoSolutions/cardano-node/blob/a01ee644a8eb25ac027ca3a7b625ea9584fcd2f2/cardano-node/src/Cardano/Node/LedgerEvent.hs#L733-L742
>
> The codec `Version` is determined from the block's era and serialized with the event to allow clients to deserialize events accordingly.

We have documented the on-the-wire format of all the mapped events using a [CDDL specification](https://github.com/CardanoSolutions/cardano-node/blob/a01ee644a8eb25ac027ca3a7b625ea9584fcd2f2/cardano-node/ledger_events.cddl). We've added descriptions and details from the (outdated) LedgerEvents.md document from the cardano-ledger, as well as from our understanding from reading the ledger rules and asking questions around. We invite the ledger team to review that document.

## Use-cases

### Explorers: historical rewards

Many tax jurisdictions require Ada holders to keep track of their rewards. As we explained earlier, this currently limits the options in tooling to `cardano-db-sync`, which introduces a massive cost in resources on any machine. Most commercial laptops cannot afford to run both the cardano-node and cardano-db-sync due to their resource usage. For 3rd party services which provide such access, the cost of running this infrastructure is also significant. It also adds complexity and increases the probability of faults. There have been several reports of bugs and inaccuracy in the past due to the logic duplication occurring between the cardano-ledger and cardano-db-sync.

By streaming events directly from the node, we reduce complexity, resource usage, and the risk of 'getting it wrong'. The Cardano Foundation is particularly interested in this feature to power its new explorer and a number of similar use cases to help onboard financial institutions.

### Mithril: Stake distribution & more

The Mithril signature depends on the knowledge of the stake distribution, which is currently acquired through the `cardano-cli` relevant command. However, as a mithril-signer or aggregator needs access to a cardano-node anyway to know what data to sign, it would make sense for it to interact with the node in a more direct way, e.g using the mini-protocols. 

Being notified of the stake distribution changes immediately, ideally through a mini-protocol delivering those events, would streamline the integration between mithril and Cardano.

Moreover, while mithril-signers currently sign the full node DB only, providing other data "certified" by a Mithril certificate, like _Rewards_, is certainly planned.

## Long-term vision

With this first proof-of-concept, we've been able to stream events from the ledger to a file and re-compute the entire reward history of some stake credentials using only ledger events. This current proof-of-concept has a few limitations, which we acknowledge:

1. It only allows a single client connection.
2. It doesn't allow clients to resume synchronization from an arbitrary point. It continues where the ledger is at.
3. From (2) means that if the client loses the connection, it may miss events.

While it is sufficient to demonstrate the capabilities, we envision this becoming a more robust mini-protocol akin to the local-chain-sync protocol. Implementing such a protocol requires the node to store all ledger events and be able to rapidly search for them using chain points (block header hash + slot number). A chunk-based approach with indexes similar to the one used for the immutable and volatile db could work nicely.

This idea is similar to the one proposed in [CIP-0078](https://github.com/cardano-foundation/CIPs/pull/375), though we propose to make an entirely new protocol for the following reasons:

1. It's decoupled from the local-chain-sync protocol, meaning we don't need to make any existing interface more complex. The added complexity can be segregated out.
2. It's nicely complementary to the local-chain-sync. Indeed, the latter is akin to a command-based interface (pushing to clients the outcome of observing an event), whereas the local-event-sync (or whatever it is called) would offer an event-based interface to let clients decide how they intend to process those events.

> **Note**
>
> The long-term vision is something up for discussion. The current PR has yet to intend to introduce any of this. Currently, we are solely interested in the continuation described earlier.