### PR TITLE
Add cabal-hoogle to nix infra

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,6 +168,29 @@ the right version of `stylish-haskell`.
 nix develop -c ./scripts/ci/run-stylish.sh
 ```
 
+# Generating documentation and setting up hoogle
+
+To generate the documentation, use the documentation script:
+
+```bash
+./scripts/docs/haddocks.sh
+```
+
+Often times, it is useful to have a
+[`hoogle`](https://github.com/ndmitchell/hoogle) server at hand, with the
+packages and its dependencies. Our suggestion is to use
+[`cabal-hoogle`](https://github.com/kokobd/cabal-hoogle) which is included in
+the `nix` shell:
+
+```bash
+nix develop
+$ cabal-hoogle generate
+$ cabal-hoogle run -- server --local
+```
+
+This will fire a `hoogle` server at https://localhost:8080/ with the local
+packages and their dependencies.
+
 ## Making and reviewing changes
 
 If you are working on changing a **substantial** part of Consensus, it is
@@ -318,10 +341,6 @@ The core contributors to consensus codebase are:
 -   [Alexander Esgen](https://github.com/amesgen)
 
 -   [Joris Dral](https://github.com/jorisdral)
-
--   [Bart Frenk](https://github.com/bartfrenk)
-
--   [Arnaud Bailly](https://github.com/abailly-iohk)
 
 -   [Fraser Murray](https://github.com/fraser-iohk)
 

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -11,6 +11,7 @@ hsPkgs.shellFor {
     pkgs.nixpkgs-fmt
     pkgs.stylish-haskell
     pkgs.cabal-fmt
+    pkgs.cabal-hoogle
     pkgs.ghcid
 
     # release management

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -35,6 +35,16 @@ in
     }];
   }).cabal-install.components.exes.cabal;
 
+  cabal-hoogle = tool "cabal-hoogle" "git" {
+    src = final.fetchFromGitHub {
+      owner = "kokobd";
+      repo = "cabal-hoogle";
+      rev = "7452c2b1dbdae4eb675d280ed99ec135293adc13";
+      hash = "sha256-w7PkNZfHJw1291c2nfviENSXykYpNV+4i3FmbMJqSMs=";
+    };
+    index-state = null; # use upstream cabal.project
+  };
+
   stylish-haskell = tool "stylish-haskell" "0.14.4.0" { };
 
   cabal-fmt = tool "cabal-fmt" "0.1.7" { };


### PR DESCRIPTION
# Description
Credits to @amesgen.

With this, inside a shell you can do `cabal-hoogle generate && cabal-hoogle run -- server --local` and have a hoogle server running
