### PR TITLE
Missing (general) instances for the `LegacyBlock`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
        fail-fast: false
        matrix:
-         ghc: ["8.10.7", "9.2.8", "9.6.2"]
+         ghc: ["8.10.7", "9.2.8", "9.6.3"]
          cabal: ["3.10.1.0"]
          os: [ubuntu-latest]
     env:

--- a/ouroboros-consensus-cardano-legacy-block/ouroboros-consensus-cardano-legacy-block.cabal
+++ b/ouroboros-consensus-cardano-legacy-block/ouroboros-consensus-cardano-legacy-block.cabal
@@ -53,7 +53,6 @@ library
     Legacy.Cardano.CanonicalTxIn
     Legacy.Cardano.Ledger
     Legacy.Convert
-    Legacy.LegacyBlock
     Legacy.Shelley.Ledger
     Ouroboros.Consensus.HardFork.Trans
     Ouroboros.Consensus.Legacy.Block
@@ -73,6 +72,7 @@ library
     , cardano-prelude
     , cardano-protocol-tpraos       >=1.0.1 && <1.1
     , cardano-slotting
+    , cborg
     , containers                    >=0.5   && <0.7
     , mtl                           >=2.2   && <2.4
     , nothunks
@@ -80,5 +80,6 @@ library
     , ouroboros-consensus-cardano
     , ouroboros-consensus-protocol
     , ouroboros-network-api
+    , serialise
     , small-steps
     , sop-core

--- a/ouroboros-consensus-cardano-legacy-block/ouroboros-consensus-cardano-legacy-block.cabal
+++ b/ouroboros-consensus-cardano-legacy-block/ouroboros-consensus-cardano-legacy-block.cabal
@@ -56,6 +56,8 @@ library
     Legacy.LegacyBlock
     Legacy.Shelley.Ledger
     Ouroboros.Consensus.HardFork.Trans
+    Ouroboros.Consensus.Legacy.Block
+    Ouroboros.Consensus.Legacy.Util
 
   build-depends:
     , base                          >=4.14  && <4.19

--- a/ouroboros-consensus-cardano-legacy-block/src/Legacy/Cardano/Block.hs
+++ b/ouroboros-consensus-cardano-legacy-block/src/Legacy/Cardano/Block.hs
@@ -9,9 +9,9 @@ module Legacy.Cardano.Block (
   ) where
 
 import           Data.Kind
-import           Legacy.LegacyBlock
 import           Ouroboros.Consensus.Byron.Ledger.Block
 import           Ouroboros.Consensus.Cardano.Block
+import           Ouroboros.Consensus.Legacy.Block
 import           Ouroboros.Consensus.Protocol.Praos
 import           Ouroboros.Consensus.Protocol.TPraos
 import           Ouroboros.Consensus.Shelley.Ledger

--- a/ouroboros-consensus-cardano-legacy-block/src/Legacy/Cardano/CanHardFork.hs
+++ b/ouroboros-consensus-cardano-legacy-block/src/Legacy/Cardano/CanHardFork.hs
@@ -44,7 +44,6 @@ import qualified Data.SOP.Tails as Tails
 import           Data.Void (absurd)
 import           Legacy.Byron.Ledger ()
 import           Legacy.Cardano.Block
