### PR TITLE
Test that consensus emits valid CBOR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
         if [ -f baseline-mempool-benchmarks.csv ]; then
           cabal new-run ouroboros-consensus:mempool-bench -- \
           --timeout=60 --baseline baseline-mempool-benchmarks.csv \
-          --fail-if-slower 20 \
+          --fail-if-slower 100 \
           +RTS -T
         else
           echo "No baseline benchmarks found. This likely happened when adding a new GHC version to the build matrix."

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/Consensus/Cardano/ByronCompatibility.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/Consensus/Cardano/ByronCompatibility.hs
@@ -61,7 +61,7 @@ tests = adjustOption reduceTests $
             , testGroup "SerialiseNodeToNode" $
                 roundtrip_SerialiseNodeToNode   byronToCardanoCodeConfig
             , testGroup "SerialiseNodeToClient" $
-                roundtrip_SerialiseNodeToClient byronToCardanoCodeConfig
+                roundtrip_SerialiseNodeToClient (const CheckCBORValidity) byronToCardanoCodeConfig
             ]
       , testGroup "Cardano to Byron" [
               testProperty "roundtrip block" $
@@ -71,7 +71,7 @@ tests = adjustOption reduceTests $
             , testGroup "SerialiseNodeToNode" $
                 roundtrip_SerialiseNodeToNode   cardanoToByronCodeConfig
             , testGroup "SerialiseNodeToClient" $
-                roundtrip_SerialiseNodeToClient cardanoToByronCodeConfig
+                roundtrip_SerialiseNodeToClient (const CheckCBORValidity) cardanoToByronCodeConfig
             ]
       ]
   where

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/Consensus/Cardano/Serialisation.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/Consensus/Cardano/Serialisation.hs
@@ -19,18 +19,24 @@ import           Ouroboros.Consensus.Shelley.Node ()
 import           Ouroboros.Consensus.Storage.Serialisation
 import           Ouroboros.Consensus.Util (Dict (..))
 import           Ouroboros.Network.Block (Serialised (..))
+import qualified Test.Consensus.Cardano.Examples as Cardano.Examples
 import           Test.Consensus.Cardano.Generators (epochSlots)
 import           Test.Consensus.Cardano.MockCrypto (MockCryptoCompatByron)
 import           Test.Tasty
-import           Test.Tasty.QuickCheck
+import           Test.Tasty.QuickCheck (Property, testProperty, (===))
 import           Test.Util.Orphans.Arbitrary ()
 import           Test.Util.Serialisation.Roundtrip
 
 tests :: TestTree
 tests = testGroup "Cardano"
-    [ roundtrip_all testCodecCfg dictNestedHdr
+    [ testGroup "Examples roundtrip" $ examplesRoundtrip Cardano.Examples.codecConfig Cardano.Examples.examples
+    , roundtrip_all_skipping result testCodecCfg dictNestedHdr
     , testProperty "BinaryBlockInfo sanity check" prop_CardanoBinaryBlockInfo
     ]
+  where
+    -- See https://github.com/input-output-hk/cardano-ledger/issues/3800
+    result "roundtrip Result" = DoNotCheckCBORValidity
+    result _                  = CheckCBORValidity
 
 testCodecCfg :: CardanoCodecConfig MockCryptoCompatByron
 testCodecCfg =

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -359,6 +359,7 @@ library unstable-consensus-testlib
     , ouroboros-consensus
     , ouroboros-network-api
     , ouroboros-network-mock
+    , pretty-simple
     , QuickCheck
     , quickcheck-state-machine
     , quiet
@@ -368,9 +369,11 @@ library unstable-consensus-testlib
     , sop-extras
     , strict-sop-core
     , tasty
+    , tasty-expected-failure
     , tasty-golden
     , tasty-quickcheck
     , template-haskell
+    , text
     , time
     , tree-diff
     , utf8-string


### PR DESCRIPTION
Fixes https://github.com/input-output-hk/ouroboros-network/issues/3099

Sadly some CBOR validity tests need to be skipped due to:

- https://github.com/input-output-hk/cardano-ledger/issues/3800
- https://github.com/input-output-hk/cardano-ledger/issues/3741
- https://github.com/input-output-hk/cardano-ledger/issues/3740

This patch introduces an ad-hoc filtering mechanism to fix problems with legacy encoders.