### PR TITLE
Remove peers from Tick

### DIFF
--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
@@ -246,7 +246,7 @@ runScheduler ::
   PointSchedule ->
   Map PeerId (PeerResources m) ->
   m ()
-runScheduler config tracer (PointSchedule ps) peers = do
+runScheduler config tracer PointSchedule {ticks=ps} peers = do
   traceWith tracer "Schedule is:"
   for_ ps  $ \tick -> traceWith tracer $ "  " ++ condense tick
   traceStartOfTimePoetry

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -5,7 +5,6 @@ module Test.Consensus.PeerSimulator.Tests.Timeouts (tests) where
 
 import           Control.Monad.IOSim (runSimOrThrow)
 import           Data.List.NonEmpty (NonEmpty ((:|)))
-import qualified Data.Map as Map
 import           Data.Maybe (fromJust)
 import           Ouroboros.Consensus.Block (getHeader)
 import           Ouroboros.Consensus.Util.Condense
@@ -68,7 +67,7 @@ prop_timeouts = do
           headerPoint = HeaderPoint $ getHeader tipBlock
           blockPoint = BlockPoint tipBlock
           state = Peer HonestPeer $ NodeOnline $ AdvertisedPoints tipPoint headerPoint blockPoint
-          tick = Tick { active = state, peers = Peers state Map.empty }
+          tick = Tick { active = state }
           maximumNumberOfTicks = round $ timeout / pscTickDuration scheduleConfig
       in
       PointSchedule (tick :| replicate maximumNumberOfTicks tick)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -70,4 +70,4 @@ prop_timeouts = do
           tick = Tick { active = state }
           maximumNumberOfTicks = round $ timeout / pscTickDuration scheduleConfig
       in
-      PointSchedule (tick :| replicate maximumNumberOfTicks tick)
+      PointSchedule (tick :| replicate maximumNumberOfTicks tick) (HonestPeer :| [])

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -208,7 +208,7 @@ instance Functor Peers where
 
 -- | A tick is an entry in a 'PointSchedule', containing the peer that is
 -- going to change state.
-data Tick =
+newtype Tick =
   Tick {
     active :: Peer NodeState
   }

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -357,11 +357,8 @@ balanced ::
   Peers [NodeState] ->
   Maybe PointSchedule
 balanced states =
-  pointSchedule (map step activeSeq) (getPeerIds states)
+  pointSchedule (map Tick activeSeq) (getPeerIds states)
   where
-    step :: Peer NodeState -> Tick
-    step active = Tick {active}
-
     -- Sequence containing the first state of all the nodes in order, then the
     -- second in order, etc.
     activeSeq = concat $ transpose $ sequenceA (honest states) : (sequenceA <$> Map.elems (others states))


### PR DESCRIPTION
The peers field was only used to extract the identifiers of peers.

This PR adds a list of PeerId to PointSchedule and removes the peers field from Tick.
