### PR TITLE
Add a test to check that timeouts are indeed enforced

### DIFF
--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -221,6 +221,8 @@ test-suite consensus-test
     Test.Consensus.PeerSimulator.Run
     Test.Consensus.PeerSimulator.ScheduledChainSyncServer
     Test.Consensus.PeerSimulator.StateView
+    Test.Consensus.PeerSimulator.Tests
+    Test.Consensus.PeerSimulator.Tests.Timeouts
     Test.Consensus.PeerSimulator.Trace
     Test.Consensus.PointSchedule
 

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -220,6 +220,7 @@ test-suite consensus-test
     Test.Consensus.PeerSimulator.Resources
     Test.Consensus.PeerSimulator.Run
     Test.Consensus.PeerSimulator.ScheduledChainSyncServer
+    Test.Consensus.PeerSimulator.StateView
     Test.Consensus.PeerSimulator.Trace
     Test.Consensus.PointSchedule
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Main.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Main.hs
@@ -3,6 +3,7 @@ module Main (main) where
 import qualified Test.Consensus.Genesis.Tests (tests)
 import qualified Test.Consensus.HardFork.Combinator (tests)
 import qualified Test.Consensus.Node (tests)
+import qualified Test.Consensus.PeerSimulator.Tests (tests)
 import           Test.Tasty
 import           Test.Util.TestEnv (defaultMainWithTestEnv,
                      defaultTestEnvConfig)
@@ -20,4 +21,5 @@ tests =
           ]
       ]
   , Test.Consensus.Genesis.Tests.tests
+  , Test.Consensus.PeerSimulator.Tests.tests
   ]

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
@@ -27,6 +27,7 @@ import           Test.Util.Tracer (recordingTracerTVar)
 import Test.Consensus.Genesis.Setup.GenChains
 import Test.Consensus.PeerSimulator.StateView
 import Ouroboros.Network.Protocol.ChainSync.Codec (ChainSyncTimeout(..))
+import Test.Consensus.PeerSimulator.Trace (traceLinesWith)
 
 runTest ::
   (IOLike m, MonadTime m, MonadTimer m, Testable a) =>
@@ -38,15 +39,16 @@ runTest ::
 runTest schedulerConfig genesisTest schedule makeProperty = do
     (tracer, getTrace) <- recordingTracerTVar
 
-    traceWith tracer $ "Security param k = " ++ show gtSecurityParam
-    traceWith tracer $ "Honest active slot coefficient asc = " ++ show gtHonestAsc
-    traceWith tracer $ "Genesis window scg = " ++ show gtGenesisWindow
-
-    traceWith tracer $ "SchedulerConfig:"
-    traceWith tracer $ "  ChainSyncTimeouts:"
-    traceWith tracer $ "    canAwait = " ++ show (canAwaitTimeout scChainSyncTimeouts)
-    traceWith tracer $ "    intersect = " ++ show (intersectTimeout scChainSyncTimeouts)
-    traceWith tracer $ "    mustReply = " ++ show (mustReplyTimeout scChainSyncTimeouts)
+    traceLinesWith tracer [
+      "Security param k = " ++ show gtSecurityParam,
+      "Honest active slot coefficient asc = " ++ show gtHonestAsc,
+      "Genesis window scg = " ++ show gtGenesisWindow,
+      "SchedulerConfig:",
+      "  ChainSyncTimeouts:",
+      "    canAwait = " ++ show (canAwaitTimeout scChainSyncTimeouts),
+      "    intersect = " ++ show (intersectTimeout scChainSyncTimeouts),
+      "    mustReply = " ++ show (mustReplyTimeout scChainSyncTimeouts)
+      ]
 
     mapM_ (traceWith tracer) $ BT.prettyPrint gtBlockTree
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
@@ -13,6 +13,7 @@ import           Ouroboros.Network.AnchoredFragment (headAnchor)
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Test.Consensus.Genesis.Setup
 import           Test.Consensus.Genesis.Setup.Classifiers
+import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
 import qualified Test.QuickCheck as QC
 import           Test.QuickCheck
