### PR TITLE
Generative point schedule

### DIFF
--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
@@ -85,6 +85,13 @@ data SchedulerConfig =
 
     -- | Config shared with point schedule generators.
     , scSchedule        :: PointScheduleConfig
+
+    -- | A function that can add more ticks once the evaluation came to an end.
+    -- It returns 'Nothing' if it does not wish to extend the point schedule or
+    -- 'Just' a point schedule otherwise. It receive the whole state view which
+    -- contains the point schedule so far as well as other information on the
+    -- current simulation.
+    , scExtender        :: StateView -> Maybe PointSchedule
   }
 
 defaultSchedulerConfig :: PointScheduleConfig -> Asc -> SchedulerConfig
@@ -92,7 +99,8 @@ defaultSchedulerConfig scSchedule asc =
   SchedulerConfig {
     scChainSyncTimeouts = chainSyncTimeouts scSlotLength asc,
     scSlotLength,
-    scSchedule
+    scSchedule,
+    scExtender = const Nothing
   }
   where
     scSlotLength = slotLengthFromSec 20
@@ -102,7 +110,8 @@ noTimeoutsSchedulerConfig scSchedule =
   SchedulerConfig {
     scChainSyncTimeouts = chainSyncNoTimeouts,
     scSlotLength,
-    scSchedule
+    scSchedule,
+    scExtender = const Nothing
   }
   where
     scSlotLength = slotLengthFromSec 20

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
@@ -291,7 +291,8 @@ runPointSchedule schedulerConfig GenesisTest {gtSecurityParam = k, gtBlockTree} 
     svSelectedChain <- atomically $ ChainDB.getCurrentChain chainDb
     pure $ StateView {
       svSelectedChain,
-      svChainSyncExceptions
+      svChainSyncExceptions,
+      svPointSchedule = pointSchedule
       }
   where
     config = defaultCfg k

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/StateView.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/StateView.hs
@@ -4,7 +4,7 @@ module Test.Consensus.PeerSimulator.StateView (
   ) where
 
 import           Ouroboros.Consensus.Util.IOLike (SomeException)
-import           Test.Consensus.PointSchedule (PeerId, TestFragH)
+import           Test.Consensus.PointSchedule (PeerId, PointSchedule, TestFragH)
 
 -- | A record to associate an exception thrown by the ChainSync
 -- thread with the peer that it was running for.
@@ -25,5 +25,8 @@ data StateView = StateView {
     -- servers.
     --
     -- REVIEW: Only the server part?
-    svChainSyncExceptions :: [ChainSyncException]
+    svChainSyncExceptions :: [ChainSyncException],
+
+    -- | The point schedule ran in the simulation.
+    svPointSchedule       :: PointSchedule
   }

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/StateView.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/StateView.hs
@@ -14,7 +14,16 @@ data ChainSyncException = ChainSyncException
        }
     deriving Show
 
