### PR TITLE
Update to GHC 9.6.3

### DIFF
--- a/.github/workflows/cabal.project.local
+++ b/.github/workflows/cabal.project.local
@@ -3,7 +3,3 @@ package cardano-crypto-praos
 
 program-options
   ghc-options: -Werror
-
-if impl(ghc >= 9.6)
-  program-options
-    ghc-options: -Wno-error=redundant-constraints

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
        fail-fast: false
        matrix:
-         ghc: ["8.10.7", "9.2.8", "9.6.2"]
+         ghc: ["8.10.7", "9.2.8", "9.6.3"]
          cabal: ["3.10.1.0"]
          os: [ubuntu-latest]
     env:

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1695809408,
-        "narHash": "sha256-3RLFxpAhvZGPq+K0MrHOC46eFeXTfMevxWYHTCY8kpo=",
+        "lastModified": 1696553797,
+        "narHash": "sha256-DLtOawpMWt0L0LnandKtDJKSiCbSqhz2LTWofMw6sLw=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "1198d4af66ccbdf2d744bdd705f1a7af6be5effb",
+        "rev": "45f0742741418d6973f88cffd0f63733ecbff549",
         "type": "github"
       },
       "original": {
@@ -155,29 +155,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1692799911,
-        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
-      "inputs": {
-        "systems": "systems_2"
-      },
-      "locked": {
-        "lastModified": 1692799911,
-        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {
@@ -203,14 +185,51 @@
         "type": "github"
       }
     },
+    "ghc980": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1692910316,
+        "narHash": "sha256-Qv8I3GzzIIN32RTEKI38BW5nO1f7j6Xm+dDeDUyYZWo=",
+        "ref": "ghc-9.8",
+        "rev": "249aa8193e4c5c1ee46ce29b39d2fffa57de7904",
+        "revCount": 61566,
+        "submodules": true,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/ghc/ghc"
+      },
+      "original": {
+        "ref": "ghc-9.8",
+        "submodules": true,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/ghc/ghc"
+      }
+    },
+    "ghc99": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1695427505,
+        "narHash": "sha256-j0hXl6uEI+Uwf37z3WLuQZN4S0XqGtiepELv2Gl2aHU=",
+        "ref": "refs/heads/master",
+        "rev": "b8e4fe2318798185228fb5f8214ba2384ac95b4f",
+        "revCount": 61951,
+        "submodules": true,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/ghc/ghc"
+      },
+      "original": {
+        "submodules": true,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/ghc/ghc"
+      }
+    },
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1693786968,
-        "narHash": "sha256-QNQ2dM3iqNV1o+0kWiO5GbMZWNA+of8wCknNKnBBQPI=",
+        "lastModified": 1696897370,
+        "narHash": "sha256-650XzXDHx98os6VAjNvlDNmOv2FMXO6h2DkcZUd0qok=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "4e9caa4ef2cc7a17a8a31ff7a44bcbbc1a314842",
+        "rev": "cc114a9a1fadc3bd883476497b2ab09608735f79",
         "type": "github"
       },
       "original": {
@@ -227,14 +246,16 @@
         "cabal-36": "cabal-36",
         "cardano-shell": "cardano-shell",
         "flake-compat": "flake-compat_2",
-        "flake-utils": "flake-utils_2",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
+        "ghc980": "ghc980",
+        "ghc99": "ghc99",
         "hackage": [
           "hackageNix"
         ],
         "hls-1.10": "hls-1.10",
         "hls-2.0": "hls-2.0",
         "hls-2.2": "hls-2.2",
+        "hls-2.3": "hls-2.3",
         "hpc-coveralls": "hpc-coveralls",
         "hydra": "hydra",
         "iserv-proxy": "iserv-proxy",
@@ -253,11 +274,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1693795950,
-        "narHash": "sha256-tvTquqMdRQqBbefNO7f+198hq3VuVlY0rjiN5hmzGFw=",
+        "lastModified": 1696938432,
+        "narHash": "sha256-OmRJCHUhgPphfzBegfL6MF30A+ui5rloWSf6h2/PO5k=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "e166d754a739f5e41d389c537498ccdc6150be0b",
+        "rev": "f9ae9f1e8479d31f43eda55efc28b3a44495d63e",
         "type": "github"
       },
       "original": {
@@ -317,6 +338,23 @@
         "type": "github"
       }
     },