-import           Legacy.LegacyBlock
 import           Legacy.Shelley.Ledger ()
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Byron.Ledger
@@ -60,6 +59,7 @@ import           Ouroboros.Consensus.HardFork.History (Bound (boundSlot),
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Ledger.Tables.Utils
+import           Ouroboros.Consensus.Legacy.Block
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Protocol.PBFT.State (PBftState)
 import qualified Ouroboros.Consensus.Protocol.PBFT.State as PBftState

--- a/ouroboros-consensus-cardano-legacy-block/src/Legacy/Cardano/Ledger.hs
+++ b/ouroboros-consensus-cardano-legacy-block/src/Legacy/Cardano/Ledger.hs
@@ -16,12 +16,12 @@ import           GHC.Stack (HasCallStack)
 import           Legacy.Cardano.Block
 import           Legacy.Cardano.CanHardFork (LegacyCardanoHardForkConstraints)
 import           Legacy.Cardano.CanonicalTxIn ()
-import           Legacy.LegacyBlock
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Cardano ()
 import           Ouroboros.Consensus.Cardano.Block
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Tables.Utils
+import           Ouroboros.Consensus.Legacy.Block
 
 {-------------------------------------------------------------------------------
   Ticking

--- a/ouroboros-consensus-cardano-legacy-block/src/Legacy/Convert.hs
+++ b/ouroboros-consensus-cardano-legacy-block/src/Legacy/Convert.hs
@@ -63,7 +63,6 @@ import           Data.SOP.Counting
 import           Data.SOP.Functors
 import           Data.SOP.Strict
 import           Legacy.Cardano
-import           Legacy.LegacyBlock
 import           Ouroboros.Consensus.Block.Abstract
 import           Ouroboros.Consensus.Cardano.Block
 import           Ouroboros.Consensus.Config
@@ -75,6 +74,7 @@ import           Ouroboros.Consensus.HardFork.History.Summary
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
+import           Ouroboros.Consensus.Legacy.Block
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.TypeFamilyWrappers
 

--- a/ouroboros-consensus-cardano-legacy-block/src/Legacy/Shelley/Ledger.hs
+++ b/ouroboros-consensus-cardano-legacy-block/src/Legacy/Shelley/Ledger.hs
@@ -21,18 +21,20 @@ import           Cardano.Slotting.EpochInfo
 import qualified Control.Exception as Exception
 import           Control.Monad.Except
 import qualified Control.State.Transition.Extended as STS
+import           Data.Coerce (coerce)
 import           Data.Functor ((<&>))
 import           Data.Functor.Identity
-import           Legacy.LegacyBlock
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Cardano.Block
+import           Ouroboros.Consensus.Config (castTopLevelConfig)
 import           Ouroboros.Consensus.HardFork.History.Util
-import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.Query
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Ledger.Tables.Utils
+import           Ouroboros.Consensus.Legacy.Block
+import           Ouroboros.Consensus.Legacy.Util
 import           Ouroboros.Consensus.Protocol.Ledger.Util (isNewEpoch)
 import           Ouroboros.Consensus.Shelley.Ledger
 import           Ouroboros.Consensus.Shelley.Protocol.Abstract (mkHeaderView)
@@ -225,12 +227,6 @@ applyHelper f cfg (LegacyBlock blk) (TickedLegacyLedgerState stBefore) = do
   Queries
 -------------------------------------------------------------------------------}
 
-castExtLedgerState ::
-     ExtLedgerState (LegacyBlock (ShelleyBlock proto era)) EmptyMK
-  -> ExtLedgerState (ShelleyBlock proto era) EmptyMK
-castExtLedgerState (ExtLedgerState st chaindep) =
-  ExtLedgerState (getLegacyLedgerState st) (castHeaderState chaindep)
-
 instance ( LedgerSupportsProtocol (ShelleyBlock proto era)
          , ShelleyCompatible proto era
          ) => BlockSupportsLedgerQuery (LegacyBlock (ShelleyBlock proto era)) where
@@ -248,132 +244,7 @@ instance ( LedgerSupportsProtocol (ShelleyBlock proto era)
       (SQFLookupTables, GetCBOR q') ->
         mkSerialised (encodeShelleyResult maxBound q') $
         answerPureBlockQuery cfg (LegacyBlockQuery q') ext
-      (SQFNoTables, _) -> answerPureBlockQuery (castExtLedgerCfg cfg) q $ castExtLedgerState ext
+      (SQFNoTables, _) -> answerPureBlockQuery (castExtLedgerCfg castTopLevelConfig cfg) q $ castExtLedgerState coerce ext
 
   answerBlockQueryLookup _cfg q _dlv = case q of {}
   answerBlockQueryTraverse _cfg q _dlv = case q of {}
-
-instance SameDepIndex2 (BlockQuery (LegacyBlock (ShelleyBlock proto era))) where
-  sameDepIndex2 (LegacyBlockQuery GetLedgerTip) (LegacyBlockQuery GetLedgerTip)
-    = Just Refl
-  sameDepIndex2 (LegacyBlockQuery GetLedgerTip) _
-    = Nothing
-  sameDepIndex2 (LegacyBlockQuery GetEpochNo) (LegacyBlockQuery GetEpochNo)
-    = Just Refl
-  sameDepIndex2 (LegacyBlockQuery GetEpochNo) _
-    = Nothing
-  sameDepIndex2 (LegacyBlockQuery (GetNonMyopicMemberRewards creds)) (LegacyBlockQuery (GetNonMyopicMemberRewards creds'))
-    | creds == creds'
-    = Just Refl
-    | otherwise
-    = Nothing
-  sameDepIndex2 (LegacyBlockQuery (GetNonMyopicMemberRewards _)) _
-    = Nothing
-  sameDepIndex2 (LegacyBlockQuery GetCurrentPParams) (LegacyBlockQuery GetCurrentPParams)
-    = Just Refl
-  sameDepIndex2 (LegacyBlockQuery GetCurrentPParams) _
-    = Nothing
-  sameDepIndex2 (LegacyBlockQuery GetProposedPParamsUpdates) (LegacyBlockQuery GetProposedPParamsUpdates)
-    = Just Refl
-  sameDepIndex2 (LegacyBlockQuery GetProposedPParamsUpdates) _
-    = Nothing
-  sameDepIndex2 (LegacyBlockQuery GetStakeDistribution) (LegacyBlockQuery GetStakeDistribution)
-    = Just Refl
-  sameDepIndex2 (LegacyBlockQuery GetStakeDistribution) _
-    = Nothing
-  sameDepIndex2 (LegacyBlockQuery (GetUTxOByAddress addrs)) (LegacyBlockQuery (GetUTxOByAddress addrs'))
-    | addrs == addrs'
-    = Just Refl
-    | otherwise
-    = Nothing
-  sameDepIndex2 (LegacyBlockQuery (GetUTxOByAddress _)) _
-    = Nothing
-  sameDepIndex2 (LegacyBlockQuery GetUTxOWhole) (LegacyBlockQuery GetUTxOWhole)
-    = Just Refl
-  sameDepIndex2 (LegacyBlockQuery GetUTxOWhole) _
-    = Nothing
-  sameDepIndex2 (LegacyBlockQuery DebugEpochState) (LegacyBlockQuery DebugEpochState)
-    = Just Refl
-  sameDepIndex2 (LegacyBlockQuery DebugEpochState) _
-    = Nothing
-  sameDepIndex2 (LegacyBlockQuery (GetCBOR q)) (LegacyBlockQuery (GetCBOR q'))
-    = (\Refl -> Refl) <$> sameDepIndex2 q q'
-  sameDepIndex2 (LegacyBlockQuery (GetCBOR _)) _
-    = Nothing
-  sameDepIndex2 (LegacyBlockQuery (GetFilteredDelegationsAndRewardAccounts creds))
-               (LegacyBlockQuery (GetFilteredDelegationsAndRewardAccounts creds'))
-    | creds == creds'
-    = Just Refl
-    | otherwise
-    = Nothing
-  sameDepIndex2 (LegacyBlockQuery (GetFilteredDelegationsAndRewardAccounts _)) _
-    = Nothing
-  sameDepIndex2 (LegacyBlockQuery GetGenesisConfig) (LegacyBlockQuery GetGenesisConfig)
-    = Just Refl
-  sameDepIndex2 (LegacyBlockQuery GetGenesisConfig) _
-    = Nothing
-  sameDepIndex2 (LegacyBlockQuery DebugNewEpochState) (LegacyBlockQuery DebugNewEpochState)
-    = Just Refl
-  sameDepIndex2 (LegacyBlockQuery DebugNewEpochState) _
-    = Nothing
-  sameDepIndex2 (LegacyBlockQuery DebugChainDepState) (LegacyBlockQuery DebugChainDepState)
-    = Just Refl
-  sameDepIndex2 (LegacyBlockQuery DebugChainDepState) _
-    = Nothing
-  sameDepIndex2 (LegacyBlockQuery GetRewardProvenance) (LegacyBlockQuery GetRewardProvenance)
-    = Just Refl
-  sameDepIndex2 (LegacyBlockQuery GetRewardProvenance) _
-    = Nothing
-  sameDepIndex2 (LegacyBlockQuery (GetUTxOByTxIn addrs)) (LegacyBlockQuery (GetUTxOByTxIn addrs'))
-    | addrs == addrs'
-    = Just Refl
-    | otherwise
-    = Nothing
-  sameDepIndex2 (LegacyBlockQuery (GetUTxOByTxIn _)) _
-    = Nothing
-  sameDepIndex2 (LegacyBlockQuery GetStakePools) (LegacyBlockQuery GetStakePools)
-    = Just Refl
-  sameDepIndex2 (LegacyBlockQuery GetStakePools) _
-    = Nothing
-  sameDepIndex2 (LegacyBlockQuery (GetStakePoolParams poolids)) (LegacyBlockQuery (GetStakePoolParams poolids'))
-    | poolids == poolids'
-    = Just Refl
-    | otherwise
-    = Nothing
-  sameDepIndex2 (LegacyBlockQuery (GetStakePoolParams _)) _
-    = Nothing
-  sameDepIndex2 (LegacyBlockQuery GetRewardInfoPools) (LegacyBlockQuery GetRewardInfoPools)
-    = Just Refl
-  sameDepIndex2 (LegacyBlockQuery GetRewardInfoPools) _
-    = Nothing
-  sameDepIndex2 (LegacyBlockQuery (GetPoolState poolids)) (LegacyBlockQuery (GetPoolState poolids'))
-    | poolids == poolids'
-    = Just Refl
-    | otherwise
-    = Nothing
-  sameDepIndex2 (LegacyBlockQuery (GetPoolState _)) _
-    = Nothing
-  sameDepIndex2 (LegacyBlockQuery (GetStakeSnapshots poolid)) (LegacyBlockQuery (GetStakeSnapshots poolid'))
-    | poolid == poolid'
-    = Just Refl
-    | otherwise
-    = Nothing
-  sameDepIndex2 (LegacyBlockQuery (GetStakeSnapshots _)) _
-    = Nothing
-  sameDepIndex2 (LegacyBlockQuery (GetPoolDistr poolids)) (LegacyBlockQuery (GetPoolDistr poolids'))
-    | poolids == poolids'
-    = Just Refl
-    | otherwise
-    = Nothing
-  sameDepIndex2 (LegacyBlockQuery (GetPoolDistr _)) _
-    = Nothing
-  sameDepIndex2 (LegacyBlockQuery (GetStakeDelegDeposits stakeCreds)) (LegacyBlockQuery (GetStakeDelegDeposits stakeCreds'))
-    | stakeCreds == stakeCreds'
-    = Just Refl
-    | otherwise
-    = Nothing
-  sameDepIndex2 (LegacyBlockQuery (GetStakeDelegDeposits _)) _
-    = Nothing
-  sameDepIndex2 (LegacyBlockQuery GetConstitutionHash) (LegacyBlockQuery GetConstitutionHash)
-    = Just Refl
-  sameDepIndex2 (LegacyBlockQuery GetConstitutionHash) _ = Nothing

--- a/ouroboros-consensus-cardano-legacy-block/src/Ouroboros/Consensus/Legacy/Block.hs
+++ b/ouroboros-consensus-cardano-legacy-block/src/Ouroboros/Consensus/Legacy/Block.hs
@@ -20,7 +20,7 @@
 {-# LANGUAGE UndecidableInstances       #-}
 {-# LANGUAGE ViewPatterns               #-}
 
-module Legacy.LegacyBlock (
+module Ouroboros.Consensus.Legacy.Block (
     BlockConfig (..)
   , BlockQuery (..)
   , CodecConfig (..)

--- a/ouroboros-consensus-cardano-legacy-block/src/Ouroboros/Consensus/Legacy/Util.hs
+++ b/ouroboros-consensus-cardano-legacy-block/src/Ouroboros/Consensus/Legacy/Util.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TypeFamilies     #-}
+{-# LANGUAGE TypeOperators    #-}
 
 module Ouroboros.Consensus.Legacy.Util (
     castExtLedgerCfg

--- a/ouroboros-consensus-cardano-legacy-block/src/Ouroboros/Consensus/Legacy/Util.hs
+++ b/ouroboros-consensus-cardano-legacy-block/src/Ouroboros/Consensus/Legacy/Util.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeFamilies     #-}
+
+module Ouroboros.Consensus.Legacy.Util (
+    castExtLedgerCfg
+  , castExtLedgerState
+  ) where
+
+import           Data.Coerce (Coercible)
+import           Ouroboros.Consensus.Block.Abstract (BlockProtocol)
+import           Ouroboros.Consensus.Config (TopLevelConfig)
+import           Ouroboros.Consensus.HeaderValidation (HasAnnTip (..),
+                     castHeaderState)
+import           Ouroboros.Consensus.Ledger.Basics (LedgerState)
+import           Ouroboros.Consensus.Ledger.Extended (ExtLedgerCfg (..),
+                     ExtLedgerState (..))
+import           Ouroboros.Consensus.Protocol.Abstract (ConsensusProtocol (..))
+
+castExtLedgerState ::
+     ( Coercible (ChainDepState (BlockProtocol blk ))
+                 (ChainDepState (BlockProtocol blk'))
+     , TipInfo blk ~ TipInfo blk'
+     )
+  => (LedgerState blk mk -> LedgerState blk' mk)
+  -> ExtLedgerState blk mk
+  -> ExtLedgerState blk' mk
+castExtLedgerState f (ExtLedgerState st chaindep) =
+  ExtLedgerState (f st) (castHeaderState chaindep)
+
+castExtLedgerCfg ::
+     (TopLevelConfig blk -> TopLevelConfig blk')
+  -> ExtLedgerCfg blk
+  -> ExtLedgerCfg blk'
+castExtLedgerCfg f (ExtLedgerCfg t) = ExtLedgerCfg $ f t


### PR DESCRIPTION
# Description

Part of #344.

The first commit moves the main `LegacyBlock` module to a new namespace. The second commit fixes compile errors and adds missing instances to the `Legacy.Block` module. It is probably best to review the commits separately, because those diffs are clearer to look at than the total diff
