### PR TITLE
Decouple db-analyser internals from cardano details (`BlockType`)

### DIFF
--- a/ouroboros-consensus-cardano/app/DBAnalyser/Parsers.hs
+++ b/ouroboros-consensus-cardano/app/DBAnalyser/Parsers.hs
@@ -59,7 +59,7 @@ parseSelectDB = asum [
 
 
 parseValidationPolicy :: Parser (Maybe ValidateBlocks)
-parseValidationPolicy = parseMaybe $ asum [
+parseValidationPolicy = optional $ asum [
       flag' ValidateAllBlocks $ mconcat [
           long "validate-all-blocks"
         , help "Validate all blocks of the Volatile and Immutable DB"
@@ -159,9 +159,6 @@ pMaybeOutputFile =
       <> help "Optional output file. Default is to write to stdout."
       <> completer (bashCompleter "file")
       )
-
-parseMaybe ::  Parser a -> Parser (Maybe a)
-parseMaybe parser = asum [Just <$> parser, pure Nothing]
 
 {-------------------------------------------------------------------------------
   Parse BlockType-specific arguments

--- a/ouroboros-consensus-cardano/app/DBTruncater/Parsers.hs
+++ b/ouroboros-consensus-cardano/app/DBTruncater/Parsers.hs
@@ -5,12 +5,14 @@ import           DBAnalyser.Parsers
 import           Options.Applicative
 import           Ouroboros.Consensus.Block.Abstract
 
-commandLineParser :: Parser DBTruncaterConfig
-commandLineParser = DBTruncaterConfig
-  <$> parseChainDBPath
-  <*> parseTruncateAfter
-  <*> blockTypeParser
-  <*> parseVerbose
+commandLineParser :: Parser (DBTruncaterConfig, BlockType)
+commandLineParser = (,) <$> parseDBTruncaterConfig <*> blockTypeParser
+
+parseDBTruncaterConfig :: Parser DBTruncaterConfig
+parseDBTruncaterConfig = DBTruncaterConfig
+    <$> parseChainDBPath
+    <*> parseTruncateAfter
+    <*> parseVerbose
   where
     parseChainDBPath = strOption $
       mconcat
@@ -19,7 +21,6 @@ commandLineParser = DBTruncaterConfig
         , metavar "PATH"
         ]
     parseVerbose = switch (long "verbose" <> help "Enable verbose logging")
-
 parseTruncateAfter :: Parser TruncateAfter
 parseTruncateAfter =
   fmap TruncateAfterSlot slotNoOption <|> fmap TruncateAfterBlock blockNoOption

--- a/ouroboros-consensus-cardano/app/db-analyser.hs
+++ b/ouroboros-consensus-cardano/app/db-analyser.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 -- | Database analysis tool.
@@ -27,13 +28,13 @@ import           Options.Applicative (execParser, fullDesc, helper, info,
 main :: IO ()
 main = do
     cryptoInit
-    cmdLine <- getCmdLine
-    void $ case blockType cmdLine of
-      ByronBlock   args -> analyse cmdLine args
-      ShelleyBlock args -> analyse cmdLine args
-      CardanoBlock args -> analyse cmdLine args
+    (conf, blocktype) <- getCmdLine
+    void $ case blocktype of
+      ByronBlock   args -> analyse conf args
+      ShelleyBlock args -> analyse conf args
+      CardanoBlock args -> analyse conf args
 
-getCmdLine :: IO DBAnalyserConfig
+getCmdLine :: IO (DBAnalyserConfig, BlockType)
 getCmdLine = execParser opts
   where
     opts = info (parseCmdLine <**> helper) (mconcat [

--- a/ouroboros-consensus-cardano/app/db-analyser.hs
+++ b/ouroboros-consensus-cardano/app/db-analyser.hs
@@ -1,19 +1,18 @@
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE RankNTypes          #-}
-{-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 -- | Database analysis tool.
 --
 -- Usage: db-analyser --db PATH [--verbose]
 --                    [--only-immutable-db [--analyse-from SLOT_NUMBER]]
---                    [--validate-all-blocks | --minimum-block-validation] COMMAND
+--                    [--validate-all-blocks | --minimum-block-validation]
 --                    [--show-slot-block-no | --count-tx-outputs |
 --                      --show-block-header-size | --show-block-txs-size |
 --                      --show-ebbs | --store-ledger SLOT_NUMBER | --count-blocks |
 --                      --checkThunks BLOCK_COUNT | --trace-ledger |
---                      --repro-mempool-and-forge INT]
---                    [--num-blocks-to-process INT]
+--                      --repro-mempool-and-forge INT | --benchmark-ledger-ops
+--                      [--out-file FILE]] [--num-blocks-to-process INT] COMMAND
 module Main (main) where
 
 import           Cardano.Crypto.Init (cryptoInit)

--- a/ouroboros-consensus-cardano/app/db-truncater.hs
+++ b/ouroboros-consensus-cardano/app/db-truncater.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE RecordWildCards #-}
-
 module Main (main) where
 
 import           Cardano.Crypto.Init (cryptoInit)

--- a/ouroboros-consensus-cardano/app/db-truncater.hs
+++ b/ouroboros-consensus-cardano/app/db-truncater.hs
@@ -1,9 +1,11 @@
+{-# LANGUAGE RecordWildCards #-}
+
 module Main (main) where
 
 import           Cardano.Crypto.Init (cryptoInit)
-import           Cardano.Tools.DBAnalyser.Types (BlockType (..))
 import           Cardano.Tools.DBTruncater.Run
 import           Cardano.Tools.DBTruncater.Types
+import           DBAnalyser.Parsers (BlockType (..))
 import qualified DBTruncater.Parsers as DBTruncater
 import           Options.Applicative (execParser, fullDesc, helper, info,
                      progDesc, (<**>))
@@ -12,14 +14,14 @@ import           Prelude hiding (truncate)
 
 main :: IO ()
 main = do
-  cryptoInit
-  config <- getCommandLineConfig
-  case blockType config of
-    CardanoBlock args -> truncate config args
-    ByronBlock args   -> truncate config args
-    ShelleyBlock args -> truncate config args
+    cryptoInit
+    (conf, blocktype) <- getCommandLineConfig
+    case blocktype of
+      ByronBlock   args -> truncate conf args
+      ShelleyBlock args -> truncate conf args
+      CardanoBlock args -> truncate conf args
 
-getCommandLineConfig :: IO DBTruncaterConfig
+getCommandLineConfig :: IO (DBTruncaterConfig, BlockType)
 getCommandLineConfig = execParser opts
   where
     opts = info (DBTruncater.commandLineParser <**> helper)

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -586,6 +586,7 @@ test-suite tools-test
   main-is:        Main.hs
   build-depends:
     , base
+    , ouroboros-consensus-cardano
     , ouroboros-consensus:unstable-consensus-testlib
     , tasty
     , tasty-hunit

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Types.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Types.hs
@@ -6,9 +6,6 @@ module Cardano.Tools.DBAnalyser.Types (
 
 import           Cardano.Tools.DBAnalyser.Analysis as AnalysisTypes
                      (AnalysisName (..), AnalysisResult (..), Limit (..))
-import           Cardano.Tools.DBAnalyser.Block.Byron (ByronBlockArgs)
-import           Cardano.Tools.DBAnalyser.Block.Cardano (CardanoBlockArgs)
-import           Cardano.Tools.DBAnalyser.Block.Shelley (ShelleyBlockArgs)
 import           Ouroboros.Consensus.Storage.LedgerDB (DiskSnapshot)
 
 
@@ -21,14 +18,8 @@ data DBAnalyserConfig = DBAnalyserConfig {
   , verbose    :: Bool
   , selectDB   :: SelectDB
   , validation :: Maybe ValidateBlocks
-  , blockType  :: BlockType
   , analysis   :: AnalysisName
   , confLimit  :: Limit
   }
 
 data ValidateBlocks = ValidateAllBlocks | MinimumBlockValidation
-
-data BlockType =
-    ByronBlock   ByronBlockArgs
-  | ShelleyBlock ShelleyBlockArgs
-  | CardanoBlock CardanoBlockArgs

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBTruncater/Types.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBTruncater/Types.hs
@@ -3,13 +3,11 @@ module Cardano.Tools.DBTruncater.Types (
   , TruncateAfter (..)
   ) where
 
-import           Cardano.Tools.DBAnalyser.Types
 import           Ouroboros.Consensus.Block.Abstract
 
 data DBTruncaterConfig = DBTruncaterConfig {
     dbDir         :: FilePath
   , truncateAfter :: TruncateAfter
-  , blockType     :: BlockType
   , verbose       :: Bool
   }
 

--- a/ouroboros-consensus-cardano/test/tools-test/Main.hs
+++ b/ouroboros-consensus-cardano/test/tools-test/Main.hs
@@ -5,6 +5,7 @@ import qualified Cardano.Tools.DBAnalyser.Run as DBAnalyser
 import           Cardano.Tools.DBAnalyser.Types
 import qualified Cardano.Tools.DBSynthesizer.Run as DBSynthesizer
 import           Cardano.Tools.DBSynthesizer.Types
+import           Ouroboros.Consensus.Cardano.Block
 import           Test.Tasty
 import           Test.Tasty.HUnit
 import           Test.Util.TestEnv
@@ -52,10 +53,12 @@ testAnalyserConfig =
     , verbose     = False
     , selectDB    = SelectChainDB
     , validation  = Just ValidateAllBlocks
-    , blockType   = CardanoBlock (Cardano.CardanoBlockArgs nodeConfig Nothing)
     , analysis    = CountBlocks
     , confLimit   = Unlimited
     }
+
+testBlockArgs :: Cardano.Args (CardanoBlock StandardCrypto)
+testBlockArgs = Cardano.CardanoBlockArgs nodeConfig Nothing
 
 -- | A multi-step test including synthesis and analaysis 'SomeConsensusProtocol' using the Cardano instance.
 --
@@ -82,9 +85,7 @@ blockCountTest logStep = do
     blockCountAppend > 0 @? "no blocks have been forged during append step"
 
     logStep "running analysis"
-    resultAnalysis <- case blockType testAnalyserConfig of
-        CardanoBlock b  -> DBAnalyser.analyse testAnalyserConfig b
-        _               -> assertFailure "expexcting test case for Cardano block type"
+    resultAnalysis <- DBAnalyser.analyse testAnalyserConfig testBlockArgs
 
     let blockCount = blockCountCreate + blockCountAppend
     resultAnalysis == Just (ResultCountBlock blockCount) @?


### PR DESCRIPTION
# Description

Currently, the `DBAnalyserConfig` datatype has a `BlockType` filed, but `BlockType` is specific to Cardano: it can either be a Byron, Shelley or Cardano blocktype. This means we can not use db-analyser with other types of blocks. This PR removes the `BlockType` field from `DBAnalyserConfig` (and the `DBTruncatorConfig`), since that field was largely unused anyway.