### PR TITLE
Enable the generation of multiple adversarial chains for the peer simulator

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -294,6 +294,7 @@ library unstable-consensus-testlib
     Test.Ouroboros.Consensus.ChainGenerator.RaceIterator
     Test.Ouroboros.Consensus.ChainGenerator.Slot
     Test.Ouroboros.Consensus.ChainGenerator.Some
+    Test.QuickCheck.Extras
     Test.Util.BoolProps
     Test.Util.ChainDB
     Test.Util.ChainUpdates
@@ -525,6 +526,8 @@ test-suite infra-test
     Test.Ouroboros.Consensus.ChainGenerator.Tests.Counting
     Test.Ouroboros.Consensus.ChainGenerator.Tests.Honest
     Test.Ouroboros.Consensus.Genesis.Setup
+    Test.Ouroboros.Consensus.Genesis.Setup.Classifiers
+    Test.Ouroboros.Consensus.Genesis.Setup.GenChains
     Test.Ouroboros.Consensus.Genesis.Tests
     Test.Ouroboros.Consensus.Genesis.Tests.LongRangeAttack
     Test.Ouroboros.Consensus.PeerSimulator.BlockFetch

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Params.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Params.hs
@@ -9,9 +9,14 @@ module Test.Ouroboros.Consensus.ChainGenerator.Params (
   , ascFromBits
   , ascFromDouble
   , ascVal
+  , genAsc
+  , genKSD
   ) where
 
 import qualified Data.Bits as B
+import           Data.Word (Word8)
+import qualified Test.QuickCheck as QC
+import           Test.QuickCheck.Extras (sized1)
 
 -----
 
@@ -87,3 +92,13 @@ ascFromBits w = ascFromDouble $ toEnum (fromEnum w) / (2 ^ B.finiteBitSize w)
 -- | Interpret 'Asc' as a 'Double'
 ascVal :: Asc -> Double
 ascVal (Asc x) = x
