### PR TITLE
Move Genesis tests to `ouroboros-consensus-diffusion:consensus-test`

### DIFF
--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -202,36 +202,63 @@ test-suite consensus-test
   hs-source-dirs: test/consensus-test
   main-is:        Main.hs
   other-modules:
+    Test.Consensus.BlockTree
+    Test.Consensus.Genesis.Setup
+    Test.Consensus.Genesis.Setup.Classifiers
+    Test.Consensus.Genesis.Setup.GenChains
+    Test.Consensus.Genesis.Tests
+    Test.Consensus.Genesis.Tests.LongRangeAttack
     Test.Consensus.HardFork.Combinator
     Test.Consensus.HardFork.Combinator.A
     Test.Consensus.HardFork.Combinator.B
+    Test.Consensus.Network.AnchoredFragment.Extras
+    Test.Consensus.Network.Driver.Limits.Extras
     Test.Consensus.Node
+    Test.Consensus.PeerSimulator.BlockFetch
+    Test.Consensus.PeerSimulator.Config
+    Test.Consensus.PeerSimulator.Handlers
+    Test.Consensus.PeerSimulator.Resources
+    Test.Consensus.PeerSimulator.Run
+    Test.Consensus.PeerSimulator.ScheduledChainSyncServer
+    Test.Consensus.PeerSimulator.Trace
+    Test.Consensus.PointSchedule
 
   build-depends:
     , base
     , binary
     , bytestring
+    , cardano-crypto-class
     , cardano-slotting
     , containers
+    , contra-tracer
     , directory
     , fs-api                                                                 ^>=0.2
     , fs-sim                                                                 ^>=0.2
+    , hashable
+    , io-classes
     , io-sim
     , mtl
     , nothunks
     , ouroboros-consensus-diffusion
     , ouroboros-consensus:{ouroboros-consensus, unstable-consensus-testlib}
+    , ouroboros-network
     , ouroboros-network-api
+    , ouroboros-network-framework
     , ouroboros-network-mock
+    , ouroboros-network-protocols
     , QuickCheck
     , quiet
     , serialise
     , si-timers
     , sop-extras
     , strict-sop-core
+    , strict-stm
     , tasty
     , tasty-hunit
     , tasty-quickcheck
     , temporary
     , time
+    , typed-protocols
+    , typed-protocols-examples
     , unstable-diffusion-testlib
+    , vector

--- a/ouroboros-consensus-diffusion/test/consensus-test/Main.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Main.hs
@@ -1,5 +1,6 @@
 module Main (main) where
 
+import qualified Test.Consensus.Genesis.Tests (tests)
 import qualified Test.Consensus.HardFork.Combinator (tests)
 import qualified Test.Consensus.Node (tests)
 import           Test.Tasty
@@ -18,4 +19,5 @@ tests =
             Test.Consensus.HardFork.Combinator.tests
           ]
       ]
+  , Test.Consensus.Genesis.Tests.tests
   ]

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/BlockTree.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/BlockTree.hs
@@ -6,7 +6,7 @@
 -- different mechanisms but maybe we should rely on that instead to avoid
 -- duplication.
 