+-- | A record that helps inspecting the current state of the simulation. This
+-- contains both information on the peer simulator and on the node under test
+-- (and in particular its ChainDB).
 data StateView = StateView {
+    -- | The chain currently selected by the ChainDB.
     svSelectedChain       :: TestFragH,
+
+    -- | A list of exception raised in threads running scheduled ChainSync
+    -- servers.
+    --
+    -- REVIEW: Only the server part?
     svChainSyncExceptions :: [ChainSyncException]
   }

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE LambdaCase     #-}
 {-# LANGUAGE NamedFieldPuns #-}
 
 module Test.Consensus.PeerSimulator.Tests.Timeouts (tests) where
@@ -28,37 +27,43 @@ import           Test.Tasty.QuickCheck
 import           Test.Util.Orphans.IOLike ()
 
 tests :: TestTree
-tests = testProperty "timeouts" prop_timeouts
+tests = testGroup "timeouts" [
+    testProperty "static" prop_timeouts_static,
+    testProperty "dynamic" prop_timeouts_dynamic
+  ]
 
-prop_timeouts :: QC.Gen QC.Property
-prop_timeouts = do
+stateViewProperty :: StateView -> QC.Property
+stateViewProperty stateView =
+  case svChainSyncExceptions stateView of
+    [] ->
+      counterexample ("result: " ++ condense (svSelectedChain stateView)) False
+    [exn] ->
+      case fromException $ cseException exn of
+        Just (ExceededTimeLimit _) -> property True
+        _ -> counterexample ("exception: " ++ show exn) False
+    exns ->
+      counterexample ("exceptions: " ++ show exns) False
+
+-- | Static variant of the test. We count exactly how many ticks are going to be
+-- necessary to make the test reach a timeout and we create a schedule that
+-- exactly that amount of ticks.
+prop_timeouts_static :: QC.Gen QC.Property
+prop_timeouts_static = do
   genesisTest <- genChains 0
 
   -- Use higher tick duration to avoid the test taking really long
   let scSchedule = PointScheduleConfig {pscTickDuration = 1}
-
       schedulerConfig = defaultSchedulerConfig scSchedule (gtHonestAsc genesisTest)
-
       schedule =
         dullSchedule
           scSchedule
           (fromJust $ mustReplyTimeout (scChainSyncTimeouts schedulerConfig))
           (btTrunk $ gtBlockTree genesisTest)
 
-  pure $ withMaxSuccess 10 $ runSimOrThrow $
-    runTest schedulerConfig genesisTest schedule $ \stateView ->
-      case svChainSyncExceptions stateView of
-        [] ->
-          counterexample ("result: " ++ condense (svSelectedChain stateView)) False
-        [exn] ->
-          case fromException $ cseException exn of
-            Just (ExceededTimeLimit _) -> property True
-            _ -> counterexample ("exception: " ++ show exn) False
-        exns ->
-          counterexample ("exceptions: " ++ show exns) False
+  pure $ runSimOrThrow $
+    runTest schedulerConfig genesisTest schedule stateViewProperty
 
   where
-
     -- A schedule that advertises all the points of the chain from the start but
     -- contains just one too many ticks, therefore reaching the timeouts.
     dullSchedule :: PointScheduleConfig -> DiffTime -> TestFrag -> PointSchedule
@@ -72,3 +77,39 @@ prop_timeouts = do
           maximumNumberOfTicks = round $ timeout / pscTickDuration scheduleConfig
       in
       PointSchedule (tick :| replicate maximumNumberOfTicks tick)
+
+-- | Dynamic variant of the test. We start with one tick but provide an extender
+-- that systematically adds another tick. If no exception is every triggered,
+-- then this test hangs. However, it is conceptually simpler and requires less
+-- inputs than its static counterpart.
+prop_timeouts_dynamic :: QC.Gen QC.Property
+prop_timeouts_dynamic = do
+  genesisTest <- genChains 0
+  let schedule = oneshotSchedule (btTrunk $ gtBlockTree genesisTest)
+
+  -- Use higher tick duration to avoid the test taking really long. Add an
+  -- extender that adds the same tick over and over again until we get a
+  -- ChainSyncException.
+  let scSchedule = PointScheduleConfig {pscTickDuration = 1}
+      schedulerConfig =
+        (defaultSchedulerConfig scSchedule (gtHonestAsc genesisTest)) {
+          scExtender = \stateView ->
+              case svChainSyncExceptions stateView of
+                [] -> Just schedule
+                _  -> Nothing
+          }
+
+  pure $ runSimOrThrow $
+    runTest schedulerConfig genesisTest schedule stateViewProperty
+
+  where
+    -- A schedule that advertises all the points of the chain in one tick.
+    oneshotSchedule :: TestFrag -> PointSchedule
+    oneshotSchedule (AF.Empty _) = error "requires a non-empty block tree"
+    oneshotSchedule (_ AF.:> tipBlock) =
+      let tipPoint = TipPoint $ tipFromHeader tipBlock
+          headerPoint = HeaderPoint $ getHeader tipBlock
+          blockPoint = BlockPoint tipBlock
+          state = Peer HonestPeer $ NodeOnline $ AdvertisedPoints tipPoint headerPoint blockPoint
+          tick = Tick { active = state, peers = Peers state Map.empty }
+      in PointSchedule (tick :| [])

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -255,6 +255,16 @@ defaultPointScheduleConfig :: PointScheduleConfig
 defaultPointScheduleConfig =
   PointScheduleConfig {pscTickDuration = 0.1}
 
+-- | REVIEW: To be future-proof, and to make function types more explicit, I
+-- would much rather have a type for point schedule _extensions_ that would only
+-- contain the types that need to be extended. We would have an operation
+-- 'extend :: PointSchedule -> PointScheduleExtension -> PointSchedule'.
+-- However, it does not work that well from a user point of view without an
+-- empty 'PointSchedule', which we precisely do not have. If 'PointSchedule'
+-- keep containing only ticks, then a 'Semigroup' instance will do just fine.
+instance Semigroup PointSchedule where
+  (<>) ps1 ps2 = PointSchedule (ticks ps1 <> ticks ps2)
+
 ----------------------------------------------------------------------------------------------------
 -- Accessors
 ----------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This PR introduces a mechanism for point schedules to be extended while running them. The commits are meant to be read one by one. This PR is not ready to be merged yet as the actual extension is untested.