### PR TITLE
Fix changelog scripts for CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   consensus-changelog:
 
-    name: Changelog sanity check
+    name: Changelogs
 
     runs-on: ubuntu-latest
 
@@ -25,16 +25,17 @@ jobs:
 
     - uses: actions/checkout@v4
       with:
-        path: 'this-pr'
+        fetch-depth: 0
 
-    - uses: actions/checkout@v4
-      with:
-        ref: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
-        path: 'main'
-
-    - run: CI=1 ./this-pr/scripts/ci/check-changelogs.sh main this-pr
+    - env:
+        BASE_REF: ${{ github.event.pull_request.base.ref }}
+        NO_CHANGELOG_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'no changelog') }}
+      run: ./scripts/ci/check-changelogs.sh
 
   check-cabal-files:
+
+    name: Cabal files check
+
     runs-on: ubuntu-latest
 
     steps:
@@ -47,9 +48,20 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Cabal check
-      run: ./scripts/ci/check-cabal-files.sh
+      run: |
+        for x in $(find . -name '*.cabal' | grep -vE 'dist-newstyle|asserts\.cabal' | cut -c 3-); do
+          (
+            d=$(dirname $x)
+            echo "== $d =="
+            cd $d
+            cabal check
+          )
+        done
 
   check-release-badges:
+
+    name: Release badges are updated
+
     runs-on: ubuntu-latest
 
     steps:

--- a/scripts/ci/check-changelogs.sh
+++ b/scripts/ci/check-changelogs.sh
@@ -1,90 +1,39 @@
 #!/usr/bin/env bash
 
-# set -x
-# For each one of the two bundles, check that:
-# (1) the version in the changelog is the same as the package's cabal file
-# (2) if the version was changed from the last one on the changelog then there
-#     must be no remaining changelog files
-# otherwise exits with exit code 1
+# Expected env vars:
+# - NO_CHANGELOG_LABEL: disables the check for changelog fragments additions
+# - BASE_REF: what to compare this branch against
 
-# Offline use:
-#    ./scripts/ci/check-changelogs.sh main
+packages=(ouroboros-consensus ouroboros-consensus-diffusion ouroboros-consensus-protocol ouroboros-consensus-cardano sop-extras strict-sop-core)
 
-# CI uses:
-#    CI=1 ./this-pr/scripts/ci/check-changelogs.sh main this-pr
-
-TARGET=${1:-"main"}
-BASE=${2:-"."}
-
-function get_last_version {
-    cd $BASE
-    if [[ -n $CI ]];
-    then grep "<a id=" $1/CHANGELOG.md  | cut -d\' -f2 | cut -d- -f2 | head -n1
-    else grep "<a id=" $1/CHANGELOG.md  | cut -d\' -f2 | cut -d- -f2 | head -n1
-    fi
-}
-
-function cabal_files_version {
-    cd $BASE
-    if [[ -n $CI ]];
-    then cat $1/$1.cabal | grep "^version" | rev | cut -d' ' -f1 | rev
-    else cat $1/$1.cabal | grep "^version" | rev | cut -d' ' -f1 | rev
-    fi
-}
-
-function this_merge_updates_version {
-    cd $BASE
-    if [[ -n $CI ]];
-    then diff -w ../$TARGET/$1/$1.cabal $1/$1.cabal | grep "^> version"
-    else git diff -b $TARGET HEAD -- $1/$1.cabal | grep "^+version"
-    fi
-}
-
-function this_merge_adds_fragment {
-    if [[ -n $CI ]];
-    then echo "$(($(ls -A1 $BASE/$1/changelog.d | wc -l) - $(ls -A1 $TARGET/$1/changelog.d | wc -l)))"
-    else git diff $TARGET HEAD --name-only --diff-filter=AR | grep $1/changelog.d | wc -l
-    fi
-}
-
-function files-changed {
-    if [[ -n $CI ]]
-    then diff -x .git -x README.md -x changelog.d -x scripts -r $TARGET/$1 $BASE/$1
-    else git diff $TARGET HEAD --name-only | grep -v README | grep -v changelog.d | grep "^$1/" | wc -l
-    fi
-}
-
-function check {
-    pkg=$1
-
-    echo "Checking consistency of $pkg"
-
-    if [[ $(files-changed $pkg) -gt 0 ]]; then
-
-        version=$(cabal_files_version $pkg)
-        last_version=$(get_last_version $pkg)
-        updated_versions=$(this_merge_updates_version $pkg)
-        adds_fragment=$(this_merge_adds_fragment $pkg)
-
-        if [[ $version != $last_version ]]; then
-            echo "ERROR: In $pkg, last version in the changelog ($last_version) is not the same as in the package's cabal file ($version)"
-            exit 1
-        elif [[ -n "$updated_versions" && $(ls -A1 $BASE/$pkg/changelog.d | wc -l) != 1 ]]; then
-            echo "ERROR: In $pkg, last commit updated the version but there are remaining changelog fragments"
-            exit 1
-        elif [[ -z "$updated_versions" && $adds_fragment -lt 1 ]]; then
-            echo "ERROR: In $pkg, there are no new changelog fragments comparing to pkg. This is enforced. Push an empty fragment if there is nothing to mention."
-            echo "   new fragments - old fragments = $adds_fragment"
-            exit 1
-        else
-            printf "version:       %s\nnew version:   %s\nnew fragments: $adds_fragment\nOK\n\n" $version $updated_versions $last_version
-        fi
+echo "Checking that changelog and .cabal versions match:"
+for p in "${packages[@]}"; do
+    if [[ $(grep -E "^<a id='changelog-" "$p/CHANGELOG.md" | head -n1) =~ $(grep -E "^version:" "$p/$p.cabal" | rev | cut -d' ' -f1 | rev) ]]; then
+        printf "\t- %s OK\n" "$p"
     else
-        printf "No source files changed in %s\n\n" $pkg
+        printf "\t- %s FAIL\n" "$p"
+        exit 1
     fi
-}
+done
 