-module Test.Ouroboros.Consensus.BlockTree (
+module Test.Consensus.BlockTree (
     BlockTree (..)
   , BlockTreeBranch (..)
   , PathAnchoredAtSource (..)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
@@ -5,9 +5,9 @@
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE NamedFieldPuns #-}
 
-module Test.Ouroboros.Consensus.Genesis.Setup
-  ( module Test.Ouroboros.Consensus.Genesis.Setup,
-    module Test.Ouroboros.Consensus.Genesis.Setup.GenChains
+module Test.Consensus.Genesis.Setup
+  ( module Test.Consensus.Genesis.Setup,
+    module Test.Consensus.Genesis.Setup.GenChains
   )
 where
 
@@ -16,13 +16,13 @@ import           Control.Monad.Class.MonadTimer.SI (MonadTimer)
 import           Control.Tracer (traceWith)
 import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Consensus.Util.IOLike
-import qualified Test.Ouroboros.Consensus.BlockTree as BT
-import           Test.Ouroboros.Consensus.PointSchedule
-import           Test.Ouroboros.Consensus.PeerSimulator.Run
+import qualified Test.Consensus.BlockTree as BT
+import           Test.Consensus.PointSchedule
+import           Test.Consensus.PeerSimulator.Run
 import           Test.QuickCheck
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.Tracer (recordingTracerTVar)
-import Test.Ouroboros.Consensus.Genesis.Setup.GenChains
+import Test.Consensus.Genesis.Setup.GenChains
 
 runTest ::
   (IOLike m, MonadTime m, MonadTimer m) =>

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/Classifiers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/Classifiers.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE NamedFieldPuns  #-}
 {-# LANGUAGE RecordWildCards #-}
 
-module Test.Ouroboros.Consensus.Genesis.Setup.Classifiers (
+module Test.Consensus.Genesis.Setup.Classifiers (
     Classifiers (..)
   , classifiers
   ) where
@@ -12,10 +12,9 @@ import           Ouroboros.Consensus.Config
 import           Ouroboros.Network.AnchoredFragment (anchor, anchorToSlotNo,
                      headSlot)
 import qualified Ouroboros.Network.AnchoredFragment as AF
-import           Ouroboros.Network.AnchoredFragment.Extras (slotLength)
-import           Test.Ouroboros.Consensus.BlockTree (BlockTree (..),
-                     BlockTreeBranch (..))
-import           Test.Ouroboros.Consensus.PointSchedule
+import           Test.Consensus.BlockTree (BlockTree (..), BlockTreeBranch (..))
+import           Test.Consensus.Network.AnchoredFragment.Extras (slotLength)
+import           Test.Consensus.PointSchedule
 import           Test.Util.Orphans.IOLike ()
 
 {- | Interesting classification predicates used by the test:

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/GenChains.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/GenChains.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE RecordWildCards           #-}
 {-# LANGUAGE ScopedTypeVariables       #-}
 
-module Test.Ouroboros.Consensus.Genesis.Setup.GenChains (
+module Test.Consensus.Genesis.Setup.GenChains (
     GenesisTest (..)
   , genChains
   ) where
@@ -21,7 +21,8 @@ import           Ouroboros.Consensus.Protocol.Abstract
                      (SecurityParam (SecurityParam))
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import qualified Ouroboros.Network.AnchoredFragment as AF
-import qualified Test.Ouroboros.Consensus.BlockTree as BT
+import qualified Test.Consensus.BlockTree as BT
+import           Test.Consensus.PointSchedule
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Adversarial as A
 import           Test.Ouroboros.Consensus.ChainGenerator.Adversarial
                      (genPrefixBlockCount)
@@ -33,7 +34,6 @@ import           Test.Ouroboros.Consensus.ChainGenerator.Honest
 import           Test.Ouroboros.Consensus.ChainGenerator.Params
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Slot as S
 import           Test.Ouroboros.Consensus.ChainGenerator.Slot (S)
-import           Test.Ouroboros.Consensus.PointSchedule
 import qualified Test.QuickCheck as QC
 import           Test.QuickCheck.Extras (unsafeMapSuchThatJust)
 import           Test.QuickCheck.Random (QCGen)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests.hs
@@ -1,0 +1,9 @@
+module Test.Consensus.Genesis.Tests (tests) where
+
+import qualified Test.Consensus.Genesis.Tests.LongRangeAttack as LongRangeAttack
+import           Test.Tasty
+
+tests :: TestTree
+tests = testGroup "Genesis tests"
+    [ LongRangeAttack.tests
+    ]

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
@@ -5,15 +5,15 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections       #-}
 
-module Test.Ouroboros.Consensus.Genesis.Tests.LongRangeAttack (tests) where
+module Test.Consensus.Genesis.Tests.LongRangeAttack (tests) where
 
 import           Control.Monad.IOSim (runSimOrThrow)
 import           Ouroboros.Consensus.Block.Abstract (HeaderHash)
 import           Ouroboros.Network.AnchoredFragment (headAnchor)
 import qualified Ouroboros.Network.AnchoredFragment as AF
-import           Test.Ouroboros.Consensus.Genesis.Setup
-import           Test.Ouroboros.Consensus.Genesis.Setup.Classifiers
-import           Test.Ouroboros.Consensus.PointSchedule
+import           Test.Consensus.Genesis.Setup
+import           Test.Consensus.Genesis.Setup.Classifiers
+import           Test.Consensus.PointSchedule
 import qualified Test.QuickCheck as QC
 import           Test.QuickCheck
 import           Test.QuickCheck.Extras (unsafeMapSuchThatJust)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Network/AnchoredFragment/Extras.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Network/AnchoredFragment/Extras.hs
@@ -1,4 +1,4 @@
-module Ouroboros.Network.AnchoredFragment.Extras (slotLength) where
+module Test.Consensus.Network.AnchoredFragment.Extras (slotLength) where
 
 import           Cardano.Slotting.Slot (SlotNo (unSlotNo), withOrigin)
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment,

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Network/Driver/Limits/Extras.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Network/Driver/Limits/Extras.hs
@@ -6,7 +6,11 @@
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TypeFamilies          #-}
 
-module Ouroboros.Network.Driver.Limits.Extras (module Ouroboros.Network.Driver.Limits.Extras) where
+module Test.Consensus.Network.Driver.Limits.Extras (
+    chainSyncNoSizeLimits
+  , chainSyncTimeouts
+  , runConnectedPeersPipelinedWithLimits
+  ) where
 
 import           Cardano.Slotting.Time (SlotLength, getSlotLength)
 import           Control.Monad.Class.MonadTimer.SI (MonadTimer)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/BlockFetch.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/BlockFetch.hs
@@ -7,7 +7,7 @@
 {-# OPTIONS_GHC -Wno-missing-export-lists #-}
 
 -- | Functions that call to the BlockFetch API to start clients and servers
-module Test.Ouroboros.Consensus.PeerSimulator.BlockFetch (
+module Test.Consensus.PeerSimulator.BlockFetch (
     runBlockFetchClient
   , startBlockFetchLogic
   , startKeepAliveThread

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Config.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Config.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE TypeFamilies #-}
 
-module Test.Ouroboros.Consensus.PeerSimulator.Config (defaultCfg) where
+module Test.Consensus.PeerSimulator.Config (defaultCfg) where
 
 import           Cardano.Crypto.DSIGN (SignKeyDSIGN (..), VerKeyDSIGN (..))
 import           Cardano.Slotting.Time (SlotLength, slotLengthFromSec)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Handlers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Handlers.hs
@@ -5,8 +5,8 @@
 --
 -- These are separated from the scheduling related mechanics of the
 -- ChainSync server mock that the peer simulator uses, in
--- "Test.Ouroboros.Consensus.PeerSimulator.ScheduledChainSyncServer".
-module Test.Ouroboros.Consensus.PeerSimulator.Handlers (
+-- "Test.Consensus.PeerSimulator.ScheduledChainSyncServer".
+module Test.Consensus.PeerSimulator.Handlers (
     handlerFindIntersection
   , handlerRequestNext
   ) where
@@ -24,14 +24,13 @@ import           Ouroboros.Consensus.Util.IOLike (IOLike, STM, StrictTVar,
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block (blockPoint, getTipPoint)
-import qualified Test.Ouroboros.Consensus.BlockTree as BT
-import           Test.Ouroboros.Consensus.BlockTree (BlockTree)
-import           Test.Ouroboros.Consensus.PeerSimulator.ScheduledChainSyncServer
+import qualified Test.Consensus.BlockTree as BT
+import           Test.Consensus.BlockTree (BlockTree)
+import           Test.Consensus.PeerSimulator.ScheduledChainSyncServer
                      (FindIntersect (..),
                      RequestNext (RollBackward, RollForward))
-import           Test.Ouroboros.Consensus.PointSchedule
-                     (AdvertisedPoints (header, tip), HeaderPoint (HeaderPoint),
-                     TipPoint (TipPoint))
+import           Test.Consensus.PointSchedule (AdvertisedPoints (header, tip),
+                     HeaderPoint (HeaderPoint), TipPoint (TipPoint))
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TestBlock (TestBlock)
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Resources.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Resources.hs
@@ -5,7 +5,7 @@
 -- | Data types and resource allocating constructors for the concurrency
 -- primitives used by ChainSync and BlockFetch in the handlers that implement
 -- the block tree analysis specific to our peer simulator.
-module Test.Ouroboros.Consensus.PeerSimulator.Resources (
+module Test.Consensus.PeerSimulator.Resources (
     ChainSyncResources (..)
   , PeerResources (..)
   , SharedResources (..)
@@ -32,10 +32,10 @@ import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block (Tip (..))
 import           Ouroboros.Network.Protocol.ChainSync.Server
                      (ChainSyncServer (..))
-import           Test.Ouroboros.Consensus.BlockTree (BlockTree)
-import           Test.Ouroboros.Consensus.PeerSimulator.Handlers
-import           Test.Ouroboros.Consensus.PeerSimulator.ScheduledChainSyncServer
-import           Test.Ouroboros.Consensus.PointSchedule
+import           Test.Consensus.BlockTree (BlockTree)
+import           Test.Consensus.PeerSimulator.Handlers
+import           Test.Consensus.PeerSimulator.ScheduledChainSyncServer
+import           Test.Consensus.PointSchedule
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TestBlock (TestBlock)
 
@@ -62,7 +62,7 @@ data SharedResources m =
   }
 
 -- | The data used by the point scheduler to interact with the mocked protocol handler in
--- "Test.Ouroboros.Consensus.PeerSimulator.ScheduledChainSyncServer".
+-- "Test.Consensus.PeerSimulator.ScheduledChainSyncServer".
 data ChainSyncResources m =
   ChainSyncResources {
     -- | A mailbox of node states that is updated by the scheduler in the peer's active tick,

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies        #-}
 
-module Test.Ouroboros.Consensus.PeerSimulator.Run (
+module Test.Consensus.PeerSimulator.Run (
     ChainSyncException (..)
   , runPointSchedule
   ) where
@@ -43,7 +43,6 @@ import           Ouroboros.Network.Channel (createConnectedChannels)
 import           Ouroboros.Network.ControlMessage (ControlMessage (..),
                      ControlMessageSTM)
 import           Ouroboros.Network.Driver.Limits
-import           Ouroboros.Network.Driver.Limits.Extras
 import           Ouroboros.Network.Driver.Simple (Role (Client, Server))
 import           Ouroboros.Network.Protocol.ChainSync.ClientPipelined
                      (ChainSyncClientPipelined, chainSyncClientPeerPipelined)
@@ -52,18 +51,18 @@ import           Ouroboros.Network.Protocol.ChainSync.PipelineDecision
                      (pipelineDecisionLowHighMark)
 import           Ouroboros.Network.Protocol.ChainSync.Server
                      (chainSyncServerPeer)
-import qualified Test.Ouroboros.Consensus.BlockTree as BT
+import qualified Test.Consensus.BlockTree as BT
+import           Test.Consensus.Genesis.Setup.GenChains (GenesisTest)
+import           Test.Consensus.Network.Driver.Limits.Extras
+import qualified Test.Consensus.PeerSimulator.BlockFetch as PeerSimulator.BlockFetch
+import           Test.Consensus.PeerSimulator.Config
+import           Test.Consensus.PeerSimulator.Resources
+import           Test.Consensus.PeerSimulator.Trace
+import qualified Test.Consensus.PointSchedule as PointSchedule
+import           Test.Consensus.PointSchedule (GenesisTest (GenesisTest),
+                     Peer (Peer), PeerId, PointSchedule (PointSchedule),
+                     TestFragH, Tick (Tick), pointSchedulePeers)
 import           Test.Ouroboros.Consensus.ChainGenerator.Params (Asc)
-import           Test.Ouroboros.Consensus.Genesis.Setup.GenChains (GenesisTest)
-import qualified Test.Ouroboros.Consensus.PeerSimulator.BlockFetch as PeerSimulator.BlockFetch
-import           Test.Ouroboros.Consensus.PeerSimulator.Config
-import           Test.Ouroboros.Consensus.PeerSimulator.Resources
-import           Test.Ouroboros.Consensus.PeerSimulator.Trace
-import qualified Test.Ouroboros.Consensus.PointSchedule as PointSchedule
-import           Test.Ouroboros.Consensus.PointSchedule
-                     (GenesisTest (GenesisTest), Peer (Peer), PeerId,
-                     PointSchedule (PointSchedule), TestFragH, Tick (Tick),
-                     pointSchedulePeers)
 import           Test.Util.ChainDB
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TestBlock (Header (..), TestBlock, testInitExtLedger)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledChainSyncServer.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledChainSyncServer.hs
@@ -5,7 +5,7 @@
 -- | A ChainSync protocol server that allows external scheduling of its
 -- operations, while deferring the implementation of the message handler
 -- logic to a simplified, abstract interface provided as a parameter.
-module Test.Ouroboros.Consensus.PeerSimulator.ScheduledChainSyncServer (
+module Test.Consensus.PeerSimulator.ScheduledChainSyncServer (
     ChainSyncServerHandlers (..)
   , FindIntersect (..)
   , RequestNext (..)
@@ -26,7 +26,7 @@ import           Ouroboros.Network.Protocol.ChainSync.Server
                      ServerStIdle (ServerStIdle, recvMsgDoneClient, recvMsgFindIntersect, recvMsgRequestNext),
                      ServerStIntersect (SendMsgIntersectFound, SendMsgIntersectNotFound),
                      ServerStNext (SendMsgRollBackward, SendMsgRollForward))
-import           Test.Ouroboros.Consensus.PeerSimulator.Trace (traceUnitWith)
+import           Test.Consensus.PeerSimulator.Trace (traceUnitWith)
 import           Test.Util.TestBlock (Header (..), TestBlock)
 
 -- | Pure representation of the messages produced by the handler for the @StNext@

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE NamedFieldPuns #-}
 
 -- | Helpers for tracing used by the peer simulator.
-module Test.Ouroboros.Consensus.PeerSimulator.Trace (
+module Test.Consensus.PeerSimulator.Trace (
     mkCdbTracer
   , mkChainSyncClientTracer
   , traceUnitWith

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE NamedFieldPuns        #-}
 {-# LANGUAGE OverloadedStrings     #-}
 
-module Test.Ouroboros.Consensus.PointSchedule (module Test.Ouroboros.Consensus.PointSchedule) where
+module Test.Consensus.PointSchedule (module Test.Consensus.PointSchedule) where
 
 import           Data.Foldable (toList)
 import           Data.Hashable (Hashable)
@@ -24,8 +24,7 @@ import           Ouroboros.Network.AnchoredFragment (AnchoredFragment,
 import           Ouroboros.Network.Block (SlotNo, Tip (Tip, TipGenesis),
                      blockNo, blockSlot, getTipSlotNo, tipFromHeader)
 import           Ouroboros.Network.Point (WithOrigin (At))
-import           Test.Ouroboros.Consensus.BlockTree (BlockTree (..),
-                     BlockTreeBranch (..))
+import           Test.Consensus.BlockTree (BlockTree (..), BlockTreeBranch (..))
 import           Test.Ouroboros.Consensus.ChainGenerator.Params (Asc)
 import           Test.Util.TestBlock (Header (TestHeader), TestBlock)
 

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -517,55 +517,23 @@ test-suite infra-test
   main-is:        Main.hs
   other-modules:
     Ouroboros.Consensus.Util.Tests
-    Ouroboros.Network.AnchoredFragment.Extras
-    Ouroboros.Network.Driver.Limits.Extras
-    Test.Ouroboros.Consensus.BlockTree
     Test.Ouroboros.Consensus.ChainGenerator.Tests
     Test.Ouroboros.Consensus.ChainGenerator.Tests.Adversarial
     Test.Ouroboros.Consensus.ChainGenerator.Tests.BitVector
     Test.Ouroboros.Consensus.ChainGenerator.Tests.Counting
     Test.Ouroboros.Consensus.ChainGenerator.Tests.Honest
-    Test.Ouroboros.Consensus.Genesis.Setup
-    Test.Ouroboros.Consensus.Genesis.Setup.Classifiers
-    Test.Ouroboros.Consensus.Genesis.Setup.GenChains
-    Test.Ouroboros.Consensus.Genesis.Tests
-    Test.Ouroboros.Consensus.Genesis.Tests.LongRangeAttack
-    Test.Ouroboros.Consensus.PeerSimulator.BlockFetch
-    Test.Ouroboros.Consensus.PeerSimulator.Config
-    Test.Ouroboros.Consensus.PeerSimulator.Handlers
-    Test.Ouroboros.Consensus.PeerSimulator.Resources
-    Test.Ouroboros.Consensus.PeerSimulator.Run
-    Test.Ouroboros.Consensus.PeerSimulator.ScheduledChainSyncServer
-    Test.Ouroboros.Consensus.PeerSimulator.Trace
-    Test.Ouroboros.Consensus.PointSchedule
     Test.Util.ChainUpdates.Tests
     Test.Util.Schedule.Tests
     Test.Util.Split.Tests
 
   build-depends:
     , base
-    , cardano-crypto-class
-    , cardano-slotting
-    , containers
-    , contra-tracer
-    , hashable
-    , io-classes
-    , io-sim
     , mtl
     , ouroboros-consensus:{ouroboros-consensus, unstable-consensus-testlib}
-    , ouroboros-network
-    , ouroboros-network-api
-    , ouroboros-network-framework
-    , ouroboros-network-protocols
     , QuickCheck
     , random
-    , si-timers
-    , strict-stm
     , tasty
     , tasty-quickcheck
-    , time
-    , typed-protocols
-    , typed-protocols-examples
     , unstable-consensus-testlib
     , vector
 

--- a/ouroboros-consensus/test/infra-test/Main.hs
+++ b/ouroboros-consensus/test/infra-test/Main.hs
@@ -14,7 +14,6 @@ module Main (main) where
 
 import qualified Ouroboros.Consensus.Util.Tests (tests)
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Tests (tests)
-import qualified Test.Ouroboros.Consensus.Genesis.Tests (tests)
 import           Test.Tasty (TestTree, testGroup)
 import qualified Test.Util.ChainUpdates.Tests (tests)
 import qualified Test.Util.Schedule.Tests (tests)
@@ -30,7 +29,6 @@ tests =
   testGroup "test-infra"
   [ Ouroboros.Consensus.Util.Tests.tests
   , Test.Ouroboros.Consensus.ChainGenerator.Tests.tests
-  , Test.Ouroboros.Consensus.Genesis.Tests.tests
   , Test.Util.ChainUpdates.Tests.tests
   , Test.Util.Schedule.Tests.tests
   , Test.Util.Split.Tests.tests

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/Genesis/Tests.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/Genesis/Tests.hs
@@ -1,9 +1,0 @@
-module Test.Ouroboros.Consensus.Genesis.Tests (tests) where
-
-import qualified Test.Ouroboros.Consensus.Genesis.Tests.LongRangeAttack as LongRangeAttack
-import           Test.Tasty
-
-tests :: TestTree
-tests = testGroup "Genesis tests"
-    [ LongRangeAttack.tests
-    ]


### PR DESCRIPTION
This PR crucially builds on top of #430 because #430 removes the dependency of Genesis tests into `Test....ChainGenerator.Tests.*` which was blocking a move to a different test suite.