### PR TITLE
Separate block tree analysis and abstract point schedule dispatch

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -558,6 +558,7 @@ test-suite infra-test
     , QuickCheck
     , random
     , si-timers
+    , strict-stm
     , tasty
     , tasty-quickcheck
     , time

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -530,6 +530,11 @@ test-suite infra-test
     Test.Ouroboros.Consensus.ChainGenerator.Tests.PointSchedule
     Test.Ouroboros.Consensus.ChainGenerator.Tests.Sync
     Test.Ouroboros.Consensus.PeerSimulator.BlockFetch
+    Test.Ouroboros.Consensus.PeerSimulator.Handlers
+    Test.Ouroboros.Consensus.PeerSimulator.Resources
+    Test.Ouroboros.Consensus.PeerSimulator.Run
+    Test.Ouroboros.Consensus.PeerSimulator.ScheduledChainSyncServer
+    Test.Ouroboros.Consensus.PeerSimulator.Trace
     Test.Util.ChainUpdates.Tests
     Test.Util.Schedule.Tests
     Test.Util.Split.Tests

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/GenesisTest.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/GenesisTest.hs
@@ -29,8 +29,6 @@ import           Test.Ouroboros.Consensus.ChainGenerator.Tests.BlockTree
 import           Test.Ouroboros.Consensus.ChainGenerator.Tests.GenChain
                      (genChains)
 import           Test.Ouroboros.Consensus.ChainGenerator.Tests.PointSchedule
-import           Test.Ouroboros.Consensus.PeerSimulator.Resources
-                     (makeChainSyncServerState)
 import           Test.Ouroboros.Consensus.PeerSimulator.Run
 import qualified Test.QuickCheck as QC
 import           Test.QuickCheck
@@ -108,11 +106,9 @@ runTest TestAdversarial{testAscH, testAscA} TestSetup{..} = do
     mapM_ (traceWith tracer) $ BT.prettyPrint blockTree
 
     let advPeer = PeerId "adversary"
-    g <- makeChainSyncServerState blockTree
-    b <- makeChainSyncServerState blockTree
-    let servers = Map.fromList [(HonestPeer, g), (advPeer, b)]
+    let peers = [HonestPeer, advPeer]
 
-    result <- runPointSchedule secParam testAscH schedule servers tracer
+    result <- runPointSchedule secParam testAscH schedule tracer blockTree peers
     trace <- unlines <$> getTrace
 
     pure

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/GenesisTest.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/GenesisTest.hs
@@ -29,6 +29,9 @@ import           Test.Ouroboros.Consensus.ChainGenerator.Tests.BlockTree
 import           Test.Ouroboros.Consensus.ChainGenerator.Tests.GenChain
                      (genChains)
 import           Test.Ouroboros.Consensus.ChainGenerator.Tests.PointSchedule
+import           Test.Ouroboros.Consensus.PeerSimulator.Resources
+                     (makeChainSyncServerState)
+import           Test.Ouroboros.Consensus.PeerSimulator.Run
 import qualified Test.QuickCheck as QC
 import           Test.QuickCheck
 import           Test.QuickCheck.Random (QCGen)
@@ -37,8 +40,6 @@ import           Test.Tasty.QuickCheck
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TestBlock hiding (blockTree)
 import           Test.Util.Tracer (recordingTracerTVar)
-import Test.Ouroboros.Consensus.PeerSimulator.Run
-import Test.Ouroboros.Consensus.PeerSimulator.Resources (makeChainSyncServerState)
 
 tests :: TestTree
 tests = testGroup "Genesis tests"

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/GenesisTest.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/GenesisTest.hs
@@ -29,7 +29,6 @@ import           Test.Ouroboros.Consensus.ChainGenerator.Tests.BlockTree
 import           Test.Ouroboros.Consensus.ChainGenerator.Tests.GenChain
                      (genChains)
 import           Test.Ouroboros.Consensus.ChainGenerator.Tests.PointSchedule
-import           Test.Ouroboros.Consensus.ChainGenerator.Tests.Sync
 import qualified Test.QuickCheck as QC
 import           Test.QuickCheck
 import           Test.QuickCheck.Random (QCGen)
@@ -38,6 +37,8 @@ import           Test.Tasty.QuickCheck
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TestBlock hiding (blockTree)
 import           Test.Util.Tracer (recordingTracerTVar)
+import Test.Ouroboros.Consensus.PeerSimulator.Run
+import Test.Ouroboros.Consensus.PeerSimulator.Resources (makeChainSyncServerState)
 
 tests :: TestTree
 tests = testGroup "Genesis tests"
@@ -106,8 +107,8 @@ runTest TestAdversarial{testAscH, testAscA} TestSetup{..} = do
     mapM_ (traceWith tracer) $ BT.prettyPrint blockTree
 
     let advPeer = PeerId "adversary"
-    g <- makeMockedChainSyncServer HonestPeer tracer blockTree
-    b <- makeMockedChainSyncServer advPeer tracer blockTree
+    g <- makeChainSyncServerState blockTree
+    b <- makeChainSyncServerState blockTree
     let servers = Map.fromList [(HonestPeer, g), (advPeer, b)]
 
     result <- runPointSchedule secParam testAscH schedule servers tracer

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/Sync.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/Sync.hs
@@ -105,7 +105,7 @@ import           Text.Printf (printf)
 -- typed-protocols peers
 newtype ConnectionThread m =
   ConnectionThread {
-    kill :: m (Either SomeException (ChainSyncClientResult, ()))
+    kill :: m (Either SomeException ChainSyncClientResult)
   }
 
 data TestResources m =
@@ -364,7 +364,7 @@ startChainSyncConnectionThread tracer activeSlotCoefficient chainDbView fetchCli
         throwIO exn
       Right res' -> pure res'
 
-  let kill = cancelPoll handle
+  let kill = fmap fst <$> cancelPoll handle
   modify' $ \ TestResources {..} -> TestResources {connectionThreads = ConnectionThread {..} : connectionThreads, ..}
   where
     protocolTracer = Tracer $ \case

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/Handlers.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/Handlers.hs
@@ -1,0 +1,98 @@
+module Test.Ouroboros.Consensus.PeerSimulator.Handlers (
+  handlerFindIntersection,
+  handlerRequestNext,
+) where
+
+import Control.Tracer (Tracer, traceWith)
+import Data.Coerce (coerce)
+import Data.Maybe (fromJust)
+import Ouroboros.Consensus.Block.Abstract (Header, Point (..), getHeader)
+import Ouroboros.Consensus.Util.Condense (Condense (..))
+import Ouroboros.Consensus.Util.IOLike (IOLike, StrictTVar, atomically, readTVarIO, writeTVar)
+import qualified Ouroboros.Network.AnchoredFragment as AF
+import Ouroboros.Network.Block (Tip (..), blockPoint, getTipPoint)
+import Test.Util.Orphans.IOLike ()
+import Test.Util.TestBlock (TestBlock)
+
+import qualified Test.Ouroboros.Consensus.ChainGenerator.Tests.BlockTree as BT
+import Test.Ouroboros.Consensus.ChainGenerator.Tests.BlockTree (BlockTree)
+import Test.Ouroboros.Consensus.ChainGenerator.Tests.PointSchedule (
+  AdvertisedPoints (header, tip),
+  HeaderPoint (HeaderPoint),
+  TipPoint (TipPoint),
+  )
+import Test.Ouroboros.Consensus.ChainGenerator.Tests.Sync (intersectWith)
+import Test.Ouroboros.Consensus.PeerSimulator.ScheduledChainSyncServer (FindIntersect (..), RequestNext (RollForward))
+
+handlerFindIntersection ::
+  IOLike m =>
+  StrictTVar m (Point TestBlock) ->
+  BlockTree TestBlock ->
+  AdvertisedPoints ->
+  [Point TestBlock] ->
+  m FindIntersect
+handlerFindIntersection currentIntersection blockTree points pts = do
+  let TipPoint tip' = tip points
+      tipPoint = Ouroboros.Network.Block.getTipPoint tip'
+      fragment = fromJust $ BT.findFragment tipPoint blockTree
+  case intersectWith fragment pts of
+    Nothing ->
+      pure $ IntersectNotFound tip'
+    Just intersection -> do
+      atomically $ writeTVar currentIntersection intersection
+      pure $ IntersectFound intersection tip'
+
+serveHeader ::
+  IOLike m =>
+  StrictTVar m (Point TestBlock) ->
+  BlockTree TestBlock ->
+  Tracer m String ->
+  AdvertisedPoints ->
+  m (Maybe (Header TestBlock, Tip TestBlock))
+serveHeader currentIntersection blockTree tracer points = do
+  intersection <- readTVarIO currentIntersection
+  trace $ "  last intersection is " ++ condense intersection
+  let HeaderPoint header' = header points
+      headerPoint = AF.castPoint $ blockPoint header'
+  case BT.findPath intersection headerPoint blockTree of
+    Nothing -> error "serveHeader: intersection and and headerPoint should always be in the block tree"
+    Just findPathResult ->
+      case findPathResult of
+        -- If the anchor is the intersection (the source of the path-finding)
+        -- but the fragment is empty, then the intersection is exactly our
+        -- header point and there is nothing to do.
+        (BT.PathAnchoredAtSource True, AF.Empty _) -> do
+          trace "  intersection is exactly our header point"
+          pure Nothing
+        -- If the anchor is the intersection and the fragment is non-empty, then
+        -- we have something to serve.
+        (BT.PathAnchoredAtSource True, fragmentAhead@(next AF.:< _)) -> do
+          trace "  intersection is before our header point"
+          trace $ "  fragment ahead: " ++ condense fragmentAhead
+          atomically $ writeTVar currentIntersection $ blockPoint next
+          pure $ Just (getHeader next, coerce (tip points))
+        -- If the anchor is not the intersection but the fragment is empty, then
+        -- the intersection is further than the tip that we can serve.
+        (BT.PathAnchoredAtSource False, AF.Empty _) -> do
+          trace "  intersection is further than our header point"
+          pure Nothing
+        -- If the anchor is not the intersection and the fragment is non-empty,
+        -- then we require a rollback
+        (BT.PathAnchoredAtSource False, fragment) -> do
+          trace $ "  we will require a rollback to" ++ condense (AF.anchorPoint fragment)
+          trace $ "  fragment: " ++ condense fragment
+          error "Rollback not supported in MockedChainSyncServer"
+  where
+    trace = traceWith tracer
+
+-- TODO this could all be STM if it weren't for tracing.
+-- Does it matter?
+handlerRequestNext ::
+  IOLike m =>
+  StrictTVar m (Point TestBlock) ->
+  BlockTree TestBlock ->
+  Tracer m String ->
+  AdvertisedPoints ->
+  m (Maybe RequestNext)
+handlerRequestNext currentIntersection blockTree tracer advertisedPoints =
+  fmap (uncurry RollForward) <$> serveHeader currentIntersection blockTree tracer advertisedPoints

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/Handlers.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/Handlers.hs
@@ -3,12 +3,15 @@ module Test.Ouroboros.Consensus.PeerSimulator.Handlers (
   , handlerRequestNext
   ) where
 
+import           Control.Monad.Trans (lift)
+import           Control.Monad.Writer.Strict (MonadWriter (tell),
+                     WriterT (runWriterT))
 import           Data.Coerce (coerce)
 import           Data.Maybe (fromJust)
-import           Ouroboros.Consensus.Block.Abstract (Point (..),
-                     getHeader)
+import           Ouroboros.Consensus.Block.Abstract (Point (..), getHeader)
 import           Ouroboros.Consensus.Util.Condense (Condense (..))
-import           Ouroboros.Consensus.Util.IOLike (IOLike, StrictTVar, writeTVar, STM, readTVar)
+import           Ouroboros.Consensus.Util.IOLike (IOLike, STM, StrictTVar,
+                     readTVar, writeTVar)
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block (blockPoint, getTipPoint)
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Tests.BlockTree as BT
@@ -20,11 +23,10 @@ import           Test.Ouroboros.Consensus.ChainGenerator.Tests.PointSchedule
 import           Test.Ouroboros.Consensus.ChainGenerator.Tests.Sync
                      (intersectWith)
 import           Test.Ouroboros.Consensus.PeerSimulator.ScheduledChainSyncServer
