### PR TITLE
Send `AwaitReply` to prevent timeouts.

### DIFF
--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
@@ -38,7 +38,7 @@ runTest genesisTest@GenesisTest {gtBlockTree, gtHonestAsc} schedule makeProperty
 
     mapM_ (traceWith tracer) $ BT.prettyPrint gtBlockTree
 
-    result <- runPointSchedule genesisTest schedule tracer
+    result <- runPointSchedule schedulerConfig genesisTest schedule tracer
     trace <- unlines <$> getTrace
 
     let
@@ -49,3 +49,5 @@ runTest genesisTest@GenesisTest {gtBlockTree, gtHonestAsc} schedule makeProperty
           counterexample ("result: " <> condense fragment) (makeProperty fragment)
 
     pure $ counterexample trace prop
+    where
+      schedulerConfig = SchedulerConfig {enableTimeouts = False}

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Network/Driver/Limits/Extras.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Network/Driver/Limits/Extras.hs
@@ -8,6 +8,7 @@
 
 module Test.Consensus.Network.Driver.Limits.Extras (
     chainSyncNoSizeLimits
+  , chainSyncNoTimeouts
   , chainSyncTimeouts
   , runConnectedPeersPipelinedWithLimits
   ) where
@@ -95,3 +96,11 @@ chainSyncTimeouts t f =
     mustReplyTimeout = Just $ secondsToDiffTime $ round $
       realToFrac (getSlotLength t)
         * log (1 - 0.999) / log (1 - ascVal f)
+
+chainSyncNoTimeouts :: ChainSyncTimeout
+chainSyncNoTimeouts =
+  ChainSyncTimeout {
+      canAwaitTimeout = Nothing
+    , intersectTimeout = Nothing
+    , mustReplyTimeout = Nothing
+  }

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Handlers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Handlers.hs
@@ -112,7 +112,13 @@ handlerRequestNext currentIntersection blockTree points =
         -- REVIEW: The following is a hack that allows the honest peer to not
         -- get disconnected when it falls behind. Why does a peer doing that not
         -- get disconnected from?
-        pure (Just AwaitReply)
+        --
+        -- We decided to hold off on making this work with timeouts, so we'll return
+        -- Nothing here for now.
+        -- The consequence of this is that a slow peer will just block until it reaches
+        -- the fork intersection in its schedule.
+        -- pure (Just AwaitReply)
+        pure Nothing
       -- If the anchor is not the intersection and the fragment is non-empty,
       -- then we require a rollback
       (BT.PathAnchoredAtSource False, fragment) -> do

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Handlers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Handlers.hs
@@ -28,7 +28,7 @@ import qualified Test.Consensus.BlockTree as BT
 import           Test.Consensus.BlockTree (BlockTree)
 import           Test.Consensus.PeerSimulator.ScheduledChainSyncServer
                      (FindIntersect (..),
-                     RequestNext (RollBackward, RollForward))
+                     RequestNext (AwaitReply, RollBackward, RollForward))
 import           Test.Consensus.PointSchedule (AdvertisedPoints (header, tip),
                      HeaderPoint (HeaderPoint), TipPoint (TipPoint))
 import           Test.Util.Orphans.IOLike ()
@@ -52,7 +52,7 @@ handlerFindIntersection ::
   STM m (FindIntersect, [String])
 handlerFindIntersection currentIntersection blockTree points clientPoints = do
   let TipPoint tip' = tip points
-      tipPoint = Ouroboros.Network.Block.getTipPoint tip'
+      tipPoint = getTipPoint tip'
       fragment = fromJust $ BT.findFragment tipPoint blockTree
   case intersectWith fragment clientPoints of
     Nothing ->
@@ -81,8 +81,6 @@ handlerRequestNext currentIntersection blockTree points =
   runWriterT $ do
     intersection <- lift $ readTVar currentIntersection
     trace $ "  last intersection is " ++ condense intersection
-    let HeaderPoint header' = header points
-        headerPoint = AF.castPoint $ blockPoint header'
     maybe noPathError analysePath (BT.findPath intersection headerPoint blockTree)
   where
     noPathError = error "serveHeader: intersection and and headerPoint should always be in the block tree"
@@ -91,6 +89,9 @@ handlerRequestNext currentIntersection blockTree points =
       -- If the anchor is the intersection (the source of the path-finding)
       -- but the fragment is empty, then the intersection is exactly our
       -- header point and there is nothing to do.
+      (BT.PathAnchoredAtSource True, AF.Empty _) | getTipPoint tip' == headerPoint -> do
+        trace "  chain has been fully served"
+        pure (Just AwaitReply)
       (BT.PathAnchoredAtSource True, AF.Empty _) -> do
         trace "  intersection is exactly our header point"
         pure Nothing
@@ -105,16 +106,19 @@ handlerRequestNext currentIntersection blockTree points =
       -- the intersection is further than the tip that we can serve.
       (BT.PathAnchoredAtSource False, AF.Empty _) -> do
         trace "  intersection is further than our header point"
