### PR TITLE
Disable `dist-newstyle` caching in GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,24 +92,6 @@ jobs:
           cabal-store-${{ env.CABAL_CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.MONTHNUM }}-${{ hashFiles('dependencies.txt') }}
           cabal-store-${{ env.CABAL_CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.MONTHNUM }}-
 
-    # This is used for caching the `dist-newstyle` directory.
-    - name: Store week number as environment variable
-      run: echo "WEEKNUM=$(/usr/bin/date -u '+%W')" >> $GITHUB_ENV
-
-    # Cache the `dist-newstyle` folder.
-    #
-    # See 'restore-cabal-store' for why we use the week number in the primary
-    # key and restore keys.
-    - name: "Cache dist-newstyle"
-      uses: actions/cache@v3
-      if: matrix.ghc!='8.10.7'
-      with:
-        path: dist-newstyle
-        key: cache-dist-${{ env.CABAL_CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.WEEKNUM }}-${{ hashFiles('dependencies.txt') }}
-        restore-keys: |
-          cache-dist-${{ env.CABAL_CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.WEEKNUM }}-${{ hashFiles('dependencies.txt') }}
-          cache-dist-${{ env.CABAL_CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.WEEKNUM }}-
-
     - name: Build dependencies
       id: build-dependencies
       run: cabal build --only-dependencies all -j


### PR DESCRIPTION
# Description

Once again, caching `dist-newstyle` is making CI fail, so I remove the relevant caching steps.