-                     (FindIntersect (..), RequestNext (RollForward, RollBackward))
+                     (FindIntersect (..),
+                     RequestNext (RollBackward, RollForward))
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TestBlock (TestBlock)
-import Control.Monad.Writer.Strict (WriterT (runWriterT), MonadWriter (tell))
-import Control.Monad.Trans (lift)
 
 handlerFindIntersection ::
   IOLike m =>

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/Handlers.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/Handlers.hs
@@ -1,28 +1,30 @@
 module Test.Ouroboros.Consensus.PeerSimulator.Handlers (
-  handlerFindIntersection,
-  handlerRequestNext,
-) where
+    handlerFindIntersection
+  , handlerRequestNext
+  ) where
 
-import Control.Tracer (Tracer, traceWith)
-import Data.Coerce (coerce)
-import Data.Maybe (fromJust)
-import Ouroboros.Consensus.Block.Abstract (Header, Point (..), getHeader)
-import Ouroboros.Consensus.Util.Condense (Condense (..))
-import Ouroboros.Consensus.Util.IOLike (IOLike, StrictTVar, atomically, readTVarIO, writeTVar)
+import           Control.Tracer (Tracer, traceWith)
+import           Data.Coerce (coerce)
+import           Data.Maybe (fromJust)
+import           Ouroboros.Consensus.Block.Abstract (Header, Point (..),
+                     getHeader)
+import           Ouroboros.Consensus.Util.Condense (Condense (..))
+import           Ouroboros.Consensus.Util.IOLike (IOLike, StrictTVar,
+                     atomically, readTVarIO, writeTVar)
 import qualified Ouroboros.Network.AnchoredFragment as AF
-import Ouroboros.Network.Block (Tip (..), blockPoint, getTipPoint)
-import Test.Util.Orphans.IOLike ()
-import Test.Util.TestBlock (TestBlock)
-
+import           Ouroboros.Network.Block (Tip (..), blockPoint, getTipPoint)
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Tests.BlockTree as BT
-import Test.Ouroboros.Consensus.ChainGenerator.Tests.BlockTree (BlockTree)
-import Test.Ouroboros.Consensus.ChainGenerator.Tests.PointSchedule (
-  AdvertisedPoints (header, tip),
-  HeaderPoint (HeaderPoint),
-  TipPoint (TipPoint),
-  )
-import Test.Ouroboros.Consensus.ChainGenerator.Tests.Sync (intersectWith)
-import Test.Ouroboros.Consensus.PeerSimulator.ScheduledChainSyncServer (FindIntersect (..), RequestNext (RollForward))
+import           Test.Ouroboros.Consensus.ChainGenerator.Tests.BlockTree
+                     (BlockTree)
+import           Test.Ouroboros.Consensus.ChainGenerator.Tests.PointSchedule
+                     (AdvertisedPoints (header, tip), HeaderPoint (HeaderPoint),
+                     TipPoint (TipPoint))
+import           Test.Ouroboros.Consensus.ChainGenerator.Tests.Sync
+                     (intersectWith)
+import           Test.Ouroboros.Consensus.PeerSimulator.ScheduledChainSyncServer
+                     (FindIntersect (..), RequestNext (RollForward))
+import           Test.Util.Orphans.IOLike ()
+import           Test.Util.TestBlock (TestBlock)
 
 handlerFindIntersection ::
   IOLike m =>

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/Handlers.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/Handlers.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE LambdaCase #-}
+
 -- | Business logic of the SyncChain protocol handlers that operates
 -- on the 'AdvertisedPoints' of a point schedule.
 --
@@ -14,10 +16,12 @@ import           Control.Monad.Writer.Strict (MonadWriter (tell),
                      WriterT (runWriterT))
 import           Data.Coerce (coerce)
 import           Data.Maybe (fromJust)
+import           Data.Monoid (First (..))
 import           Ouroboros.Consensus.Block.Abstract (Point (..), getHeader)
 import           Ouroboros.Consensus.Util.Condense (Condense (..))
 import           Ouroboros.Consensus.Util.IOLike (IOLike, STM, StrictTVar,
                      readTVar, writeTVar)
+import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block (blockPoint, getTipPoint)
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Tests.BlockTree as BT
@@ -26,14 +30,21 @@ import           Test.Ouroboros.Consensus.ChainGenerator.Tests.BlockTree
 import           Test.Ouroboros.Consensus.ChainGenerator.Tests.PointSchedule
                      (AdvertisedPoints (header, tip), HeaderPoint (HeaderPoint),
                      TipPoint (TipPoint))
-import           Test.Ouroboros.Consensus.ChainGenerator.Tests.Sync
-                     (intersectWith)
 import           Test.Ouroboros.Consensus.PeerSimulator.ScheduledChainSyncServer
                      (FindIntersect (..),
                      RequestNext (RollBackward, RollForward))
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TestBlock (TestBlock)
 
+-- | Find the first fragment contained in the first arg that starts at one of the given points.
+intersectWith :: AnchoredFragment TestBlock -> [Point TestBlock] -> Maybe (Point TestBlock)
+intersectWith fullFrag pts =
+  AF.anchorPoint . snd <$> getFirst (foldMap (First . AF.splitAfterPoint fullFrag) pts)
+
+-- | Handle a @MsgFindIntersect@ message.
+--
+-- Extracts the fragment up to the current advertised tip from the block tree,
+-- then searches for any of the client's points in it.
 handlerFindIntersection ::
   IOLike m =>
   StrictTVar m (Point TestBlock) ->
@@ -41,68 +52,71 @@ handlerFindIntersection ::
   AdvertisedPoints ->
   [Point TestBlock] ->
   STM m (FindIntersect, [String])
-handlerFindIntersection currentIntersection blockTree points pts = do
+handlerFindIntersection currentIntersection blockTree points clientPoints = do
   let TipPoint tip' = tip points
       tipPoint = Ouroboros.Network.Block.getTipPoint tip'
       fragment = fromJust $ BT.findFragment tipPoint blockTree