+    "hls-2.3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1695910642,
+        "narHash": "sha256-tR58doOs3DncFehHwCLczJgntyG/zlsSd7DgDgMPOkI=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "458ccdb55c9ea22cd5d13ec3051aaefb295321be",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.3.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "hpc-coveralls": {
       "flake": false,
       "locked": {
@@ -366,11 +404,11 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1693544019,
-        "narHash": "sha256-Ijce8Rw0NhaLQDYDYngGYBmUOrLtF6dKmMYj0/Fslkk=",
+        "lastModified": 1696471795,
+        "narHash": "sha256-aNNvjUtCGXaXSp5M/HSj1SOeLjqLyTRWYbIHqAEeUp0=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "4b342603a36edacc9610139db8d1b6f77cd272c7",
+        "rev": "91f16fa8acb58b312f94977715c630d8bf77e33e",
         "type": "github"
       },
       "original": {
@@ -382,11 +420,11 @@
     "iserv-proxy": {
       "flake": false,
       "locked": {
-        "lastModified": 1688517130,
-        "narHash": "sha256-hUqfxSlo+ffqVdkSZ1EDoB7/ILCL25eYkcCXW9/P3Wc=",
+        "lastModified": 1691634696,
+        "narHash": "sha256-MZH2NznKC/gbgBu8NgIibtSUZeJ00HTLJ0PlWKCBHb0=",
         "ref": "hkm/remote-iserv",
-        "rev": "9151db2a9a61d7f5fe52ff8836f18bbd0fd8933c",
-        "revCount": 13,
+        "rev": "43a979272d9addc29fbffc2e8542c5d96e993d73",
+        "revCount": 14,
         "type": "git",
         "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
       },
@@ -531,11 +569,11 @@
     },
     "nixpkgs-2305": {
       "locked": {
-        "lastModified": 1690680713,
-        "narHash": "sha256-NXCWA8N+GfSQyoN7ZNiOgq/nDJKOp5/BHEpiZP8sUZw=",
+        "lastModified": 1695416179,
+        "narHash": "sha256-610o1+pwbSu+QuF3GE0NU5xQdTHM3t9wyYhB9l94Cd8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b81af66deb21f73a70c67e5ea189568af53b1e8c",
+        "rev": "715d72e967ec1dd5ecc71290ee072bcaf5181ed6",
         "type": "github"
       },
       "original": {
@@ -563,11 +601,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1690720142,
-        "narHash": "sha256-GywuiZjBKfFkntQwpNQfL+Ksa2iGjPprBGL0/psgRZM=",
+        "lastModified": 1695318763,
+        "narHash": "sha256-FHVPDRP2AfvsxAdc+AsgFJevMz5VBmnZglFUMlxBkcY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3acb5c4264c490e7714d503c7166a3fde0c51324",
+        "rev": "e12483116b3b51a185a33a272bf351e357ba9a99",
         "type": "github"
       },
       "original": {
@@ -645,11 +683,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1693786159,
-        "narHash": "sha256-IzpBwbwD90CIdhOKfdzS98+o3AtoADNsSz5QBr281Gg=",
+        "lastModified": 1696896539,
+        "narHash": "sha256-dr7SiY6c+KndtOHaxWIT1t4XDM2Kx9LdDZzM1Uk4oFM=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "69d620fde80c1dfbe78b081db1b5725e9c0ce9e2",
+        "rev": "0ba46ba4a66fa51aa4699d52e07ab03c349f7303",
         "type": "github"
       },
       "original": {
@@ -659,21 +697,6 @@
       }
     },
     "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -17,18 +17,14 @@ let
     compiler-nix-name = "ghc928";
     flake.variants = {
       ghc810 = { compiler-nix-name = lib.mkForce "ghc8107"; };
-      ghc96 = { compiler-nix-name = lib.mkForce "ghc962"; };
+      ghc96 = { compiler-nix-name = lib.mkForce "ghc963"; };
     };
     inputMap = {
       "https://input-output-hk.github.io/cardano-haskell-packages" = inputs.CHaP;
     };
     modules = [
-      (forAllProjectPackages ({ config, lib, ... }: {
-        ghcOptions = [ "-Werror" ] ++
-          lib.optional
-            # waiting for a new 9.6.x release to fix https://gitlab.haskell.org/ghc/ghc/-/issues/23323
-            (lib.hasPrefix "ghc96" config.compiler.nix-name)
-            "-Wno-error=redundant-constraints";
+      (forAllProjectPackages ({ ... }: {
+        ghcOptions = [ "-Werror" ];
       }))
       {
         # Options related to tasty-golden:

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -21,7 +21,7 @@ hsPkgs.shellFor {
   # This is the place for tools that are required to be built with the same GHC
   # version as used in hsPkgs.
   tools = lib.mapAttrs (_: t: t // { index-state = pkgs.tool-index-state; }) {
-    haskell-language-server = { version = "2.2.0.0"; };
+    haskell-language-server = { version = "2.3.0.0"; };
   };
 
   shellHook = ''

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -1,7 +1,7 @@
 inputs: final: prev:
 
 let
-  tool-index-state = "2023-09-04T00:00:00Z";
+  tool-index-state = "2023-10-06T00:00:00Z";
   tool = name: version: other:
     final.haskell-nix.tool final.hsPkgs.args.compiler-nix-name name ({
       version = version;


### PR DESCRIPTION
This fixes the false positives with `-Wredundant-constraints` in earlier GHC 9.6.x releases that we had to work around.

Also update HLS to 2.3.0.0.