+
+genAsc :: QC.Gen Asc
+genAsc = ascFromBits <$> QC.choose (1 :: Word8, maxBound - 1)
+
+genKSD :: QC.Gen (Kcp, Scg, Delta)
+genKSD = sized1 $ \sz -> do
+    d <- QC.choose (0, div sz 4)
+    k <- QC.choose (1, 2 * sz)
+    s <- (+ k) <$> QC.choose (0, 3 * sz)   -- ensures @k / s <= 1@
+    pure (Kcp k, Scg s, Delta d)

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/QuickCheck/Extras.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/QuickCheck/Extras.hs
@@ -1,0 +1,16 @@
+module Test.QuickCheck.Extras (
+    sized1
+  , unsafeMapSuchThatJust
+  ) where
+
+import qualified Test.QuickCheck as QC
+
+sized1 :: (Int -> QC.Gen a) -> QC.Gen a
+sized1 f = QC.sized (f . succ)
+
+-- | A generator that checks its own satisfaction
+--
+-- WARNING: 'QC.suchThat' et al often causes a /very/ confusing
+-- non-termination when its argument is impossible/extremely unlikely
+unsafeMapSuchThatJust :: QC.Gen (Maybe a) -> QC.Gen a
+unsafeMapSuchThatJust m = QC.suchThatMap m id

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/Genesis/Setup.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/Genesis/Setup.hs
@@ -1,128 +1,51 @@
 {-# LANGUAGE BlockArguments      #-}
 {-# LANGUAGE DerivingStrategies  #-}
-{-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE NamedFieldPuns #-}
 
 module Test.Ouroboros.Consensus.Genesis.Setup
   ( module Test.Ouroboros.Consensus.Genesis.Setup,
+    module Test.Ouroboros.Consensus.Genesis.Setup.GenChains
   )
 where
 
 import           Control.Monad.Class.MonadTime (MonadTime)
 import           Control.Monad.Class.MonadTimer.SI (MonadTimer)
 import           Control.Tracer (traceWith)
-import           Ouroboros.Consensus.Block.Abstract hiding (Header)
-import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Consensus.Util.IOLike
-import qualified Ouroboros.Network.AnchoredFragment as AF
-import           Test.Ouroboros.Consensus.ChainGenerator.Params
 import qualified Test.Ouroboros.Consensus.BlockTree as BT
 import           Test.Ouroboros.Consensus.PointSchedule
 import           Test.Ouroboros.Consensus.PeerSimulator.Run
 import           Test.QuickCheck
-import           Test.QuickCheck.Random (QCGen)
 import           Test.Util.Orphans.IOLike ()
-import           Test.Util.TestBlock hiding (blockTree)
 import           Test.Util.Tracer (recordingTracerTVar)
-import           Data.List (foldl')
-import qualified Data.Vector.Unboxed as Vector
-import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
-import qualified Test.Ouroboros.Consensus.ChainGenerator.Adversarial as A
-import           Test.Ouroboros.Consensus.ChainGenerator.Counting
-                     (Count (Count), getVector)
-import qualified Test.Ouroboros.Consensus.ChainGenerator.Honest as H
-import qualified Test.Ouroboros.Consensus.ChainGenerator.Slot as S
-import           Test.Ouroboros.Consensus.ChainGenerator.Slot (S)
-
--- | Generates a block tree randomly from an adversarial recipe. The block tree
--- contains one trunk (the “good chain”) and one branch (the “bad chain”). For
--- instance, one such tree could be graphically represented as:
---
---     slots:    1  2  3  4  5  6  7  8  9
---     good:  O─────1──2──3──4─────5──6──7
---     bad:            ╰─────3──4─────5
---
--- REVIEW: Generate more alternative chains?
-genChains ::
-  Asc ->
-  A.AdversarialRecipe base hon ->
-  A.SomeCheckedAdversarialRecipe base hon ->
-  QCGen ->
-  BT.BlockTree TestBlock
-genChains ascA A.AdversarialRecipe {A.arHonest, A.arPrefix = Count prefixCount} (A.SomeCheckedAdversarialRecipe _ recipeA') seed =
-  BT.addBranch' badChain $ BT.mkTrunk goodChain
-  where
-    goodChain = mkTestFragment goodBlocks
-
-    badChain = mkTestFragment (mkTestBlocks False prefix slotsA)
-
-    -- blocks in the common prefix in reversed order
-    prefix = drop (length goodBlocks - prefixCount) goodBlocks
-
-    slotsA = Vector.toList (getVector vA)
-
-    -- blocks for the good chain in reversed order
-    goodBlocks = mkTestBlocks True [] slotsH
-
-    slotsH = Vector.toList (getVector vH)
-
-    incSlot :: SlotNo -> TestBlock -> TestBlock
-    incSlot n b = b { tbSlot = tbSlot b + n }
-
-    mkTestFragment :: [TestBlock] -> AnchoredFragment TestBlock
-    mkTestFragment =
-      AF.fromNewestFirst AF.AnchorGenesis
-
-    mkTestBlocks :: Bool -> [TestBlock] -> [S] -> [TestBlock]
-    mkTestBlocks honest pre active =
-      fst (foldl' folder ([], 0) active)
-      where
-        folder (chain, inc) s | S.test S.notInverted s = (issue inc chain, 0)
-                              | otherwise = (chain, inc + 1)
-        issue inc (h : t) = incSlot inc (successorBlock h) : h : t
-        issue inc [] | [] <- pre = [ incSlot inc (firstBlock (if honest then 0 else 1)) ]
-                     | h : t <- pre = incSlot inc (forkBlock (successorBlock h)) : h : t
-
-    H.ChainSchema _ vH = arHonest
-    H.ChainSchema _ vA = A.uniformAdversarialChain (Just ascA) recipeA' seed
-
-newtype GenesisWindow = GenesisWindow { getGenesisWindow :: SlotNo }
-  deriving stock (Show)
-
-data TestSetup = TestSetup {
-    secParam                  :: SecurityParam
-  , genesisWindow             :: GenesisWindow
-  , honestAsc                 :: Asc
-  , schedule                  :: PointSchedule
-  , blockTree                 :: BT.BlockTree TestBlock
-  , genesisAcrossIntersection :: Bool
-  , genesisAfterIntersection  :: Bool
-  }
-  deriving stock (Show)
+import Test.Ouroboros.Consensus.Genesis.Setup.GenChains
 
 runTest ::
   (IOLike m, MonadTime m, MonadTimer m) =>
-  TestSetup ->
-  (TestFragH -> m Property) ->
+  GenesisTest ->
+  PointSchedule ->
+  (TestFragH -> Property) ->
   m Property
-runTest TestSetup{..} makeProperty = do
+runTest genesisTest@GenesisTest {gtBlockTree, gtHonestAsc} schedule makeProperty = do
     (tracer, getTrace) <- recordingTracerTVar
+    -- let tracer = debugTracer
 
-    traceWith tracer $ "Honest active slot coefficient: " ++ show honestAsc
+    traceWith tracer $ "Honest active slot coefficient: " ++ show gtHonestAsc
 
-    mapM_ (traceWith tracer) $ BT.prettyPrint blockTree
+    mapM_ (traceWith tracer) $ BT.prettyPrint gtBlockTree
 
-    result <- runPointSchedule secParam honestAsc schedule tracer blockTree
+    result <- runPointSchedule genesisTest schedule tracer
     trace <- unlines <$> getTrace
 
-    case result of
-      Left exn ->
-        pure $ counterexample ("exception: " <> show exn) False
-      Right fragment -> do
-        prop <- makeProperty fragment
-        pure
-          $ counterexample ("result: " <> condense fragment)
-          $ counterexample trace
-          $ prop
+    let
+      prop = case result of
+        Left exn ->
+          counterexample ("exception: " <> show exn) False
+        Right fragment ->
+          counterexample ("result: " <> condense fragment) (makeProperty fragment)
+
+    pure $ counterexample trace prop

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/Genesis/Setup/Classifiers.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/Genesis/Setup/Classifiers.hs
@@ -1,0 +1,78 @@
+{-# LANGUAGE NamedFieldPuns  #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Test.Ouroboros.Consensus.Genesis.Setup.Classifiers (
+    Classifiers (..)
+  , classifiers
+  ) where
+
+import           Ouroboros.Consensus.Block.Abstract (SlotNo (SlotNo),
+                     withOrigin)
+import           Ouroboros.Consensus.Config
+import           Ouroboros.Network.AnchoredFragment (anchor, anchorToSlotNo,
+                     headSlot)
+import qualified Ouroboros.Network.AnchoredFragment as AF
+import           Ouroboros.Network.AnchoredFragment.Extras (slotLength)
+import           Test.Ouroboros.Consensus.BlockTree (BlockTree (..),
+                     BlockTreeBranch (..))
+import           Test.Ouroboros.Consensus.PointSchedule
+import           Test.Util.Orphans.IOLike ()
+
+{- | Interesting classification predicates used by the test:
+
+1. the immutable tip should ALWAYS be honest
+2. the selection should be honest IF there is at least a Genesis window after the intersection.
+
+It is possible that, at the end of a test, the selection might be dishonest.
+Consider the following example, where k = 5 and scg = 12:
+
+    slots:  0  1  2  3  4  5  6  7  8  9  10  11  12
+    trunk:  0──1──2──3──4──5──6──7──8──────9──10──11
+                     ╰──4──5──6──7──8──9──────────10
+
+Because of the Limit on Eagerness, the selection is stuck at slot 8 (k-th
+block after the intersection).
+Since the test chains only have 7 and 8 blocks after the intersection, Genesis
+will not be able to make a final decision, since it needs to have enough information
+to determine that one of the fragments is definitely denser within 12 slots, and here
+both fragments have the potential to win the race.
+This means that a test will terminate while the selection contains an arbitrary fragment
+whose tip is the block in slot 8.
+
+Without Genesis, if the blocks are sent so that the N+1st slot's blocks arrive after all
+blocks in slot N have arrived, the adversarial fragment will be selected every time because
+it will have k+1 blocks first.
+
+So in our test we classify the input data according to the presence of an entire Genesis
+window after the intersection of at least one adversarial chain with the honest chain,
+on both chains.
+-}
+data Classifiers =
+  Classifiers {
+    existsSelectableAdversary :: Bool,
+    genesisAfterIntersection  :: Bool
+  }
+
+classifiers :: GenesisTest -> Classifiers
+classifiers GenesisTest {gtBlockTree, gtSecurityParam = SecurityParam k, gtGenesisWindow = GenesisWindow scg} =
+  Classifiers {existsSelectableAdversary, genesisAfterIntersection}
+  where
+    genesisAfterIntersection =
+      any fragmentHasGenesis branches
+
+    fragmentHasGenesis btb =
+      let
+        frag = btbSuffix btb
+        SlotNo intersection = withOrigin 0 id (anchorToSlotNo (anchor frag))
+      in isSelectable btb && slotLength frag > fromIntegral scg && goodTipSlot - intersection > scg
+
+    existsSelectableAdversary =
+      any isSelectable branches
+
+    isSelectable BlockTreeBranch{..} = AF.length btbSuffix > fromIntegral k
+
+    SlotNo goodTipSlot = withOrigin 0 id (headSlot goodChain)
+
+    branches = btBranches gtBlockTree
+
+    goodChain = btTrunk gtBlockTree

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/Genesis/Setup/GenChains.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/Genesis/Setup/GenChains.hs
@@ -1,0 +1,144 @@
+{-# LANGUAGE BlockArguments            #-}
+{-# LANGUAGE DerivingStrategies        #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE NamedFieldPuns            #-}
+{-# LANGUAGE RecordWildCards           #-}
+{-# LANGUAGE ScopedTypeVariables       #-}
+
+module Test.Ouroboros.Consensus.Genesis.Setup.GenChains (
+    GenesisTest (..)
+  , genChains
+  ) where
+
+import           Control.Monad (replicateM)
+import qualified Control.Monad.Except as Exn
+import           Data.List (foldl')
+import           Data.Proxy (Proxy (Proxy))
+import qualified Data.Vector.Unboxed as Vector
+import           Data.Word (Word8)
+import           Ouroboros.Consensus.Block.Abstract hiding (Header)
+import           Ouroboros.Consensus.Protocol.Abstract
+                     (SecurityParam (SecurityParam))
+import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
+import qualified Ouroboros.Network.AnchoredFragment as AF
+import qualified Test.Ouroboros.Consensus.BlockTree as BT
+import qualified Test.Ouroboros.Consensus.ChainGenerator.Adversarial as A
+import           Test.Ouroboros.Consensus.ChainGenerator.Adversarial
+                     (genPrefixBlockCount)
+import           Test.Ouroboros.Consensus.ChainGenerator.Counting
+                     (Count (Count), getVector)
+import qualified Test.Ouroboros.Consensus.ChainGenerator.Honest as H
+import           Test.Ouroboros.Consensus.ChainGenerator.Honest
+                     (ChainSchema (ChainSchema), HonestRecipe (..))
+import           Test.Ouroboros.Consensus.ChainGenerator.Params
+import qualified Test.Ouroboros.Consensus.ChainGenerator.Slot as S
+import           Test.Ouroboros.Consensus.ChainGenerator.Slot (S)
+import           Test.Ouroboros.Consensus.PointSchedule
+import qualified Test.QuickCheck as QC
+import           Test.QuickCheck.Extras (unsafeMapSuchThatJust)
+import           Test.QuickCheck.Random (QCGen)
+import           Test.Util.Orphans.IOLike ()
+import           Test.Util.TestBlock hiding (blockTree)
+
+-- | Random generator for an honest chain recipe and schema.
+genHonestChainSchema :: QC.Gen (Asc, H.HonestRecipe, H.SomeHonestChainSchema)
+genHonestChainSchema = do
+  asc <- genAsc
+  honestRecipe <- H.genHonestRecipe
+
+  H.SomeCheckedHonestRecipe Proxy Proxy honestRecipe' <-
+    case Exn.runExcept $ H.checkHonestRecipe honestRecipe of
+      Left exn            -> error $ "impossible! " <> show (honestRecipe, exn)
+      Right honestRecipe' -> pure honestRecipe'
+  (seed :: QCGen) <- QC.arbitrary
+  let schema = H.uniformTheHonestChain (Just asc) honestRecipe' seed
+
+  pure (asc, honestRecipe, H.SomeHonestChainSchema Proxy Proxy schema)
+
+-- | Random generator for one alternative chain schema forking off a given
+-- honest chain schema. The alternative chain schema is returned as the pair of
+-- a slot number on the honest chain schema and a list of active slots.
+--
+-- REVIEW: Use 'SlotNo' instead of 'Int'?
+genAlternativeChainSchema :: (H.HonestRecipe, H.ChainSchema base hon) -> QC.Gen (Int, [S])
+genAlternativeChainSchema (testRecipeH, arHonest) =
+  unsafeMapSuchThatJust $ do
+    let H.HonestRecipe kcp scg delta _len = testRecipeH
+
+    (seedPrefix :: QCGen) <- QC.arbitrary
+    let arPrefix = genPrefixBlockCount seedPrefix arHonest
+
+    let testRecipeA = A.AdversarialRecipe {
+      A.arPrefix,
+      A.arParams = (kcp, scg, delta),
+      A.arHonest
+    }
+
+    alternativeAsc <- ascFromBits <$> QC.choose (1 :: Word8, maxBound - 1)
+
+    case Exn.runExcept $ A.checkAdversarialRecipe testRecipeA of
+      Left e -> case e of
+        A.NoSuchAdversarialBlock -> pure Nothing
+        A.NoSuchCompetitor       -> error $ "impossible! " <> show e
+        A.NoSuchIntersection     -> error $ "impossible! " <> show e
+
+      Right (A.SomeCheckedAdversarialRecipe _ testRecipeA'') -> do
+        let Count prefixCount = arPrefix
+        (seed :: QCGen) <- QC.arbitrary
+        let H.ChainSchema _ v = A.uniformAdversarialChain (Just alternativeAsc) testRecipeA'' seed
+        pure $ Just (prefixCount, Vector.toList (getVector v))
+
+-- | Random generator for a block tree. The block tree contains one trunk (the
+-- “honest” chain) and as many branches as given as a parameter (the
+-- “alternative” chains or “bad” chains). For instance, one such tree could be
+-- graphically represented as:
+--
+--     slots:    1  2  3  4  5  6  7  8  9
+--     trunk: O─────1──2──3──4─────5──6──7
+--                     │           ╰─────6
+--                     ╰─────3──4─────5
+genChains :: Word -> QC.Gen GenesisTest
+genChains numForks = do
+  (asc, honestRecipe, someHonestChainSchema) <- genHonestChainSchema
+
+  H.SomeHonestChainSchema _ _ honestChainSchema <- pure someHonestChainSchema
+  let ChainSchema _ vH = honestChainSchema
+      goodChain = mkTestFragment goodBlocks
+      -- blocks for the good chain in reversed order
+      goodBlocks = mkTestBlocks True [] slotsH
+      slotsH = Vector.toList (getVector vH)
+      HonestRecipe (Kcp kcp) (Scg scg) _delta _len = honestRecipe
+
+  alternativeChainSchemas <- replicateM (fromIntegral numForks) (genAlternativeChainSchema (honestRecipe, honestChainSchema))
+  pure $ GenesisTest {
+    gtHonestAsc = asc,
+    gtSecurityParam = SecurityParam (fromIntegral kcp),
+    gtGenesisWindow = GenesisWindow (fromIntegral scg),
+    gtBlockTree = foldl' (flip BT.addBranch') (BT.mkTrunk goodChain) $ map (genAdversarialFragment goodBlocks) alternativeChainSchemas
+    }
+
+  where
+    genAdversarialFragment :: [TestBlock] -> (Int, [S]) -> TestFrag
+    genAdversarialFragment goodBlocks (prefixCount, slotsA)
+      =
+      mkTestFragment (mkTestBlocks False prefix slotsA)
+      where
+        -- blocks in the common prefix in reversed order
+        prefix = drop (length goodBlocks - prefixCount) goodBlocks
+
+    mkTestFragment :: [TestBlock] -> AnchoredFragment TestBlock
+    mkTestFragment =
+      AF.fromNewestFirst AF.AnchorGenesis
+
+    mkTestBlocks :: Bool -> [TestBlock] -> [S] -> [TestBlock]
+    mkTestBlocks honest pre active =
+      fst (foldl' folder ([], 0) active)
+      where
+        folder (chain, inc) s | S.test S.notInverted s = (issue inc chain, 0)
+                              | otherwise = (chain, inc + 1)
+        issue inc (h : t) = incSlot inc (successorBlock h) : h : t
+        issue inc [] | [] <- pre = [ incSlot inc (firstBlock (if honest then 0 else 1)) ]
+                     | h : t <- pre = incSlot inc (forkBlock (successorBlock h)) : h : t
+
+    incSlot :: SlotNo -> TestBlock -> TestBlock
+    incSlot n b = b { tbSlot = tbSlot b + n }

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/Config.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/PeerSimulator/Config.hs
@@ -19,6 +19,7 @@ import           Test.Util.TestBlock (BlockConfig (TestBlockConfig),
                      CodecConfig (TestBlockCodecConfig),
                      StorageConfig (TestBlockStorageConfig), TestBlock)
 
+-- REVIEW: this has not been deliberately chosen
 defaultCfg :: SecurityParam -> TopLevelConfig TestBlock
 defaultCfg secParam = TopLevelConfig {
     topLevelConfigProtocol = BftConfig {


### PR DESCRIPTION
Refactors some parts of ChainGenerator to be reused by PeerSimulator

Creates individual functions for the steps involved and removes most of the general logic from the property test