@@ -37,11 +38,11 @@ prop_longRangeAttack = do
   let Classifiers {..} = classifiers genesisTest
 
   pure $ withMaxSuccess 10 $ runSimOrThrow $
-    runTest genesisTest schedule $ \fragment ->
+    runTest' genesisTest schedule $ \StateView{svSelectedChain} ->
         classify genesisWindowAfterIntersection "Full genesis window after intersection"
-        $ existsSelectableAdversary ==> not $ isHonestTestFragH fragment
+        $ existsSelectableAdversary ==> not $ isHonestTestFragH svSelectedChain
         -- TODO
-        -- $ not existsSelectableAdversary ==> immutableTipBeforeFork fragment
+        -- $ not existsSelectableAdversary ==> immutableTipBeforeFork svSelectedChain
   where
     isHonestTestFragH :: TestFragH -> Bool
     isHonestTestFragH frag = case headAnchor frag of

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
@@ -235,22 +235,25 @@ runScheduler config tracer (PointSchedule ps) peers = do
   for_ ps (dispatchTick config tracer peers)
   traceEndOfTimePoetry
   where
-    traceStartOfTimePoetry = do
-      traceLine
-      trace "» Time says “Let there be”"
-      trace "» every moment and instantly"
-      trace "» there is space and the radiance"
-      trace "» of each bright galaxy."
-      traceLine
-    traceEndOfTimePoetry = do
-      traceLine
-      trace "» A Clock stopped -"
-      trace "» Not the Mantel's -"
-      trace "» Geneva's farthest skill"
-      trace "» Can't put the puppet bowing"
-      trace "» That just now dangled still -"
-    traceLine = trace "--------------------------------------------------------------------------------"
-    trace = traceWith tracer
+    traceStartOfTimePoetry =
+      traceLinesWith tracer [
+        hline,
+        "» Time says “Let there be”",
+        "» every moment and instantly",
+        "» there is space and the radiance",
+        "» of each bright galaxy.",
+        hline
+        ]
+    traceEndOfTimePoetry =
+      traceLinesWith tracer [
+        hline,
+        "» A Clock stopped -",
+        "» Not the Mantel's -",
+        "» Geneva's farthest skill",
+        "» Can't put the puppet bowing",
+        "» That just now dangled still -"
+        ]
+    hline = "--------------------------------------------------------------------------------"
 
 -- | Construct STM resources, set up ChainSync and BlockFetch threads, and
 -- send all ticks in a 'PointSchedule' to all given peers in turn.

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
@@ -30,9 +30,8 @@ import qualified Ouroboros.Consensus.Storage.ChainDB.Impl as ChainDB.Impl
 import           Ouroboros.Consensus.Util.Condense (Condense (..))
 import           Ouroboros.Consensus.Util.IOLike (Exception (fromException),
                      IOLike, MonadCatch (try), MonadDelay (threadDelay),
-                     MonadSTM (atomically, retry), MonadThrow (throwIO),
-                     StrictTVar, readTVar, readTVarIO, tryPutTMVar,
-                     uncheckedNewTVarM, writeTVar)
+                     MonadSTM (atomically, retry), StrictTVar, readTVar,
+                     readTVarIO, tryPutTMVar, uncheckedNewTVarM, writeTVar)
 import           Ouroboros.Consensus.Util.ResourceRegistry
 import           Ouroboros.Network.Block (blockPoint)
 import           Ouroboros.Network.BlockFetch (FetchClientRegistry,
@@ -134,8 +133,7 @@ startChainSyncConnectionThread registry tracer cfg chainDbView fetchClientRegist
               traceUnitWith tracer ("ChainSyncClient " ++ condense srPeerId) "Terminating because of time limit exceeded."
             Nothing ->
               pure ()
-          throwIO exn
-        Right res' -> pure res'
+        Right _ -> pure ()
   pure chainSyncException
 
 -- | Start the BlockFetch client, using the supplied 'FetchClientRegistry' to

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
@@ -219,19 +219,26 @@ runScheduler ::
 runScheduler tracer (PointSchedule ps) peers = do
   traceWith tracer "Schedule is:"
   for_ ps  $ \tick -> traceWith tracer $ "  " ++ condense tick
-  traceWith tracer "--------------------------------------------------------------------------------"
-  traceWith tracer "» Time says “Let there be”"
-  traceWith tracer "» every moment and instantly"
-  traceWith tracer "» there is space and the radiance"
-  traceWith tracer "» of each bright galaxy."
-  traceWith tracer "--------------------------------------------------------------------------------"
+  traceStartOfTimePoetry
   for_ ps (dispatchTick tracer peers)
-  traceWith tracer "--------------------------------------------------------------------------------"
-  traceWith tracer "» A Clock stopped -"
-  traceWith tracer "» Not the Mantel's -"
-  traceWith tracer "» Geneva's farthest skill"
-  traceWith tracer "» Can't put the puppet bowing"
-  traceWith tracer "» That just now dangled still -"
+  traceEndOfTimePoetry
+  where
+    traceStartOfTimePoetry = do
+      traceLine
+      trace "» Time says “Let there be”"
+      trace "» every moment and instantly"
+      trace "» there is space and the radiance"
+      trace "» of each bright galaxy."
+      traceLine
+    traceEndOfTimePoetry = do
+      traceLine
+      trace "» A Clock stopped -"
+      trace "» Not the Mantel's -"
+      trace "» Geneva's farthest skill"
+      trace "» Can't put the puppet bowing"
+      trace "» That just now dangled still -"
+    traceLine = trace "--------------------------------------------------------------------------------"
+    trace = traceWith tracer
 
 -- | Construct STM resources, set up ChainSync and BlockFetch threads, and
 -- send all ticks in a 'PointSchedule' to all given peers in turn.

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/StateView.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/StateView.hs
@@ -1,0 +1,20 @@
+module Test.Consensus.PeerSimulator.StateView (
+    ChainSyncException (..)
+  , StateView (..)
+  ) where
+
+import           Ouroboros.Consensus.Util.IOLike (SomeException)
+import           Test.Consensus.PointSchedule (PeerId, TestFragH)
+
+-- | A record to associate an exception thrown by the ChainSync
+-- thread with the peer that it was running for.
+data ChainSyncException = ChainSyncException
+       { csePeerId    :: PeerId
+       , cseException :: SomeException
+       }
+    deriving Show
+
+data StateView = StateView {
+    svSelectedChain       :: TestFragH,
+    svChainSyncExceptions :: [ChainSyncException]
+  }

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests.hs
@@ -1,0 +1,9 @@
+module Test.Consensus.PeerSimulator.Tests (tests) where
+
+import qualified Test.Consensus.PeerSimulator.Tests.Timeouts as Timeouts
+import           Test.Tasty
+
+tests :: TestTree
+tests = testGroup "PeerSimulator" [
+    Timeouts.tests
+  ]

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -1,0 +1,85 @@
+{-# LANGUAGE LambdaCase     #-}
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Test.Consensus.PeerSimulator.Tests.Timeouts (tests) where
+
+import           Cardano.Slotting.Time (SlotLength, slotLengthFromSec)
+import           Control.Monad.IOSim (runSimOrThrow)
+import           Data.List.NonEmpty (NonEmpty ((:|)))
+import qualified Data.Map as Map
+import           Data.Maybe (fromJust)
+import           Data.Time.Clock (diffTimeToPicoseconds)
+import           Ouroboros.Consensus.Block (getHeader)
+import           Ouroboros.Consensus.Util.Condense
+import           Ouroboros.Consensus.Util.IOLike (DiffTime, fromException)
+import qualified Ouroboros.Network.AnchoredFragment as AF
+import           Ouroboros.Network.Block (tipFromHeader)
+import           Ouroboros.Network.Driver.Limits
+                     (ProtocolLimitFailure (ExceededTimeLimit))
+import           Ouroboros.Network.Protocol.ChainSync.Codec (mustReplyTimeout)
+import           Test.Consensus.BlockTree (btTrunk)
+import           Test.Consensus.Genesis.Setup
+import           Test.Consensus.Network.Driver.Limits.Extras (chainSyncTimeouts)
+import           Test.Consensus.PeerSimulator.Run (SchedulerConfig (..))
+import           Test.Consensus.PeerSimulator.StateView
+import           Test.Consensus.PointSchedule
+import qualified Test.QuickCheck as QC
+import           Test.QuickCheck
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+import           Test.Util.Orphans.IOLike ()
+
+tests :: TestTree
+tests = testProperty "timeouts" prop_timeouts
+
+prop_timeouts :: QC.Gen QC.Property
+prop_timeouts = do
+  genesisTest <- genChains 0
+
+  let scChainSyncTimeouts = chainSyncTimeouts slotLength (gtHonestAsc genesisTest)
+      schedulerConfig = SchedulerConfig {scChainSyncTimeouts}
+
+  let schedule =
+        dullSchedule
+          (fromJust $ mustReplyTimeout scChainSyncTimeouts)
+          (btTrunk $ gtBlockTree genesisTest)
+
+  pure $ withMaxSuccess 10 $ runSimOrThrow $
+    runTest schedulerConfig genesisTest schedule $ \stateView ->
+      case svChainSyncExceptions stateView of
+        [] ->
+          counterexample ("result: " ++ condense (svSelectedChain stateView)) False
+        [exn] ->
+          case fromException $ cseException exn of
+            Just (ExceededTimeLimit _) -> counterexample "REVIEW" True
+            _ -> counterexample ("exception: " ++ show exn) False
+        exns ->
+          counterexample ("exceptions: " ++ show exns) False
+
+  where
+    -- FIXME: Should ideally not be hardcoded, especially because it is now
+    -- duplicated between here and within the PeerSimulator.
+    tickDuration :: DiffTime
+    tickDuration = 0.100 -- seconds
+
+    -- FIXME: Should ideally not be hardcoded, especially because it is now
+    -- duplicated between here and within the PeerSimulator.
+    slotLength :: SlotLength
+    slotLength = slotLengthFromSec 20
+
+    -- A schedule that advertises all the points of the chain from the start but
+    -- contains just one too many ticks, therefore reaching the timeouts.
+    dullSchedule :: DiffTime -> TestFrag -> PointSchedule
+    dullSchedule _ (AF.Empty _) = error "requires a non-empty block tree"
+    dullSchedule timeout (_ AF.:> tipBlock) =
+      let tipPoint = TipPoint $ tipFromHeader tipBlock
+          headerPoint = HeaderPoint $ getHeader tipBlock
+          blockPoint = BlockPoint tipBlock
+          state = Peer HonestPeer $ NodeOnline $ AdvertisedPoints tipPoint headerPoint blockPoint
+          tick = Tick { active = state, peers = Peers state Map.empty }
+          maximumNumberOfTicks = fromIntegral $ roundDiffTimeToSeconds $ timeout / tickDuration
+      in
+      PointSchedule (tick :| replicate maximumNumberOfTicks tick)
+
+    roundDiffTimeToSeconds :: DiffTime -> Integer
+    roundDiffTimeToSeconds = (`div` 1000000000000) . (+ 500000000000) . diffTimeToPicoseconds

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
@@ -5,10 +5,12 @@
 module Test.Consensus.PeerSimulator.Trace (
     mkCdbTracer
   , mkChainSyncClientTracer
+  , traceLinesWith
   , traceUnitWith
   ) where
 
 import           Control.Tracer (Tracer (Tracer), traceWith)
+import           Data.Foldable (traverse_)
 import           Data.Time.Clock (diffTimeToPicoseconds)
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client
                      (TraceChainSyncClientEvent (..))
@@ -69,3 +71,10 @@ traceUnitWith tracer unit msg = do
           seconds = (ps `div` 1000000000000) `rem` 60
           minutes = (ps `div` 1000000000000) `quot` 60
        in printf "%02d:%02d.%03d" minutes seconds milliseconds
+
+traceLinesWith ::
+  Applicative m =>
+  Tracer m String ->
+  [String] ->
+  m ()
+traceLinesWith = traverse_ . traceWith

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -37,11 +37,13 @@ module Test.Consensus.PointSchedule (
   , PeerId (..)
   , Peers (..)
   , PointSchedule (..)
+  , PointScheduleConfig (..)
   , ScheduleType (..)
   , TestFrag
   , TestFragH
   , Tick (..)
   , TipPoint (..)
+  , defaultPointScheduleConfig
   , genSchedule
   , onlyHonestWithMintingPointSchedule
   , pointSchedulePeers
@@ -54,6 +56,7 @@ import           Data.List.NonEmpty (NonEmpty ((:|)), nonEmpty)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.String (IsString (fromString))
+import           Data.Time (DiffTime)
 import           Data.Word (Word64)
 import           GHC.Generics (Generic)
 import           Ouroboros.Consensus.Block.Abstract (HasHeader, getHeader)
@@ -227,6 +230,19 @@ newtype PointSchedule =
 
 instance Condense PointSchedule where
   condense (PointSchedule ticks) = unlines (condense <$> toList ticks)
+
+-- | Parameters that are significant for components outside of generators, like the peer
+-- simulator.
+data PointScheduleConfig =
+  PointScheduleConfig {
+    -- | Duration of a tick, for timeouts in the scheduler.
+    pscTickDuration :: DiffTime
+  }
+  deriving (Eq, Show)
+
+defaultPointScheduleConfig :: PointScheduleConfig
+defaultPointScheduleConfig =
+  PointScheduleConfig {pscTickDuration = 0.1}
 
 ----------------------------------------------------------------------------------------------------
 -- Accessors
@@ -559,8 +575,8 @@ data GenesisTest = GenesisTest {
 -- | Create a point schedule from the given block tree.
 --
 -- The first argument determines the scheduling style.
-genSchedule :: ScheduleType -> BlockTree TestBlock -> Maybe PointSchedule
-genSchedule = \case
+genSchedule :: PointScheduleConfig -> ScheduleType -> BlockTree TestBlock -> Maybe PointSchedule
+genSchedule _ = \case
   FastAdversary -> fastAdversaryPointSchedule
   Banal -> banalPointSchedule
   OnlyHonest -> onlyHonestPointSchedule

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -35,6 +35,7 @@ module Test.Consensus.PointSchedule (
   , NodeState (..)
   , Peer (..)
   , PeerId (..)
+  , Peers (..)
   , PointSchedule (..)
   , ScheduleType (..)
   , TestFrag


### PR DESCRIPTION
aka the return of https://github.com/input-output-hk/ouroboros-consensus/pull/436

This pull requests introduces a test to check that timeouts are indeed enforced. This induces some other work needed to achieve this goal:

- We introduce a notion of “peer simulator state view”, which allows to inspect the state of the peer simulator. For now, this view only shows the selected chain (already used in the long range attack test) and the `ChainSync` exceptions (needed in the new timeout tests). We will add there all additional information that we need eventually. This state view is currently only used at the very end of the test but we could imagine (LTL-like?) properties that rely on the state at other moments in the execution. It could also serve as a basis to build “dynamic” point schedule generators.

- We generalise block tree printing to support an arbitrary number of branch. It work previously on only exactly one branch, which wasn't great for tests featuring more branches and would crash for tests featuring no branches (only a trunk) such as the timeout test. This change isn't really related and could be extracted to another PR.

- We split `runTest` in two variants, one that requires to define everything (in particular it does not force exceptions to be failures) and one that is currently used in the long range attack test. We might refine this second one or decide that it is in fact useless later in the future. We shall see when adding more tests. We also generalise `SchedulerConfig` to hold timeouts instead of just a boolean and we expose it to the tests, leaving them in charge of deciding which timeouts they want. Again, we might want to add helpers for those in the future.

- Finally, we add a timeout test. It features only one peer and a dull schedule that advertises the whole chain from the start but has just too many ticks, causing a timeout. It is actually fun to add a `- 1` to the number of ticks and see that the test then gets falsified.