### PR TITLE
Discard the test cases _before_ running the peer simulator if possible?

### DIFF
--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
@@ -38,12 +38,20 @@ prop_longRangeAttack = do
   (genesisTest, schedule) <- genChainsAndSchedule scheduleConfig 1 FastAdversary
   let Classifiers {..} = classifiers genesisTest
 
-  pure $ withMaxSuccess 10 $ runSimOrThrow $
-    runTest (noTimeoutsSchedulerConfig scheduleConfig) genesisTest schedule $ exceptionCounterexample $ \StateView{svSelectedChain} ->
-        classify genesisWindowAfterIntersection "Full genesis window after intersection"
-        $ existsSelectableAdversary ==> not $ isHonestTestFragH svSelectedChain
-        -- TODO
-        -- $ not existsSelectableAdversary ==> immutableTipBeforeFork svSelectedChain
+  -- TODO: not existsSelectableAdversary ==> immutableTipBeforeFork svSelectedChain
+
+  pure $ withMaxSuccess 10 $
+    classify genesisWindowAfterIntersection "Full genesis window after intersection" $
+    existsSelectableAdversary
+    ==>
+    runSimOrThrow $
+      runTest
+        (noTimeoutsSchedulerConfig scheduleConfig)
+        genesisTest
+        schedule
+        $ exceptionCounterexample $ \StateView{svSelectedChain} ->
+            not $ isHonestTestFragH svSelectedChain
+
   where
     isHonestTestFragH :: TestFragH -> Bool
     isHonestTestFragH frag = case headAnchor frag of


### PR DESCRIPTION
This PR is intended only to spark a discussion. Currently, we have:

```haskell
runTest .... $ \stateView ->
  testPremise ==> testConclusion
```

which means that we run the whole schedule before actually checking whether the premise holds. In my example, if `testPremise` depends on `stateView`, we can't really do anything different. However, if it doesn't (like in our current long range attack test case), we can also go for:

```haskell
testPremise
==>
runTest .... $ stateView -> testConclusion
```

which only runs the schedule when the premise holds. This is faster, and potentially a lot faster if a lot of tests are discarded (in the current state of the long range attack test case, we discard a bit less than 2/3 of the test cases). Is there a reason why not to do this? I already used this pattern in https://github.com/input-output-hk/ouroboros-consensus/pull/458 but can of course change that.