-        pure Nothing
+        pure (Just AwaitReply)
       -- If the anchor is not the intersection and the fragment is non-empty,
       -- then we require a rollback
       (BT.PathAnchoredAtSource False, fragment) -> do
         trace $ "  we will require a rollback to" ++ condense (AF.anchorPoint fragment)
         trace $ "  fragment: " ++ condense fragment
         let
-          tip' = coerce (tip points)
           point = AF.anchorPoint fragment
         lift $ writeTVar currentIntersection point
         pure $ Just (RollBackward point tip')
+
+    HeaderPoint header' = header points
+    headerPoint = AF.castPoint $ blockPoint header'
+    TipPoint tip' = tip points
 
     trace = tell . pure

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
@@ -126,7 +126,7 @@ startChainSyncConnectionThread registry tracer cfg activeSlotCoefficient chainDb
     bracketSyncWithFetchClient fetchClientRegistry srPeerId $ do
       res <- try $ runConnectedPeersPipelinedWithLimits
         createConnectedChannels
-        protocolTracer
+        nullTracer
         codecChainSyncId
         chainSyncNoSizeLimits
         (timeLimitsChainSync timeouts)
@@ -145,18 +145,6 @@ startChainSyncConnectionThread registry tracer cfg activeSlotCoefficient chainDb
           throwIO exn
         Right res' -> pure res'
   pure chainSyncException
-
-  where
-    protocolTracer = Tracer $ \case
-      (clientOrServer, TraceSendMsg payload) ->
-        traceUnitWith
-          tracer
-          ("Protocol ChainSync " ++ condense srPeerId)
-          (case clientOrServer of
-             Client -> "Client -> Server"
-             Server -> "Server -> Client"
-           ++ ": " ++ show payload)
-      _ -> pure ()
 
 -- | Start the BlockFetch client, using the supplied 'FetchClientRegistry' to
 -- register it for synchronization with the ChainSync client.

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
@@ -13,7 +13,7 @@ import           Control.Monad.Class.MonadAsync
                      (AsyncCancelled (AsyncCancelled))
 import           Control.Monad.Class.MonadTime (MonadTime)
 import           Control.Monad.Class.MonadTimer.SI (MonadTimer)
-import           Control.Tracer (Tracer (Tracer), nullTracer, traceWith)
+import           Control.Tracer (Tracer, nullTracer, traceWith)
 import           Data.Foldable (for_)
 import           Data.Functor (void)
 import           Data.List.NonEmpty (NonEmpty, nonEmpty)
@@ -43,7 +43,6 @@ import           Ouroboros.Network.Channel (createConnectedChannels)
 import           Ouroboros.Network.ControlMessage (ControlMessage (..),
                      ControlMessageSTM)
 import           Ouroboros.Network.Driver.Limits
-import           Ouroboros.Network.Driver.Simple (Role (Client, Server))
 import           Ouroboros.Network.Protocol.ChainSync.ClientPipelined
                      (ChainSyncClientPipelined, chainSyncClientPeerPipelined)
 import           Ouroboros.Network.Protocol.ChainSync.Codec

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledChainSyncServer.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledChainSyncServer.hs
@@ -1,6 +1,5 @@
-{-# LANGUAGE LambdaCase      #-}
-{-# LANGUAGE NamedFieldPuns  #-}
-{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE LambdaCase     #-}
+{-# LANGUAGE NamedFieldPuns #-}
 
 -- | A ChainSync protocol server that allows external scheduling of its
 -- operations, while deferring the implementation of the message handler
@@ -15,7 +14,6 @@ module Test.Consensus.PeerSimulator.ScheduledChainSyncServer (
 
 import           Control.Tracer (Tracer (Tracer), traceWith)
 import           Data.Foldable (traverse_)
-import           Data.Functor (void)
 import           Ouroboros.Consensus.Block.Abstract (Point (..))
 import           Ouroboros.Consensus.Util.Condense (Condense (..))
 import           Ouroboros.Consensus.Util.IOLike (IOLike, MonadSTM (STM),

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
@@ -29,10 +29,9 @@ mkCdbTracer tracer =
   Tracer $ \case
     ChainDB.Impl.TraceAddBlockEvent event ->
       case event of
-        AddedToCurrentChain _ NewTipInfo {newTipPoint} _ newFragment -> do
+        AddedToCurrentChain _ NewTipInfo {newTipPoint} _ _ -> do
           trace "Added to current chain"
           trace $ "New tip: " ++ condense newTipPoint
-          trace $ "New fragment: " ++ condense newFragment
         SwitchedToAFork _ NewTipInfo {newTipPoint} _ newFragment -> do
           trace "Switched to a fork"
           trace $ "New tip: " ++ condense newTipPoint


### PR DESCRIPTION
This PR builds on top of #431.

When a ChainSync server is done serving its chain, it now sends an `AwaitReply` message to the client so as to not get disconnected from too fast (typically, clients wait for 10s for a response, or 80-150s for a response after `AwaitReply`).

As a hack, servers also now return `AwaitReply` when they fall behind the intersection of the client due to the `PointSchedule`'s structure. It is not clear to us why this is accepted by a client.