-check ouroboros-consensus
-check ouroboros-consensus-protocol
-check ouroboros-consensus-cardano
-check ouroboros-consensus-diffusion
+if [ "${NO_CHANGELOG_LABEL}" = "true" ]; then
+    exit 0
+else
+    echo "Checking for new changelog fragments:"
+    for p in "${packages[@]}"; do
+        printf "\t- %s\n" "$p"
+        if ! git diff --quiet --name-only "origin/${BASE_REF}" -- "$p/***.hs"|| ! git diff --quiet --name-only "origin/${BASE_REF}" -- "$p/***.cabal"; then
+            if ! git diff --quiet --name-only --diff-filter=A "origin/${BASE_REF}" -- "$p/changelog.d" ; then
+                printf "\t\tNew fragments found. OK.\n"
+                git diff --name-only --diff-filter=A "origin/${BASE_REF}" -- "$p/changelog.d" | sed 's/^/\t\t- /g'
+            else
+                printf "\t\tNo new fragments found, but code changed. Please push a fragment or add the \"no changelog\" label to the PR. The diff follows:\n"
+                git --no-pager -c color.diff=always diff "origin/${BASE_REF}" -- "$p/***.hs" | sed 's/^/diff> /g'
+                git --no-pager -c color.diff=always diff "origin/${BASE_REF}" -- "$p/***.cabal" | sed 's/^/diff> /g'
+                exit 1
+            fi
+        else
+            printf "\t\tNo haskell/cabal code changes\n"
+        fi
+    done
+fi

--- a/scripts/docs/haddocks.sh
+++ b/scripts/docs/haddocks.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Build haddock documentation and an index for all projects in
 # `ouroboros-consensus` repository.
 #

--- a/sop-extras/CHANGELOG.md
+++ b/sop-extras/CHANGELOG.md
@@ -1,5 +1,8 @@
-# Revision history for sop-extras
+# sop-extras Changelog
 
-## 0.1.0.0 -- YYYY-mm-dd
+# Changelog entries
+
+<a id='changelog-0.1.0.0'></a>
+## 0.1.0.0 — 2023-08-25
 
 * First version. Released on an unsuspecting world.

--- a/sop-extras/changelog.d/scriv.ini
+++ b/sop-extras/changelog.d/scriv.ini
@@ -1,0 +1,13 @@
+[scriv]
+format = md
+insert_marker = Changelog entries
+md_header_level = 2
+version = literal: sop-extras.cabal: version
+categories = Patch, Non-Breaking, Breaking
+end_marker = scriv-end-here
+fragment_directory = changelog.d
+ghrel_template = {{body}}
+main_branches = master, main, develop
+new_fragment_template = file: new_fragment.${config:format}.j2
+output_file = CHANGELOG.${config:format}
+skip_fragments = README.*

--- a/strict-sop-core/CHANGELOG.md
+++ b/strict-sop-core/CHANGELOG.md
@@ -1,5 +1,8 @@
-# Revision history for strict-sop-core
+# Strict sop-core Changelog
 
-## 0.1.0.0 -- YYYY-mm-dd
+# Changelog entries
+
+<a id='changelog-0.1.0.0'></a>
+## 0.1.0.0 — 2023-08-25
 
 * First version. Released on an unsuspecting world.

--- a/strict-sop-core/changelog.d/scriv.ini
+++ b/strict-sop-core/changelog.d/scriv.ini
@@ -1,0 +1,13 @@
+[scriv]
+format = md
+insert_marker = Changelog entries
+md_header_level = 2
+version = literal: strict-sop-core.cabal: version
+categories = Patch, Non-Breaking, Breaking
+end_marker = scriv-end-here
+fragment_directory = changelog.d
+ghrel_template = {{body}}
+main_branches = master, main, develop
+new_fragment_template = file: new_fragment.${config:format}.j2
+output_file = CHANGELOG.${config:format}
+skip_fragments = README.*


### PR DESCRIPTION
# Description

The CI check will fail if the latest version in the changelog is different from the version in the cabal file.

It will also fail if the PR doesn't have the `no changelog` tag and there are haskell/cabal changes but no corresponding fragment.