-  case intersectWith fragment pts of
+  case intersectWith fragment clientPoints of
     Nothing ->
       pure (IntersectNotFound tip', [])
     Just intersection -> do
       writeTVar currentIntersection intersection
       pure (IntersectFound intersection tip', [])
-
-serveHeader ::
-  IOLike m =>
-  StrictTVar m (Point TestBlock) ->
-  BlockTree TestBlock ->
-  AdvertisedPoints ->
-  WriterT [String] (STM m) (Maybe RequestNext)
-serveHeader currentIntersection blockTree points = do
-  intersection <- lift $ readTVar currentIntersection
-  trace $ "  last intersection is " ++ condense intersection
-  let HeaderPoint header' = header points
-      headerPoint = AF.castPoint $ blockPoint header'
-  case BT.findPath intersection headerPoint blockTree of
-    Nothing -> error "serveHeader: intersection and and headerPoint should always be in the block tree"
-    Just findPathResult ->
-      case findPathResult of
-        -- If the anchor is the intersection (the source of the path-finding)
-        -- but the fragment is empty, then the intersection is exactly our
-        -- header point and there is nothing to do.
-        (BT.PathAnchoredAtSource True, AF.Empty _) -> do
-          trace "  intersection is exactly our header point"
-          pure Nothing
-        -- If the anchor is the intersection and the fragment is non-empty, then
-        -- we have something to serve.
-        (BT.PathAnchoredAtSource True, fragmentAhead@(next AF.:< _)) -> do
-          trace "  intersection is before our header point"
-          trace $ "  fragment ahead: " ++ condense fragmentAhead
-          lift $ writeTVar currentIntersection $ blockPoint next
-          pure $ Just (RollForward (getHeader next) (coerce (tip points)))
-        -- If the anchor is not the intersection but the fragment is empty, then
-        -- the intersection is further than the tip that we can serve.
-        (BT.PathAnchoredAtSource False, AF.Empty _) -> do
-          trace "  intersection is further than our header point"
-          pure Nothing
-        -- If the anchor is not the intersection and the fragment is non-empty,
-        -- then we require a rollback
-        (BT.PathAnchoredAtSource False, fragment) -> do
-          trace $ "  we will require a rollback to" ++ condense (AF.anchorPoint fragment)
-          trace $ "  fragment: " ++ condense fragment
-          let
-            tip' = coerce (tip points)
-            point = AF.anchorPoint fragment
-          lift $ writeTVar currentIntersection point
-          pure $ Just (RollBackward point tip')
   where
-    trace = tell . pure
 
+-- | Handle a @MsgRequestNext@ message.
+--
+-- Finds the potential path from the current intersection to the advertised header point for this turn,
+-- which can have four distinct configurations for the anchor point and the path:
+--
+-- - Anchor == intersection == HP
+-- - HP after intersection == HP
+-- - HP before intersection (special case for the point scheduler architecture)
+-- - Anchor != intersection
 handlerRequestNext ::
   IOLike m =>
   StrictTVar m (Point TestBlock) ->
   BlockTree TestBlock ->
   AdvertisedPoints ->
   STM m (Maybe RequestNext, [String])
-handlerRequestNext currentIntersection blockTree advertisedPoints =
-  runWriterT (serveHeader currentIntersection blockTree advertisedPoints)
+handlerRequestNext currentIntersection blockTree points =
+  runWriterT $ do
+    intersection <- lift $ readTVar currentIntersection
+    trace $ "  last intersection is " ++ condense intersection
+    let HeaderPoint header' = header points
+        headerPoint = AF.castPoint $ blockPoint header'
+    maybe noPathError analysePath (BT.findPath intersection headerPoint blockTree)
+  where
+    noPathError = error "serveHeader: intersection and and headerPoint should always be in the block tree"
+
+    analysePath = \case
+      -- If the anchor is the intersection (the source of the path-finding)
+      -- but the fragment is empty, then the intersection is exactly our
+      -- header point and there is nothing to do.
+      (BT.PathAnchoredAtSource True, AF.Empty _) -> do
+        trace "  intersection is exactly our header point"
+        pure Nothing
+      -- If the anchor is the intersection and the fragment is non-empty, then
+      -- we have something to serve.
+      (BT.PathAnchoredAtSource True, fragmentAhead@(next AF.:< _)) -> do
+        trace "  intersection is before our header point"
+        trace $ "  fragment ahead: " ++ condense fragmentAhead
+        lift $ writeTVar currentIntersection $ blockPoint next
+        pure $ Just (RollForward (getHeader next) (coerce (tip points)))
+      -- If the anchor is not the intersection but the fragment is empty, then
+      -- the intersection is further than the tip that we can serve.
+      (BT.PathAnchoredAtSource False, AF.Empty _) -> do
+        trace "  intersection is further than our header point"
+        pure Nothing
+      -- If the anchor is not the intersection and the fragment is non-empty,
+      -- then we require a rollback
+      (BT.PathAnchoredAtSource False, fragment) -> do
+        trace $ "  we will require a rollback to" ++ condense (AF.anchorPoint fragment)
+        trace $ "  fragment: " ++ condense fragment
+        let
+          tip' = coerce (tip points)
+          point = AF.anchorPoint fragment
+        lift $ writeTVar currentIntersection point
+        pure $ Just (RollBackward point tip')
+
+    trace = tell . pure

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/Handlers.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/Handlers.hs
@@ -1,3 +1,9 @@
+-- | Business logic of the SyncChain protocol handlers that operates
+-- on the 'AdvertisedPoints' of a point schedule.
+--
+-- These are separated from the scheduling related mechanics of the
+-- ChainSync server mock that the peer simulator uses, in
+-- "Test.Ouroboros.Consensus.PeerSimulator.ScheduledChainSyncServer".
 module Test.Ouroboros.Consensus.PeerSimulator.Handlers (
     handlerFindIntersection
   , handlerRequestNext

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/Handlers.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/Handlers.hs
@@ -81,11 +81,11 @@ serveHeader currentIntersection blockTree tracer points = do
         (BT.PathAnchoredAtSource False, fragment) -> do
           trace $ "  we will require a rollback to" ++ condense (AF.anchorPoint fragment)
           trace $ "  fragment: " ++ condense fragment
-          error "Rollback not supported in MockedChainSyncServer"
+          error "Rollback not supported in PeerSimulator"
   where
     trace = traceWith tracer
 
--- TODO this could all be STM if it weren't for tracing.
+-- REVIEW: this could all be STM if it weren't for tracing.
 -- Does it matter?
 handlerRequestNext ::
   IOLike m =>

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/Resources.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/Resources.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module Test.Ouroboros.Consensus.PeerSimulator.Resources (
-  ChainSyncServerResources (..),
+  ChainSyncResources (..),
   ChainSyncServerState (..),
   makeChainSyncServerResources,
   makeChainSyncServerState,
@@ -48,16 +48,16 @@ data ChainSyncServerState m =
 
 -- | The data used by the point scheduler to interact with the mocked protocol handler in
 -- "Test.Ouroboros.Consensus.PeerSimulator.ScheduledChainSyncServer".
-data ChainSyncServerResources m =
-  ChainSyncServerResources {
+data ChainSyncResources m =
+  ChainSyncResources {
     -- | A queue of node states coming from the scheduler.
-    cssrQueue :: TQueue m NodeState,
+    csrQueue :: TQueue m NodeState,
 
     -- | REVIEW: Not sure why we need this.
-    cssrCandidateFragment :: StrictTVar m TestFragH,
+    csrCandidateFragment :: StrictTVar m TestFragH,
 
     -- | The final server passed to typed-protocols.
-    cssrServer :: ChainSyncServer (Header TestBlock) (Point TestBlock) (Tip TestBlock) m ()
+    csrServer :: ChainSyncServer (Header TestBlock) (Point TestBlock) (Tip TestBlock) m ()
   }
 
 makeChainSyncServerState ::
@@ -84,16 +84,16 @@ makeChainSyncServerResources ::
   Tracer m String ->
   PeerId ->
   ChainSyncServerState m ->
-  m (ChainSyncServerResources m)
+  m (ChainSyncResources m)
 makeChainSyncServerResources tracer peerId state = do
-  cssrQueue <- newTQueueIO
-  cssrCandidateFragment <- uncheckedNewTVarM $ AF.Empty AF.AnchorGenesis
+  csrQueue <- newTQueueIO
+  csrCandidateFragment <- uncheckedNewTVarM $ AF.Empty AF.AnchorGenesis
   let
-    wait = readTQueue cssrQueue <&> \case
+    wait = readTQueue csrQueue <&> \case
       NodeOffline -> Nothing
       NodeOnline tick -> Just tick
-  cssrServer <- runScheduledChainSyncServer wait serverTracer handlers
-  pure ChainSyncServerResources {..}
+  csrServer <- runScheduledChainSyncServer wait serverTracer handlers
+  pure ChainSyncResources {..}
   where
     handlers = makeChainSyncServerHandlers handlersTracer state
     handlersTracer = Tracer $ traceUnitWith tracer ("ChainSyncServerHandlers " ++ condense peerId)

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/Resources.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/Resources.hs
@@ -3,99 +3,163 @@
 
 module Test.Ouroboros.Consensus.PeerSimulator.Resources (
     ChainSyncResources (..)
-  , ChainSyncServerState (..)
+  , SharedResources (..)
+  , PeerResources (..)
+  , makePeerResources
+  , makePeersResources
   , makeChainSyncResources
-  , makeChainSyncServerState
   ) where
 
-import           Control.Concurrent.Class.MonadSTM.Strict (newEmptyTMVarIO,
-                     takeTMVar)
-import           Control.Tracer (Tracer)
-import           Ouroboros.Consensus.Block (WithOrigin (Origin))
-import           Ouroboros.Consensus.Block.Abstract (Header, Point (..))
-import           Ouroboros.Consensus.Util.Condense (Condense (..))
-import           Ouroboros.Consensus.Util.IOLike (IOLike, StrictTMVar,
-                     StrictTVar, readTVar, uncheckedNewTVarM, writeTVar)
+import Control.Concurrent.Class.MonadSTM.Strict (newEmptyTMVarIO, takeTMVar)
+import Control.Tracer (Tracer)
+import qualified Data.Map.Strict as Map
+import Data.Map.Strict (Map)
+import Data.Traversable (for)
+import Ouroboros.Consensus.Block (WithOrigin (Origin))
+import Ouroboros.Consensus.Block.Abstract (Header, Point (..))
+import Ouroboros.Consensus.Util.Condense (Condense (..))
+import Ouroboros.Consensus.Util.IOLike (
+  IOLike,
+  MonadSTM (STM),
+  StrictTMVar,
+  StrictTVar,
+  readTVar,
+  uncheckedNewTVarM,
+  writeTVar,
+  )
 import qualified Ouroboros.Network.AnchoredFragment as AF
-import           Ouroboros.Network.Block (Tip (..))
-import           Ouroboros.Network.Protocol.ChainSync.Server
-                     (ChainSyncServer (..))
-import           Test.Ouroboros.Consensus.ChainGenerator.Tests.BlockTree
-                     (BlockTree)
-import           Test.Ouroboros.Consensus.ChainGenerator.Tests.PointSchedule
-import           Test.Ouroboros.Consensus.PeerSimulator.Handlers
-import           Test.Ouroboros.Consensus.PeerSimulator.ScheduledChainSyncServer
-import           Test.Util.Orphans.IOLike ()
-import           Test.Util.TestBlock (TestBlock)
+import Ouroboros.Network.Block (Tip (..))
+import Ouroboros.Network.Protocol.ChainSync.Server (ChainSyncServer (..))
+import Test.Util.Orphans.IOLike ()
+import Test.Util.TestBlock (TestBlock)
 
--- | The data used by the handler implementation in "Test.Ouroboros.Consensus.PeerSimulator.Handlers".
-data ChainSyncServerState m =
-  ChainSyncServerState {
-    -- | The current known intersection with the chain of the client.
-    csssCurrentIntersection :: StrictTVar m (Point TestBlock),
+import Test.Ouroboros.Consensus.ChainGenerator.Tests.BlockTree (BlockTree)
+import Test.Ouroboros.Consensus.ChainGenerator.Tests.PointSchedule
+import Test.Ouroboros.Consensus.PeerSimulator.Handlers
+import Test.Ouroboros.Consensus.PeerSimulator.ScheduledChainSyncServer
+
+-- | Resources used by both ChainSync and BlockFetch for a single peer.
+data SharedResources m =
+  SharedResources {
+    -- | The name of the peer.
+    srPeerId :: PeerId,
 
     -- | The block tree in which the test is taking place. In combination to
     -- 'csssCurrentIntersection' and the current point schedule tick, it allows
     -- to define which blocks to serve to the client.
-    csssTree                :: BlockTree TestBlock
+    srBlockTree :: BlockTree TestBlock,
+
+    -- | The currently active schedule point.
+    srCurrentState :: StrictTVar m (Maybe AdvertisedPoints),
+
+    -- | The candidate fragment for a peer is shared by ChainSync, BlockFetch and the ChainDB.
+    srCandidateFragment :: StrictTVar m TestFragH,
+
+    srTracer :: Tracer m String
   }
 
 -- | The data used by the point scheduler to interact with the mocked protocol handler in
 -- "Test.Ouroboros.Consensus.PeerSimulator.ScheduledChainSyncServer".
 data ChainSyncResources m =
   ChainSyncResources {
-    -- | A mailbox of node states coming from the scheduler.
+    -- | A mailbox of node states that is updated by the scheduler in the peer's active tick,
+    -- waking up the chain sync server.
     csrNextState :: StrictTMVar m NodeState,
 
-    -- | The current schedule point that is updated by the scheduler in the peer's active tick,
-    -- waking up the chain sync server.
-    csrCurrentState :: StrictTVar m (Maybe AdvertisedPoints),
-
-    -- | REVIEW: Not sure why we need this.
-    csrCandidateFragment :: StrictTVar m TestFragH,
+    -- | The current known intersection with the chain of the client.
+    csrCurrentIntersection :: StrictTVar m (Point TestBlock),
 
     -- | The final server passed to typed-protocols.
     csrServer :: ChainSyncServer (Header TestBlock) (Point TestBlock) (Tip TestBlock) m ()
   }
 
-makeChainSyncServerState ::
-  IOLike m =>
-  BlockTree TestBlock ->
-  m (ChainSyncServerState m)
-makeChainSyncServerState csssTree = do
-  csssCurrentIntersection <- uncheckedNewTVarM $ AF.Point Origin
-  pure ChainSyncServerState {..}
+-- | The totality of resources used by a single peer in ChainSync and BlockFetch.
+data PeerResources m =
+  PeerResources {
+    -- | Resources used by ChainSync and BlockFetch.
+    prShared :: SharedResources m,
 
-makeChainSyncServerHandlers ::
-  IOLike m =>
-  ChainSyncServerState m ->
-  ChainSyncServerHandlers m AdvertisedPoints
-makeChainSyncServerHandlers ChainSyncServerState {..} =
-  ChainSyncServerHandlers {
-    csshFindIntersection = handlerFindIntersection csssCurrentIntersection csssTree,
-    csshRequestNext = handlerRequestNext csssCurrentIntersection csssTree
+    -- | Resources used by ChainSync only.
+    prChainSync :: ChainSyncResources m
   }
 
+-- | Create 'ChainSyncServerHandlers' for our default implementation using 'AdvertisedPoints'.
+makeChainSyncServerHandlers ::
+  IOLike m =>
+  StrictTVar m (Point TestBlock) ->
+  BlockTree TestBlock ->
+  ChainSyncServerHandlers m AdvertisedPoints
+makeChainSyncServerHandlers currentIntersection blockTree =
+  ChainSyncServerHandlers {
+    csshFindIntersection = handlerFindIntersection currentIntersection blockTree,
+    csshRequestNext = handlerRequestNext currentIntersection blockTree
+  }
+
+-- | Transaction that blocks until the next turn of the current peer, when the
+-- scheduler puts the new state into the TMVar, and updates the TVar that is
+-- read by all of the ChainSync and BlockFetch handlers.
+--
+-- The ChainSync protocol handler mock is agnostic of our state type,
+-- 'NodeState', so we convert it to 'Maybe'.
+waitForNextState ::
+  IOLike m =>
+  StrictTMVar m NodeState ->
+  StrictTVar m (Maybe AdvertisedPoints) ->
+  STM m (Maybe AdvertisedPoints)
+waitForNextState nextState currentState =
+  takeTMVar nextState >>= \ newState -> do
+    let
+      a = case newState of
+        NodeOffline     -> Nothing
+        NodeOnline tick -> Just tick
+    writeTVar currentState a
+    pure a
+
+-- | Create all the resources used exclusively by the ChainSync handlers, and
+-- the ChainSync protocol server that uses the handlers to interface with the
+-- typed-protocols engine.
 makeChainSyncResources ::
   IOLike m =>
-  Tracer m String ->
-  PeerId ->
-  ChainSyncServerState m ->
+  SharedResources m ->
   m (ChainSyncResources m)
-makeChainSyncResources tracer peerId state = do
+makeChainSyncResources SharedResources {..} = do
   csrNextState <- newEmptyTMVarIO
-  csrCandidateFragment <- uncheckedNewTVarM $ AF.Empty AF.AnchorGenesis
-  csrCurrentState <- uncheckedNewTVarM Nothing
+  csrCurrentIntersection <- uncheckedNewTVarM $ AF.Point Origin
   let
-    wait =
-      takeTMVar csrNextState >>= \ newState -> do
-        let
-          a = case newState of
-            NodeOffline     -> Nothing
-            NodeOnline tick -> Just tick
-        writeTVar csrCurrentState a
-        pure a
-    csrServer = runScheduledChainSyncServer (condense peerId) wait (readTVar csrCurrentState) tracer handlers
+    wait = waitForNextState csrNextState srCurrentState
+    handlers = makeChainSyncServerHandlers csrCurrentIntersection srBlockTree
+    csrServer = runScheduledChainSyncServer (condense srPeerId) wait (readTVar srCurrentState) srTracer handlers
   pure ChainSyncResources {..}
-  where
-    handlers = makeChainSyncServerHandlers state
+
+-- | Create all concurrency resources and the ChainSync protocol server used
+-- for a single peer.
+--
+-- A peer performs BlockFetch and ChainSync using a state of
+-- type 'AdvertisedPoints' that is updated by a separate scheduler, waking up
+-- the protocol handlers to process messages until the conditions of the new
+-- state are satisfied.
+makePeerResources ::
+  IOLike m =>
+  Tracer m String ->
+  BlockTree TestBlock ->
+  PeerId ->
+  m (PeerResources m)
+makePeerResources srTracer srBlockTree srPeerId = do
+  srCandidateFragment <- uncheckedNewTVarM $ AF.Empty AF.AnchorGenesis
+  srCurrentState <- uncheckedNewTVarM Nothing
+  let prShared = SharedResources {..}
+  prChainSync <- makeChainSyncResources prShared
+  pure PeerResources {..}
+
+-- | Create resources for all given peers operating on the given block tree.
+makePeersResources ::
+  IOLike m =>
+  Tracer m String ->
+  BlockTree TestBlock ->
+  [PeerId] ->
+  m (Map PeerId (PeerResources m))
+makePeersResources tracer blockTree peers = do
+  resources <- for peers $ \ peerId -> do
+    peerResources <- makePeerResources tracer blockTree peerId
+    pure (peerId, peerResources)
+  pure (Map.fromList resources)

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/Resources.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/Resources.hs
@@ -1,38 +1,33 @@
-{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE LambdaCase      #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module Test.Ouroboros.Consensus.PeerSimulator.Resources (
-  ChainSyncResources (..),
-  ChainSyncServerState (..),
-  makeChainSyncResources,
-  makeChainSyncServerState,
-) where
+    ChainSyncResources (..)
+  , ChainSyncServerState (..)
+  , makeChainSyncResources
+  , makeChainSyncServerState
+  ) where
 
-import Control.Tracer (Tracer (Tracer))
-import Data.Functor ((<&>))
-import Ouroboros.Consensus.Block (WithOrigin (Origin))
-import Ouroboros.Consensus.Block.Abstract (Header, Point (..))
-import Ouroboros.Consensus.Util.Condense (Condense (..))
-import Ouroboros.Consensus.Util.IOLike (
-  IOLike,
-  MonadSTM (TQueue, readTQueue),
-  StrictTVar,
-  TQueue,
-  newTQueueIO,
-  readTQueue,
-  uncheckedNewTVarM,
-  )
+import           Control.Tracer (Tracer (Tracer))
+import           Data.Functor ((<&>))
+import           Ouroboros.Consensus.Block (WithOrigin (Origin))
+import           Ouroboros.Consensus.Block.Abstract (Header, Point (..))
+import           Ouroboros.Consensus.Util.Condense (Condense (..))
+import           Ouroboros.Consensus.Util.IOLike (IOLike,
+                     MonadSTM (TQueue, readTQueue), StrictTVar, TQueue,
+                     newTQueueIO, readTQueue, uncheckedNewTVarM, writeTVar)
 import qualified Ouroboros.Network.AnchoredFragment as AF
-import Ouroboros.Network.Block (Tip (..))
-import Ouroboros.Network.Protocol.ChainSync.Server (ChainSyncServer (..))
-import Test.Util.Orphans.IOLike ()
-import Test.Util.TestBlock (TestBlock)
-
-import Test.Ouroboros.Consensus.ChainGenerator.Tests.BlockTree (BlockTree)
-import Test.Ouroboros.Consensus.ChainGenerator.Tests.PointSchedule
-import Test.Ouroboros.Consensus.PeerSimulator.Handlers
-import Test.Ouroboros.Consensus.PeerSimulator.ScheduledChainSyncServer
-import Test.Ouroboros.Consensus.PeerSimulator.Trace (traceUnitWith)
+import           Ouroboros.Network.Block (Tip (..))
+import           Ouroboros.Network.Protocol.ChainSync.Server
+                     (ChainSyncServer (..))
+import           Test.Ouroboros.Consensus.ChainGenerator.Tests.BlockTree
+                     (BlockTree)
+import           Test.Ouroboros.Consensus.ChainGenerator.Tests.PointSchedule
+import           Test.Ouroboros.Consensus.PeerSimulator.Handlers
+import           Test.Ouroboros.Consensus.PeerSimulator.ScheduledChainSyncServer
+import           Test.Ouroboros.Consensus.PeerSimulator.Trace (traceUnitWith)
+import           Test.Util.Orphans.IOLike ()
+import           Test.Util.TestBlock (TestBlock)
 
 -- | The data used by the handler implementation in "Test.Ouroboros.Consensus.PeerSimulator.Handlers".
 data ChainSyncServerState m =
@@ -43,7 +38,7 @@ data ChainSyncServerState m =
     -- | The block tree in which the test is taking place. In combination to
     -- 'csssCurrentIntersection' and the current point schedule tick, it allows
     -- to define which blocks to serve to the client.
-    csssTree :: BlockTree TestBlock
+    csssTree                :: BlockTree TestBlock
   }
 
 -- | The data used by the point scheduler to interact with the mocked protocol handler in

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/Resources.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/Resources.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE LambdaCase      #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE NamedFieldPuns  #-}
+{-# LANGUAGE RecordWildCards #-}
 
 -- | Data types and resource allocating constructors for the concurrency
 -- primitives used by ChainSync and BlockFetch in the handlers that implement

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/Resources.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/Resources.hs
@@ -8,18 +8,14 @@ module Test.Ouroboros.Consensus.PeerSimulator.Resources (
   , makeChainSyncServerState
   ) where
 
-import           Control.Concurrent.Class.MonadSTM
-                     (MonadSTM (TMVar, newTMVarIO))
 import           Control.Concurrent.Class.MonadSTM.Strict (newEmptyTMVarIO,
-                     readTMVar, takeTMVar)
-import           Control.Tracer (Tracer (Tracer))
+                     takeTMVar)
+import           Control.Tracer (Tracer)
 import           Ouroboros.Consensus.Block (WithOrigin (Origin))
 import           Ouroboros.Consensus.Block.Abstract (Header, Point (..))
 import           Ouroboros.Consensus.Util.Condense (Condense (..))
-import           Ouroboros.Consensus.Util.IOLike (IOLike,
-                     MonadSTM (TQueue, readTQueue), StrictTMVar, StrictTVar,
-                     TQueue, newTQueueIO, readTQueue, readTVar,
-                     uncheckedNewTVarM, writeTVar)
+import           Ouroboros.Consensus.Util.IOLike (IOLike, StrictTMVar,
+                     StrictTVar, readTVar, uncheckedNewTVarM, writeTVar)
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block (Tip (..))
 import           Ouroboros.Network.Protocol.ChainSync.Server
@@ -29,7 +25,6 @@ import           Test.Ouroboros.Consensus.ChainGenerator.Tests.BlockTree
 import           Test.Ouroboros.Consensus.ChainGenerator.Tests.PointSchedule
 import           Test.Ouroboros.Consensus.PeerSimulator.Handlers
 import           Test.Ouroboros.Consensus.PeerSimulator.ScheduledChainSyncServer
-import           Test.Ouroboros.Consensus.PeerSimulator.Trace (traceUnitWith)
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TestBlock (TestBlock)
 

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/Resources.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/Resources.hs
@@ -1,0 +1,96 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Test.Ouroboros.Consensus.PeerSimulator.Resources (
+  ChainSyncServerResources (..),
+  ChainSyncServerState (..),
+  makeChainSyncServerResources,
+  makeChainSyncServerState,
+) where
+
+import Control.Tracer (Tracer (Tracer))
+import Data.Functor ((<&>))
+import Ouroboros.Consensus.Block (WithOrigin (Origin))
+import Ouroboros.Consensus.Block.Abstract (Header, Point (..))
+import Ouroboros.Consensus.Util.Condense (Condense (..))
+import Ouroboros.Consensus.Util.IOLike (
+  IOLike,
+  MonadSTM (TQueue, readTQueue),
+  StrictTVar,
+  TQueue,
+  newTQueueIO,
+  readTQueue,
+  uncheckedNewTVarM,
+  )
+import qualified Ouroboros.Network.AnchoredFragment as AF
+import Ouroboros.Network.Block (Tip (..))
+import Ouroboros.Network.Protocol.ChainSync.Server (ChainSyncServer (..))
+import Test.Util.Orphans.IOLike ()
+import Test.Util.TestBlock (TestBlock)
+
+import Test.Ouroboros.Consensus.ChainGenerator.Tests.BlockTree (BlockTree)
+import Test.Ouroboros.Consensus.ChainGenerator.Tests.PointSchedule
+import Test.Ouroboros.Consensus.PeerSimulator.Handlers
+import Test.Ouroboros.Consensus.PeerSimulator.ScheduledChainSyncServer
+import Test.Ouroboros.Consensus.PeerSimulator.Trace (traceUnitWith)
+
+-- | The data used by the handler implementation in "Test.Ouroboros.Consensus.PeerSimulator.Handlers".
+data ChainSyncServerState m =
+  ChainSyncServerState {
+    csssCurrentIntersection :: StrictTVar m (Point TestBlock),
+    -- ^ The current known intersection with the chain of the client.
+    csssTree :: BlockTree TestBlock
+    -- ^ The block tree in which the test is taking place. In combination to
+    -- 'mcssCurrentState' and 'mcssCurrentIntersection', it allows to define
+    -- which blocks to serve to the client.
+  }
+
+-- | The data used by the point scheduler to interact with the mocked protocol handler in
+-- "Test.Ouroboros.Consensus.PeerSimulator.ScheduledChainSyncServer".
+data ChainSyncServerResources m =
+  ChainSyncServerResources {
+    cssrQueue :: TQueue m NodeState,
+    -- ^ A queue of node states coming from the scheduler.
+    cssrCandidateFragment :: StrictTVar m TestFragH,
+    -- ^ REVIEW: Not sure why we need this.
+    cssrServer :: ChainSyncServer (Header TestBlock) (Point TestBlock) (Tip TestBlock) m ()
+    -- ^ The final server passed to typed-protocols.
+  }
+
+makeChainSyncServerState ::
+  IOLike m =>
+  BlockTree TestBlock ->
+  m (ChainSyncServerState m)
+makeChainSyncServerState csssTree = do
+  csssCurrentIntersection <- uncheckedNewTVarM $ AF.Point Origin
+  pure ChainSyncServerState {..}
+
+makeChainSyncServerHandlers ::
+  IOLike m =>
+  Tracer m String ->
+  ChainSyncServerState m ->
+  ChainSyncServerHandlers m AdvertisedPoints
+makeChainSyncServerHandlers tracer ChainSyncServerState {..} =
+  ChainSyncServerHandlers {
+    csshFindIntersection = handlerFindIntersection csssCurrentIntersection csssTree,
+    csshRequestNext = handlerRequestNext csssCurrentIntersection csssTree tracer
+  }
+
+makeChainSyncServerResources ::
+  IOLike m =>
+  Tracer m String ->
+  PeerId ->
+  ChainSyncServerState m ->
+  m (ChainSyncServerResources m)
+makeChainSyncServerResources tracer peerId state = do
+  cssrQueue <- newTQueueIO
+  cssrCandidateFragment <- uncheckedNewTVarM $ AF.Empty AF.AnchorGenesis
+  let
+    wait = readTQueue cssrQueue <&> \case
+      NodeOffline -> Nothing
+      NodeOnline tick -> Just tick
+  cssrServer <- runScheduledChainSyncServer wait serverTracer handlers
+  pure ChainSyncServerResources {..}
+  where
+    handlers = makeChainSyncServerHandlers serverTracer state
+    serverTracer = Tracer $ traceUnitWith tracer ("MockedChainSyncServer " ++ condense peerId)

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/Resources.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/Resources.hs
@@ -4,7 +4,7 @@
 module Test.Ouroboros.Consensus.PeerSimulator.Resources (
   ChainSyncResources (..),
   ChainSyncServerState (..),
-  makeChainSyncServerResources,
+  makeChainSyncResources,
   makeChainSyncServerState,
 ) where
 
@@ -79,13 +79,13 @@ makeChainSyncServerHandlers tracer ChainSyncServerState {..} =
     csshRequestNext = handlerRequestNext csssCurrentIntersection csssTree tracer
   }
 
-makeChainSyncServerResources ::
+makeChainSyncResources ::
   IOLike m =>
   Tracer m String ->
   PeerId ->
   ChainSyncServerState m ->
   m (ChainSyncResources m)
-makeChainSyncServerResources tracer peerId state = do
+makeChainSyncResources tracer peerId state = do
   csrQueue <- newTQueueIO
   csrCandidateFragment <- uncheckedNewTVarM $ AF.Empty AF.AnchorGenesis
   let

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/Run.hs
@@ -33,9 +33,9 @@ import           Ouroboros.Consensus.Util.Condense (Condense (..))
 import           Ouroboros.Consensus.Util.IOLike
                      (Exception (fromException, toException), IOLike,
                      MonadAsync (Async, async, cancel, poll), MonadCatch (try),
-                     MonadDelay (threadDelay),
-                     MonadSTM (atomically, writeTQueue), MonadThrow (throwIO),
-                     SomeException, StrictTVar, readTVar, putTMVar, tryPutTMVar)
+                     MonadDelay (threadDelay), MonadSTM (atomically),
+                     MonadThrow (throwIO), SomeException, StrictTVar, readTVar,
+                     tryPutTMVar)
 import           Ouroboros.Consensus.Util.ResourceRegistry
 import           Ouroboros.Consensus.Util.STM (blockUntilChanged)
 import qualified Ouroboros.Network.AnchoredFragment as AF

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/Run.hs
@@ -1,0 +1,216 @@
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE RecordWildCards     #-}
+
+module Test.Ouroboros.Consensus.PeerSimulator.Run (
+  runPointSchedule,
+) where
+
+import Control.Monad.State.Strict (StateT, evalStateT, get, gets, lift, modify')
+import Control.Tracer (nullTracer, traceWith, Tracer)
+import Data.Foldable (for_, traverse_)
+import Data.Functor (void)
+import qualified Data.Map.Strict as Map
+import Data.Map.Strict (Map)
+import Network.TypedProtocol.Channel (createConnectedChannels)
+import Network.TypedProtocol.Driver.Simple (runConnectedPeersPipelined)
+import Ouroboros.Consensus.Block.Abstract (Point (..))
+import Ouroboros.Consensus.Config (SecurityParam, TopLevelConfig (..))
+import Ouroboros.Consensus.MiniProtocol.ChainSync.Client (
+  ChainDbView,
+  ChainSyncClientException,
+  Consensus,
+  chainSyncClient,
+  defaultChainDbView,
+  )
+import Ouroboros.Consensus.Storage.ChainDB.API
+import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
+import qualified Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment as InvalidBlockPunishment
+import qualified Ouroboros.Consensus.Storage.ChainDB.Impl as ChainDB.Impl
+import Ouroboros.Consensus.Storage.ChainDB.Impl (ChainDbArgs (cdbTracer))
+import Ouroboros.Consensus.Util.Condense (Condense (..))
+import Ouroboros.Consensus.Util.IOLike (
+  IOLike,
+  StrictTVar,
+  async,
+  atomically,
+  race,
+  readTVar,
+  threadDelay,
+  try,
+  waitCatch,
+  writeTQueue,
+  )
+import Ouroboros.Consensus.Util.ResourceRegistry
+import Ouroboros.Consensus.Util.STM (blockUntilChanged)
+import qualified Ouroboros.Network.AnchoredFragment as AF
+import Ouroboros.Network.Block (blockPoint)
+import Ouroboros.Network.ControlMessage (ControlMessage (..))
+import Ouroboros.Network.Protocol.ChainSync.ClientPipelined (ChainSyncClientPipelined, chainSyncClientPeerPipelined)
+import Ouroboros.Network.Protocol.ChainSync.Codec (codecChainSyncId)
+import Ouroboros.Network.Protocol.ChainSync.PipelineDecision (pipelineDecisionLowHighMark)
+import Ouroboros.Network.Protocol.ChainSync.Server (chainSyncServerPeer)
+import Test.Util.ChainDB
+import Test.Util.Orphans.IOLike ()
+import Test.Util.TestBlock (Header (..), TestBlock, testInitExtLedger)
+
+import Test.Ouroboros.Consensus.ChainGenerator.Tests.PointSchedule
+import Test.Ouroboros.Consensus.ChainGenerator.Tests.Sync (ConnectionThread (..), TestResources (..), defaultCfg)
+import Test.Ouroboros.Consensus.PeerSimulator.Resources
+import Test.Ouroboros.Consensus.PeerSimulator.Trace
+
+basicChainSyncClient ::
+  IOLike m =>
+  Tracer m String ->
+  TopLevelConfig TestBlock ->
+  ChainDbView m TestBlock ->
+  StrictTVar m TestFragH ->
+  Consensus ChainSyncClientPipelined TestBlock m
+basicChainSyncClient tracer cfg chainDbView varCandidate =
+  chainSyncClient
+    (pipelineDecisionLowHighMark 10 20)
+    (mkChainSyncClientTracer tracer)
+    cfg
+    chainDbView
+    maxBound
+    (return Continue)
+    nullTracer
+    varCandidate
+
+startChainSyncConnectionThread ::
+  IOLike m =>
+  Tracer m String ->
+  ChainDbView m TestBlock ->
+  ChainSyncServerResources m ->
+  StateT (TestResources m) m ()
+startChainSyncConnectionThread tracer chainDbView ChainSyncServerResources {cssrCandidateFragment, cssrServer} = do
+  cfg <- gets topConfig
+  handle <- lift $ async $ do
+    runConnectedPeersPipelined
+      createConnectedChannels
+      nullTracer
+      codecChainSyncId
+      (chainSyncClientPeerPipelined (basicChainSyncClient tracer cfg chainDbView cssrCandidateFragment))
+      (chainSyncServerPeer cssrServer)
+  let wait = void (waitCatch handle)
+  modify' $ \ TestResources {..} -> TestResources {connectionThreads = ConnectionThread {..} : connectionThreads, ..}
+
+awaitAll ::
+  IOLike m =>
+  TestResources m ->
+  m ()
+awaitAll TestResources {..} =
+  void $
+  race (threadDelay 100) $
+  for_ connectionThreads wait
+
+dispatchTick ::
+  IOLike m =>
+  Tracer m String ->
+  Map PeerId (ChainSyncServerResources m) ->
+  Tick ->
+  m ()
+dispatchTick tracer peers Tick {active = Peer pid state} =
+  case peers Map.!? pid of
+    Just ChainSyncServerResources {cssrQueue} -> do
+      traceUnitWith tracer "Scheduler" $ "Writing state " ++ condense state
+      atomically $ writeTQueue cssrQueue state
+      traceUnitWith tracer "Scheduler" $ "Waiting for full resolution of " ++ condense pid ++ "'s tick..."
+      threadDelay 0.100
+      traceUnitWith tracer "Scheduler" $ condense pid ++ "'s tick is now done."
+    Nothing -> error "“The impossible happened,” as GHC would say."
+
+runScheduler ::
+  IOLike m =>
+  Tracer m String ->
+  Map PeerId (ChainSyncServerResources m) ->
+  StateT (TestResources m) m ()
+runScheduler tracer peers = do
+  TestResources {pointSchedule = PointSchedule ps _} <- get
+  lift $ do
+    traceWith tracer "Schedule is:"
+    for_ ps  $ \tick -> traceWith tracer $ "  " ++ condense tick
+    traceWith tracer "--------------------------------------------------------------------------------"
+    traceWith tracer "» Time says “Let there be”"
+    traceWith tracer "» every moment and instantly"
+    traceWith tracer "» there is space and the radiance"
+    traceWith tracer "» of each bright galaxy."
+    traceWith tracer "--------------------------------------------------------------------------------"
+    for_ ps (dispatchTick tracer peers)
+    traceWith tracer "--------------------------------------------------------------------------------"
+    traceWith tracer "» A Clock stopped -"
+    traceWith tracer "» Not the Mantel's -"
+    traceWith tracer "» Geneva's farthest skill"
+    traceWith tracer "» Can't put the puppet bowing"
+    traceWith tracer "» That just now dangled still -"
+
+runPointSchedule ::
+  IOLike m =>
+  SecurityParam ->
+  PointSchedule ->
+  Map PeerId (ChainSyncServerState m) ->
+  Tracer m String ->
+  m (Either ChainSyncClientException TestFragH)
+runPointSchedule k pointSchedule peers tracer =
+  withRegistry $ \registry -> do
+    stuffs <- Map.traverseWithKey (makeChainSyncServerResources tracer) peers
+    flip evalStateT TestResources {topConfig = defaultCfg k, connectionThreads = [], pointSchedule, registry} $ do
+      a <- setup stuffs
+      s <- get
+      runScheduler tracer stuffs
+      res <- lift (try (awaitAll s))
+      b <- lift $ atomically $ ChainDB.getCurrentChain a
+      pure (b <$ res)
+  where
+    setup stuffs = do
+      st <- get
+      lift $ traceWith tracer $ "Security param k = " ++ show k
+      chainDb <- lift $ mkChainDb tracer (cssrCandidateFragment <$> stuffs) (topConfig st) (registry st)
+      let chainDbView = defaultChainDbView chainDb
+      traverse_ (startChainSyncConnectionThread tracer chainDbView) stuffs
+      pure chainDb
+
+mkChainDb ::
+  IOLike m =>
+  Tracer m String ->
+  Map PeerId (StrictTVar m TestFragH) ->
+  TopLevelConfig TestBlock ->
+  ResourceRegistry m ->
+  m (ChainDB m TestBlock)
+mkChainDb tracer candidateVars nodeCfg registry = do
+    chainDbArgs <- do
+      mcdbNodeDBs <- emptyNodeDBs
+      pure $ (
+        fromMinimalChainDbArgs MinimalChainDbArgs {
+            mcdbTopLevelConfig = nodeCfg
+          , mcdbChunkInfo      = mkTestChunkInfo nodeCfg
+          , mcdbInitLedger     = testInitExtLedger
+          , mcdbRegistry       = registry
+          , mcdbNodeDBs
+          }
+        ) {
+            cdbTracer = mkCdbTracer tracer
+        }
+    (_, (chainDB, ChainDB.Impl.Internal{intAddBlockRunner})) <-
+      allocate
+        registry
+        (\_ -> ChainDB.Impl.openDBInternal chainDbArgs False)
+        (ChainDB.closeDB . fst)
+    _ <- forkLinkedThread registry "AddBlockRunner" intAddBlockRunner
+    void $ flip Map.traverseWithKey candidateVars $ \ pid varCandidate ->
+      forkLinkedThread registry (condense pid) $ monitorCandidate chainDB varCandidate
+    pure chainDB
+  where
+    monitorCandidate chainDB varCandidate =
+        go GenesisPoint
+      where
+        go candidateTip = do
+          ((frag, candidateTip'), isFetched) <- atomically $
+            (,)
+              <$> blockUntilChanged AF.headPoint candidateTip (readTVar varCandidate)
+              <*> ChainDB.getIsFetched chainDB
+          let blks =
+                  filter (not . isFetched . blockPoint)
+                $ testHeader <$> AF.toOldestFirst frag
+          for_ blks $ ChainDB.addBlock_ chainDB InvalidBlockPunishment.noPunishment
+          go candidateTip'

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/Run.hs
@@ -8,8 +8,6 @@ module Test.Ouroboros.Consensus.PeerSimulator.Run (runPointSchedule) where
 import           Control.Monad.Class.MonadAsync
                      (AsyncCancelled (AsyncCancelled))
 import           Control.Monad.Class.MonadTimer.SI (MonadTimer)
-import           Control.Monad.State.Strict (StateT, evalStateT, get, gets,
-                     lift, modify')
 import           Control.Tracer (Tracer (Tracer), nullTracer, traceWith)
 import           Data.Foldable (for_)
 import           Data.Functor (void)
@@ -18,14 +16,12 @@ import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (mapMaybe)
 import           Data.Traversable (for)
-import           Ouroboros.Consensus.Block.Abstract (Point (..))
 import           Ouroboros.Consensus.Config (SecurityParam, TopLevelConfig (..))
 import qualified Ouroboros.Consensus.HardFork.History.EraParams as HardFork
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client (ChainDbView,
                      Consensus, chainSyncClient, defaultChainDbView)
 import           Ouroboros.Consensus.Storage.ChainDB.API
 import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
-import qualified Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment as InvalidBlockPunishment
 import           Ouroboros.Consensus.Storage.ChainDB.Impl
                      (ChainDbArgs (cdbTracer))
 import qualified Ouroboros.Consensus.Storage.ChainDB.Impl as ChainDB.Impl
@@ -33,15 +29,13 @@ import           Ouroboros.Consensus.Util.Condense (Condense (..))
 import           Ouroboros.Consensus.Util.IOLike
                      (Exception (fromException, toException), IOLike,
                      MonadAsync (Async, async, cancel, poll), MonadCatch (try),
-                     MonadDelay (threadDelay), MonadSTM (atomically),
+                     MonadDelay (threadDelay), MonadSTM (atomically, retry),
                      MonadThrow (throwIO), SomeException, StrictTVar, readTVar,
                      tryPutTMVar)
 import           Ouroboros.Consensus.Util.ResourceRegistry
-import           Ouroboros.Consensus.Util.STM (blockUntilChanged)
-import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block (blockPoint)
 import           Ouroboros.Network.Channel (createConnectedChannels)
-import           Ouroboros.Network.ControlMessage (ControlMessage (..))
+import           Ouroboros.Network.ControlMessage (ControlMessage (..), ControlMessageSTM)
 import           Ouroboros.Network.Driver.Limits
 import           Ouroboros.Network.Driver.Limits.Extras
 import           Ouroboros.Network.Driver.Simple (Role (Client, Server))
@@ -54,13 +48,18 @@ import           Ouroboros.Network.Protocol.ChainSync.Server
                      (chainSyncServerPeer)
 import           Test.Ouroboros.Consensus.ChainGenerator.Params (Asc)
 import           Test.Ouroboros.Consensus.ChainGenerator.Tests.PointSchedule
-import           Test.Ouroboros.Consensus.ChainGenerator.Tests.Sync
-                     (ConnectionThread (..), TestResources (..), defaultCfg)
+import           Test.Ouroboros.Consensus.ChainGenerator.Tests.Sync (defaultCfg, ConnectionThread (..))
 import           Test.Ouroboros.Consensus.PeerSimulator.Resources
 import           Test.Ouroboros.Consensus.PeerSimulator.Trace
 import           Test.Util.ChainDB
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TestBlock (Header (..), TestBlock, testInitExtLedger)
+import Control.Monad.Class.MonadTime (MonadTime)
+import Ouroboros.Network.BlockFetch (FetchClientRegistry, newFetchClientRegistry, bracketSyncWithFetchClient)
+import qualified Test.Ouroboros.Consensus.PeerSimulator.BlockFetch as PeerSimulator.BlockFetch
+import qualified Test.Ouroboros.Consensus.ChainGenerator.Tests.PointSchedule as Tests.PointSchedule
+import qualified Test.Ouroboros.Consensus.ChainGenerator.Tests.BlockTree as BT
+import Test.Ouroboros.Consensus.ChainGenerator.Tests.BlockTree (BlockTree)
 
 basicChainSyncClient ::
   IOLike m =>
@@ -83,59 +82,82 @@ basicChainSyncClient tracer cfg chainDbView varCandidate =
 startChainSyncConnectionThread ::
   (IOLike m, MonadTimer m) =>
   Tracer m String ->
+  TopLevelConfig TestBlock ->
   Asc ->
   ChainDbView m TestBlock ->
-  PeerId ->
+  FetchClientRegistry PeerId (Header TestBlock) TestBlock m ->
+  SharedResources m ->
   ChainSyncResources m ->
-  StateT (TestResources m) m ()
-startChainSyncConnectionThread tracer activeSlotCoefficient chainDbView peerId ChainSyncResources {csrCandidateFragment, csrServer} = do
-  cfg <- gets topConfig
-  let slotLength = HardFork.eraSlotLength . topLevelConfigLedger $ cfg
-  let timeouts = chainSyncTimeouts slotLength activeSlotCoefficient
-  lift $ do
-    traceWith tracer $ "timeouts:"
-    traceWith tracer $ "  canAwait = " ++ show (canAwaitTimeout timeouts)
-    traceWith tracer $ "  intersect = " ++ show (intersectTimeout timeouts)
-    traceWith tracer $ "  mustReply = " ++ show (mustReplyTimeout timeouts)
-  handle <- lift $ async $ do
-    res <- try $ runConnectedPeersPipelinedWithLimits
-      createConnectedChannels
-      protocolTracer
-      codecChainSyncId
-      chainSyncNoSizeLimits
-      (timeLimitsChainSync timeouts)
-      (chainSyncClientPeerPipelined (basicChainSyncClient tracer cfg chainDbView csrCandidateFragment))
-      (chainSyncServerPeer csrServer)
-    case res of
-      Left exn -> do
-        case fromException exn of
-          Just (ExceededSizeLimit _) ->
-            traceUnitWith tracer ("ChainSyncClient " ++ condense peerId) "Terminating because of size limit exceeded."
-          Just (ExceededTimeLimit _) ->
-            traceUnitWith tracer ("ChainSyncClient " ++ condense peerId) "Terminating because of time limit exceeded."
-          Nothing ->
-            pure ()
-        throwIO exn
-      Right res' -> pure res'
+  m (ConnectionThread m)
+startChainSyncConnectionThread tracer cfg activeSlotCoefficient chainDbView fetchClientRegistry SharedResources {srPeerId, srCandidateFragment} ChainSyncResources {csrServer} = do
+  let
+    slotLength = HardFork.eraSlotLength . topLevelConfigLedger $ cfg
+    timeouts = chainSyncTimeouts slotLength activeSlotCoefficient
+  traceWith tracer $ "timeouts:"
+  traceWith tracer $ "  canAwait = " ++ show (canAwaitTimeout timeouts)
+  traceWith tracer $ "  intersect = " ++ show (intersectTimeout timeouts)
+  traceWith tracer $ "  mustReply = " ++ show (mustReplyTimeout timeouts)
+  handle <- async $ do
+    bracketSyncWithFetchClient fetchClientRegistry srPeerId $ do
+      res <- try $ runConnectedPeersPipelinedWithLimits
+        createConnectedChannels
+        protocolTracer
+        codecChainSyncId
+        chainSyncNoSizeLimits
+        (timeLimitsChainSync timeouts)
+        (chainSyncClientPeerPipelined (basicChainSyncClient tracer cfg chainDbView srCandidateFragment))
+        (chainSyncServerPeer csrServer)
+      case res of
+        Left exn -> do
+          case fromException exn of
+            Just (ExceededSizeLimit _) ->
+              traceUnitWith tracer ("ChainSyncClient " ++ condense srPeerId) "Terminating because of size limit exceeded."
+            Just (ExceededTimeLimit _) ->
+              traceUnitWith tracer ("ChainSyncClient " ++ condense srPeerId) "Terminating because of time limit exceeded."
+            Nothing ->
+              pure ()
+          throwIO exn
+        Right res' -> pure res'
 
-  let kill = cancelPoll handle
-  modify' $ \ TestResources {..} -> TestResources {connectionThreads = ConnectionThread {..} : connectionThreads, ..}
+  let kill = fmap fst <$> cancelPoll handle
+  pure (ConnectionThread kill)
   where
     protocolTracer = Tracer $ \case
       (clientOrServer, TraceSendMsg payload) ->
         traceUnitWith
           tracer
-          ("Protocol ChainSync " ++ condense peerId)
+          ("Protocol ChainSync " ++ condense srPeerId)
           (case clientOrServer of
              Client -> "Client -> Server"
              Server -> "Server -> Client"
            ++ ": " ++ show payload)
       _ -> pure ()
 
+startBlockFetchConnectionThread ::
+  (IOLike m, MonadTime m) =>
+  ResourceRegistry m ->
+  FetchClientRegistry PeerId (Header TestBlock) TestBlock m ->
+  ControlMessageSTM m ->
+  SharedResources m ->
+  m ()
+startBlockFetchConnectionThread registry fetchClientRegistry controlMsgSTM SharedResources {..} =
+  void $ forkLinkedThread registry ("BlockFetchClient" <> condense srPeerId) $
+    PeerSimulator.BlockFetch.runBlockFetchClient srPeerId fetchClientRegistry controlMsgSTM getCurrentChain
+  where
+    getCurrentChain = atomically $ do
+      nodeState <- readTVar srCurrentState
+      case nodeState of
+        Nothing -> retry
+        Just aps -> do
+          let Tests.PointSchedule.BlockPoint b = block aps
+          case BT.findFragment (blockPoint b) srBlockTree of
+            Just f  -> pure f
+            Nothing -> error "block tip is not in the block tree"
+
 -- | NOTE: io-sim provides 'cancel' which does not propagate already existing
 -- exceptions from the thread.
 cancelPoll :: MonadAsync m => Async m a -> m (Either SomeException a)
-cancelPoll a = do
+cancelPoll a =
   poll a >>= \case
     Just result ->
       -- Thread is already terminated (with either an exception or a value)
@@ -147,9 +169,9 @@ cancelPoll a = do
 
 killAll ::
   IOLike m =>
-  TestResources m ->
+  [ConnectionThread m] ->
   m (Maybe (NonEmpty SomeException))
-killAll TestResources {..} = do
+killAll connectionThreads = do
   results <- for connectionThreads kill
   pure $ nonEmpty $ flip mapMaybe results $ \case
     Left exn ->
@@ -161,12 +183,12 @@ killAll TestResources {..} = do
 dispatchTick ::
   IOLike m =>
   Tracer m String ->
-  Map PeerId (ChainSyncResources m) ->
+  Map PeerId (PeerResources m) ->
   Tick ->
   m ()
 dispatchTick tracer peers Tick {active = Peer pid state} =
   case peers Map.!? pid of
-    Just ChainSyncResources {csrNextState} -> do
+    Just PeerResources {prChainSync = ChainSyncResources {csrNextState}} -> do
       trace $ "Writing state " ++ condense state
       atomically (tryPutTMVar csrNextState state) >>= \case
         True -> trace $ "Waiting for full resolution of " ++ condense pid ++ "'s tick..."
@@ -180,53 +202,60 @@ dispatchTick tracer peers Tick {active = Peer pid state} =
 runScheduler ::
   IOLike m =>
   Tracer m String ->
-  Map PeerId (ChainSyncResources m) ->
-  StateT (TestResources m) m ()
-runScheduler tracer peers = do
-  TestResources {pointSchedule = PointSchedule ps _} <- get
-  lift $ do
-    traceWith tracer "Schedule is:"
-    for_ ps  $ \tick -> traceWith tracer $ "  " ++ condense tick
-    traceWith tracer "--------------------------------------------------------------------------------"
-    traceWith tracer "» Time says “Let there be”"
-    traceWith tracer "» every moment and instantly"
-    traceWith tracer "» there is space and the radiance"
-    traceWith tracer "» of each bright galaxy."
-    traceWith tracer "--------------------------------------------------------------------------------"
-    for_ ps (dispatchTick tracer peers)
-    traceWith tracer "--------------------------------------------------------------------------------"
-    traceWith tracer "» A Clock stopped -"
-    traceWith tracer "» Not the Mantel's -"
-    traceWith tracer "» Geneva's farthest skill"
-    traceWith tracer "» Can't put the puppet bowing"
-    traceWith tracer "» That just now dangled still -"
+  PointSchedule ->
+  Map PeerId (PeerResources m) ->
+  m ()
+runScheduler tracer (PointSchedule ps _) peers = do
+  traceWith tracer "Schedule is:"
+  for_ ps  $ \tick -> traceWith tracer $ "  " ++ condense tick
+  traceWith tracer "--------------------------------------------------------------------------------"
+  traceWith tracer "» Time says “Let there be”"
+  traceWith tracer "» every moment and instantly"
+  traceWith tracer "» there is space and the radiance"
+  traceWith tracer "» of each bright galaxy."
+  traceWith tracer "--------------------------------------------------------------------------------"
+  for_ ps (dispatchTick tracer peers)
+  traceWith tracer "--------------------------------------------------------------------------------"
+  traceWith tracer "» A Clock stopped -"
+  traceWith tracer "» Not the Mantel's -"
+  traceWith tracer "» Geneva's farthest skill"
+  traceWith tracer "» Can't put the puppet bowing"
+  traceWith tracer "» That just now dangled still -"
 
 runPointSchedule ::
-  (IOLike m, MonadTimer m) =>
+  (IOLike m, MonadTime m, MonadTimer m) =>
   SecurityParam ->
   Asc ->
   PointSchedule ->
-  Map PeerId (ChainSyncServerState m) ->
   Tracer m String ->
+  BlockTree TestBlock ->
+  [PeerId] ->
   m (Either (NonEmpty SomeException) TestFragH)
-runPointSchedule k asc pointSchedule peers tracer =
+runPointSchedule k asc pointSchedule tracer blockTree peers =
   withRegistry $ \registry -> do
-    resources <- Map.traverseWithKey (makeChainSyncResources tracer) peers
-    flip evalStateT TestResources {topConfig = defaultCfg k, connectionThreads = [], pointSchedule, registry} $ do
-      a <- setup resources
-      s <- get
-      runScheduler tracer resources
-      res <- lift (killAll s)
-      b <- lift $ atomically $ ChainDB.getCurrentChain a
-      pure $ maybe (Right b) Left res
+    resources <- makePeersResources tracer blockTree peers
+    let candidates = srCandidateFragment . prShared <$> resources
+    traceWith tracer $ "Security param k = " ++ show k
+    chainDb <- mkChainDb tracer candidates config registry
+    fetchClientRegistry <- newFetchClientRegistry
+    let chainDbView = defaultChainDbView chainDb
+    chainSyncThreads <- for resources $ \PeerResources {..} -> do
+      thread <- startChainSyncConnectionThread tracer config asc chainDbView fetchClientRegistry prShared prChainSync
+      PeerSimulator.BlockFetch.startKeepAliveThread registry fetchClientRegistry (srPeerId prShared)
+      pure thread
+    for_ resources $ \PeerResources {..} ->
+      startBlockFetchConnectionThread registry fetchClientRegistry (pure Continue) prShared
+    -- The block fetch logic needs to be started after the block fetch clients
+    -- otherwise, an internal assertion fails because getCandidates yields more
+    -- peer fragments than registered clients.
+    let getCandidates = traverse readTVar candidates
+    PeerSimulator.BlockFetch.startBlockFetchLogic registry chainDb fetchClientRegistry getCandidates
+    runScheduler tracer pointSchedule resources
+    res <- killAll (Map.elems chainSyncThreads)
+    b <- atomically $ ChainDB.getCurrentChain chainDb
+    pure $ maybe (Right b) Left res
   where
-    setup resources = do
-      st <- get
-      lift $ traceWith tracer $ "Security param k = " ++ show k
-      chainDb <- lift $ mkChainDb tracer (csrCandidateFragment <$> resources) (topConfig st) (registry st)
-      let chainDbView = defaultChainDbView chainDb
-      void $ Map.traverseWithKey (startChainSyncConnectionThread tracer asc chainDbView) resources
-      pure chainDb
+    config = defaultCfg k
 
 mkChainDb ::
   IOLike m =>
@@ -235,7 +264,7 @@ mkChainDb ::
   TopLevelConfig TestBlock ->
   ResourceRegistry m ->
   m (ChainDB m TestBlock)
-mkChainDb tracer candidateVars nodeCfg registry = do
+mkChainDb tracer _candidateVars nodeCfg registry = do
     chainDbArgs <- do
       mcdbNodeDBs <- emptyNodeDBs
       pure $ (
@@ -255,20 +284,4 @@ mkChainDb tracer candidateVars nodeCfg registry = do
         (\_ -> ChainDB.Impl.openDBInternal chainDbArgs False)
         (ChainDB.closeDB . fst)
     _ <- forkLinkedThread registry "AddBlockRunner" intAddBlockRunner
-    void $ flip Map.traverseWithKey candidateVars $ \ pid varCandidate ->
-      forkLinkedThread registry (condense pid) $ monitorCandidate chainDB varCandidate
     pure chainDB
-  where
-    monitorCandidate chainDB varCandidate =
-        go GenesisPoint
-      where
-        go candidateTip = do
-          ((frag, candidateTip'), isFetched) <- atomically $
-            (,)
-              <$> blockUntilChanged AF.headPoint candidateTip (readTVar varCandidate)
-              <*> ChainDB.getIsFetched chainDB
-          let blks =
-                  filter (not . isFetched . blockPoint)
-                $ testHeader <$> AF.toOldestFirst frag
-          for_ blks $ ChainDB.addBlock_ chainDB InvalidBlockPunishment.noPunishment
-          go candidateTip'

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/Run.hs
@@ -113,12 +113,14 @@ dispatchTick ::
 dispatchTick tracer peers Tick {active = Peer pid state} =
   case peers Map.!? pid of
     Just ChainSyncServerResources {cssrQueue} -> do
-      traceUnitWith tracer "Scheduler" $ "Writing state " ++ condense state
+      trace $ "Writing state " ++ condense state
       atomically $ writeTQueue cssrQueue state
-      traceUnitWith tracer "Scheduler" $ "Waiting for full resolution of " ++ condense pid ++ "'s tick..."
+      trace $ "Waiting for full resolution of " ++ condense pid ++ "'s tick..."
       threadDelay 0.100
-      traceUnitWith tracer "Scheduler" $ condense pid ++ "'s tick is now done."
+      trace $ condense pid ++ "'s tick is now done."
     Nothing -> error "“The impossible happened,” as GHC would say."
+  where
+    trace = traceUnitWith tracer "Scheduler"
 
 runScheduler ::
   IOLike m =>

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/ScheduledChainSyncServer.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/ScheduledChainSyncServer.hs
@@ -12,6 +12,7 @@ module Test.Ouroboros.Consensus.PeerSimulator.ScheduledChainSyncServer (
   ) where
 
 import           Control.Tracer (Tracer (Tracer), traceWith)
+import           Data.Foldable (traverse_)
 import           Data.Functor (void)
 import           Ouroboros.Consensus.Block.Abstract (Point (..))
 import           Ouroboros.Consensus.Util.Condense (Condense (..))
@@ -23,10 +24,8 @@ import           Ouroboros.Network.Protocol.ChainSync.Server
                      ServerStIdle (ServerStIdle, recvMsgDoneClient, recvMsgFindIntersect, recvMsgRequestNext),
                      ServerStIntersect (SendMsgIntersectFound, SendMsgIntersectNotFound),
                      ServerStNext (SendMsgRollBackward, SendMsgRollForward))
+import           Test.Ouroboros.Consensus.PeerSimulator.Trace (traceUnitWith)
 import           Test.Util.TestBlock (Header (..), TestBlock)
-import Data.Foldable (traverse_)
-
-import Test.Ouroboros.Consensus.PeerSimulator.Trace (traceUnitWith)
 
 data RequestNext =
   RollForward (Header TestBlock) (Tip TestBlock)

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/ScheduledChainSyncServer.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/ScheduledChainSyncServer.hs
@@ -1,0 +1,148 @@
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE RecordWildCards     #-}
+
+module Test.Ouroboros.Consensus.PeerSimulator.ScheduledChainSyncServer (
+  RequestNext (..),
+  FindIntersect (..),
+  ChainSyncServerHandlers (..),
+  ScheduledChainSyncServer (..),
+  scheduledChainSyncServer,
+  runScheduledChainSyncServer,
+) where
+
+import Control.Tracer (Tracer, traceWith)
+import Data.Functor (void)
+import Ouroboros.Consensus.Block.Abstract (Point (..))
+import Ouroboros.Consensus.Util.Condense (Condense (..))
+import Ouroboros.Consensus.Util.IOLike (
+  IOLike,
+  MonadSTM (STM),
+  StrictTVar,
+  atomically,
+  readTVarIO,
+  uncheckedNewTVarM,
+  writeTVar,
+  )
+import Ouroboros.Network.Block (Tip (..))
+import Ouroboros.Network.Protocol.ChainSync.Server (
+  ChainSyncServer (..),
+  ServerStIdle (ServerStIdle, recvMsgDoneClient, recvMsgFindIntersect, recvMsgRequestNext),
+  ServerStIntersect (SendMsgIntersectFound, SendMsgIntersectNotFound),
+  ServerStNext (SendMsgRollBackward, SendMsgRollForward),
+  )
+import Test.Util.TestBlock (Header (..), TestBlock)
+
+data RequestNext =
+  RollForward (Header TestBlock) (Tip TestBlock)
+  |
+  RollBackward (Point TestBlock) (Tip TestBlock)
+  deriving (Eq, Show)
+
+data FindIntersect =
+  IntersectFound (Point TestBlock) (Tip TestBlock)
+  |
+  IntersectNotFound (Tip TestBlock)
+  deriving (Eq, Show)
+
+data ChainSyncServerHandlers m a =
+  ChainSyncServerHandlers {
+    csshRequestNext :: a -> m (Maybe RequestNext),
+    csshFindIntersection :: a -> [Point TestBlock] -> m FindIntersect
+  }
+
+data ScheduledChainSyncServer m a =
+  ScheduledChainSyncServer {
+    scssCurrentState :: StrictTVar m (Maybe a),
+    scssAwaitNextState :: STM m (Maybe a),
+    scssHandlers :: ChainSyncServerHandlers m a,
+    scssTracer :: Tracer m String
+  }
+
+awaitNextState ::
+  IOLike m =>
+  ScheduledChainSyncServer m a ->
+  m a
+awaitNextState server@ScheduledChainSyncServer{..} = do
+  newState <- atomically $ do
+    newState <- scssAwaitNextState
+    writeTVar scssCurrentState newState
+    pure newState
+  case newState of
+    Nothing -> awaitNextState server
+    Just resource -> pure resource
+
+ensureCurrentState ::
+  IOLike m =>
+  ScheduledChainSyncServer m a ->
+  m a
+ensureCurrentState server@ScheduledChainSyncServer{..} =
+  readTVarIO scssCurrentState >>= \case
+    Nothing -> awaitNextState server
+    Just resource -> pure resource
+
+scheduledChainSyncServer ::
+  Condense a =>
+  IOLike m =>
+  ScheduledChainSyncServer m a ->
+  ChainSyncServer (Header TestBlock) (Point TestBlock) (Tip TestBlock) m ()
+scheduledChainSyncServer server@ScheduledChainSyncServer{scssHandlers = ChainSyncServerHandlers {..}, ..} =
+  go
+  where
+    go =
+      ChainSyncServer $ pure ServerStIdle {
+          recvMsgRequestNext
+        , recvMsgFindIntersect
+        , recvMsgDoneClient
+      }
+
+    recvMsgRequestNext = do
+      currentState <- ensureCurrentState server
+      trace "handling MsgRequestNext"
+      trace $ "  state is " ++ condense currentState
+      csshRequestNext currentState >>= \case
+        Just (RollForward header tip) -> do
+          trace $ "  gotta serve " ++ condense header
+          trace $ "  tip is      " ++ condense tip
+          trace "done handling MsgRequestNext"
+          pure $ Left $ SendMsgRollForward header tip go
+        Just (RollBackward point tip) -> do
+          trace "done handling MsgRequestNext"
+          pure $ Left $ (SendMsgRollBackward point tip) go
+        Nothing -> do
+          trace "  cannot serve at this point; waiting for node state and starting again"
+          void $ awaitNextState server
+          recvMsgRequestNext
+
+    recvMsgFindIntersect pts = do
+      currentState <- ensureCurrentState server
+      trace "handling MsgFindIntersect"
+      csshFindIntersection currentState pts >>= \case
+        IntersectNotFound tip -> do
+          trace "  no intersection found"
+          trace "done handling MsgFindIntersect"
+          pure $ SendMsgIntersectNotFound tip go
+        IntersectFound intersection tip -> do
+          trace $ "  intersection found: " ++ condense intersection
+          trace "done handling MsgFindIntersect"
+          pure $ SendMsgIntersectFound intersection tip go
+
+    recvMsgDoneClient = do
+      trace "received MsgDoneClient"
+      pure ()
+
+    trace = traceWith scssTracer
+
+runScheduledChainSyncServer ::
+  Condense a =>
+  IOLike m =>
+  STM m (Maybe a) ->
+  Tracer m String ->
+  ChainSyncServerHandlers m a ->
+  m (ChainSyncServer (Header TestBlock) (Point TestBlock) (Tip TestBlock) m ())
+runScheduledChainSyncServer scssAwaitNextState scssTracer handlers = do
+  scssCurrentState <- uncheckedNewTVarM Nothing
+  pure $ scheduledChainSyncServer ScheduledChainSyncServer {
+    scssHandlers = handlers,
+    ..
+  }

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/ScheduledChainSyncServer.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/ScheduledChainSyncServer.hs
@@ -1,37 +1,30 @@
-{-# LANGUAGE LambdaCase          #-}
-{-# LANGUAGE NamedFieldPuns      #-}
-{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE LambdaCase      #-}
+{-# LANGUAGE NamedFieldPuns  #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module Test.Ouroboros.Consensus.PeerSimulator.ScheduledChainSyncServer (
-  RequestNext (..),
-  FindIntersect (..),
-  ChainSyncServerHandlers (..),
-  ScheduledChainSyncServer (..),
-  scheduledChainSyncServer,
-  runScheduledChainSyncServer,
-) where
+    ChainSyncServerHandlers (..)
+  , FindIntersect (..)
+  , RequestNext (..)
+  , ScheduledChainSyncServer (..)
+  , runScheduledChainSyncServer
+  , scheduledChainSyncServer
+  ) where
 
-import Control.Tracer (Tracer, traceWith)
-import Data.Functor (void)
-import Ouroboros.Consensus.Block.Abstract (Point (..))
-import Ouroboros.Consensus.Util.Condense (Condense (..))
-import Ouroboros.Consensus.Util.IOLike (
-  IOLike,
-  MonadSTM (STM),
-  StrictTVar,
-  atomically,
-  readTVarIO,
-  uncheckedNewTVarM,
-  writeTVar,
-  )
-import Ouroboros.Network.Block (Tip (..))
-import Ouroboros.Network.Protocol.ChainSync.Server (
-  ChainSyncServer (..),
-  ServerStIdle (ServerStIdle, recvMsgDoneClient, recvMsgFindIntersect, recvMsgRequestNext),
-  ServerStIntersect (SendMsgIntersectFound, SendMsgIntersectNotFound),
-  ServerStNext (SendMsgRollBackward, SendMsgRollForward),
-  )
-import Test.Util.TestBlock (Header (..), TestBlock)
+import           Control.Tracer (Tracer, traceWith)
+import           Data.Functor (void)
+import           Ouroboros.Consensus.Block.Abstract (Point (..))
+import           Ouroboros.Consensus.Util.Condense (Condense (..))
+import           Ouroboros.Consensus.Util.IOLike (IOLike, MonadSTM (STM),
+                     StrictTVar, atomically, readTVarIO, uncheckedNewTVarM,
+                     writeTVar)
+import           Ouroboros.Network.Block (Tip (..))
+import           Ouroboros.Network.Protocol.ChainSync.Server
+                     (ChainSyncServer (..),
+                     ServerStIdle (ServerStIdle, recvMsgDoneClient, recvMsgFindIntersect, recvMsgRequestNext),
+                     ServerStIntersect (SendMsgIntersectFound, SendMsgIntersectNotFound),
+                     ServerStNext (SendMsgRollBackward, SendMsgRollForward))
+import           Test.Util.TestBlock (Header (..), TestBlock)
 
 data RequestNext =
   RollForward (Header TestBlock) (Tip TestBlock)
@@ -47,16 +40,16 @@ data FindIntersect =
 
 data ChainSyncServerHandlers m a =
   ChainSyncServerHandlers {
-    csshRequestNext :: a -> m (Maybe RequestNext),
+    csshRequestNext      :: a -> m (Maybe RequestNext),
     csshFindIntersection :: a -> [Point TestBlock] -> m FindIntersect
   }
 
 data ScheduledChainSyncServer m a =
   ScheduledChainSyncServer {
-    scssCurrentState :: StrictTVar m (Maybe a),
+    scssCurrentState   :: StrictTVar m (Maybe a),
     scssAwaitNextState :: STM m (Maybe a),
-    scssHandlers :: ChainSyncServerHandlers m a,
-    scssTracer :: Tracer m String
+    scssHandlers       :: ChainSyncServerHandlers m a,
+    scssTracer         :: Tracer m String
   }
 
 awaitNextState ::
@@ -69,7 +62,7 @@ awaitNextState server@ScheduledChainSyncServer{..} = do
     writeTVar scssCurrentState newState
     pure newState
   case newState of
-    Nothing -> awaitNextState server
+    Nothing       -> awaitNextState server
     Just resource -> pure resource
 
 ensureCurrentState ::

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/Trace.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/Trace.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE LambdaCase     #-}
 {-# LANGUAGE NamedFieldPuns #-}
 
+-- | Helpers for tracing used by the peer simulator.
 module Test.Ouroboros.Consensus.PeerSimulator.Trace (
     mkCdbTracer
   , mkChainSyncClientTracer

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/Trace.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/Trace.hs
@@ -1,0 +1,68 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Test.Ouroboros.Consensus.PeerSimulator.Trace (
+  traceUnitWith,
+  mkCdbTracer,
+  mkChainSyncClientTracer,
+) where
+
+import Control.Tracer (Tracer (Tracer), traceWith)
+import Data.Time.Clock (diffTimeToPicoseconds)
+import Ouroboros.Consensus.MiniProtocol.ChainSync.Client (TraceChainSyncClientEvent (..))
+import qualified Ouroboros.Consensus.Storage.ChainDB.Impl as ChainDB.Impl
+import Ouroboros.Consensus.Storage.ChainDB.Impl.Types (NewTipInfo (..), TraceAddBlockEvent (..))
+import Ouroboros.Consensus.Util.Condense (Condense (..))
+import Ouroboros.Consensus.Util.IOLike (IOLike, MonadMonotonicTime, Time (Time), getMonotonicTime)
+import Test.Util.TestBlock (TestBlock)
+import Text.Printf (printf)
+
+mkCdbTracer ::
+  IOLike m =>
+  Tracer m String ->
+  Tracer m (ChainDB.Impl.TraceEvent TestBlock)
+mkCdbTracer tracer =
+  Tracer $ \case
+    ChainDB.Impl.TraceAddBlockEvent event ->
+      case event of
+        AddedToCurrentChain _ NewTipInfo {newTipPoint} _ newFragment -> do
+          trace "Added to current chain"
+          trace $ "New tip: " ++ condense newTipPoint
+          trace $ "New fragment: " ++ condense newFragment
+        SwitchedToAFork _ NewTipInfo {newTipPoint} _ newFragment -> do
+          trace "Switched to a fork"
+          trace $ "New tip: " ++ condense newTipPoint
+          trace $ "New fragment: " ++ condense newFragment
+        _ -> pure ()
+    _ -> pure ()
+  where
+    trace = traceUnitWith tracer "ChainDB"
+
+mkChainSyncClientTracer ::
+  IOLike m =>
+  Tracer m String ->
+  Tracer m (TraceChainSyncClientEvent TestBlock)
+mkChainSyncClientTracer tracer =
+  Tracer $ \case
+    TraceRolledBack point ->
+      trace $ "Rolled back to: " ++ condense point
+    TraceFoundIntersection point _ourTip _theirTip ->
+      trace $ "Found intersection at: " ++ condense point
+    _ -> pure ()
+  where
+    trace = traceUnitWith tracer "ChainSyncClient"
+
+-- | Trace using the given tracer, printing the current time (typically the time
+-- of the simulation) and the unit name.
+traceUnitWith :: MonadMonotonicTime m => Tracer m String -> String -> String -> m ()
+traceUnitWith tracer unit msg = do
+  time <- getMonotonicTime
+  traceWith tracer $ printf "%s %s | %s" (showTime time) unit msg
+  where
+    showTime :: Time -> String
+    showTime (Time time) =
+      let ps = diffTimeToPicoseconds time
+          milliseconds = (ps `div` 1000000000) `mod` 1000
+          seconds = (ps `div` 1000000000000) `rem` 60
+          minutes = (ps `div` 1000000000000) `quot` 60
+       in printf "%02d:%02d.%03d" minutes seconds milliseconds

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/Trace.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/Trace.hs
@@ -1,21 +1,24 @@
-{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE LambdaCase     #-}
 {-# LANGUAGE NamedFieldPuns #-}
 
 module Test.Ouroboros.Consensus.PeerSimulator.Trace (
-  traceUnitWith,
-  mkCdbTracer,
-  mkChainSyncClientTracer,
-) where
+    mkCdbTracer
+  , mkChainSyncClientTracer
+  , traceUnitWith
+  ) where
 
-import Control.Tracer (Tracer (Tracer), traceWith)
-import Data.Time.Clock (diffTimeToPicoseconds)
-import Ouroboros.Consensus.MiniProtocol.ChainSync.Client (TraceChainSyncClientEvent (..))
+import           Control.Tracer (Tracer (Tracer), traceWith)
+import           Data.Time.Clock (diffTimeToPicoseconds)
+import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client
+                     (TraceChainSyncClientEvent (..))
 import qualified Ouroboros.Consensus.Storage.ChainDB.Impl as ChainDB.Impl
-import Ouroboros.Consensus.Storage.ChainDB.Impl.Types (NewTipInfo (..), TraceAddBlockEvent (..))
-import Ouroboros.Consensus.Util.Condense (Condense (..))
-import Ouroboros.Consensus.Util.IOLike (IOLike, MonadMonotonicTime, Time (Time), getMonotonicTime)
-import Test.Util.TestBlock (TestBlock)
-import Text.Printf (printf)
+import           Ouroboros.Consensus.Storage.ChainDB.Impl.Types
+                     (NewTipInfo (..), TraceAddBlockEvent (..))
+import           Ouroboros.Consensus.Util.Condense (Condense (..))
+import           Ouroboros.Consensus.Util.IOLike (IOLike, MonadMonotonicTime,
+                     Time (Time), getMonotonicTime)
+import           Test.Util.TestBlock (TestBlock)
+import           Text.Printf (printf)
 
 mkCdbTracer ::
   IOLike m =>


### PR DESCRIPTION
`PeerSimulator.ScheduledChainSyncServer` now only implements the boilerplate of fetching the next item from an STM action (a `TMVar`) and maintaining it as shared state between the handlers, in a `ChainSyncServer`.

`PeerSimulator.Handlers` contains the logic that determines the intersection and next header from the block tree.

`PeerSimulator.Run` contains only the scheduler, operating on the minimal set of resources.

`PeerSimulator.Resources` contains the data types and resource acquisition constructors.

Changed the `TQueue` to a `TMVar`.

-----------

We should wait for the other currently active PRs to be merged, then add those changes to this one, before merging it.
