### PR TITLE
Adjust number of test cases

### DIFF
--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
@@ -26,11 +26,12 @@ import           Test.Tasty
 import           Test.Tasty.QuickCheck
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TestBlock (TestBlock, unTestHash)
+import           Test.Util.TestEnv (adjustQuickCheckTests)
 
 tests :: TestTree
 tests =
   testGroup "long range attack" [
-    testProperty "one adversary" (prop_longRangeAttack 1 [10])
+    adjustQuickCheckTests (`div` 10) $ testProperty "one adversary" (prop_longRangeAttack 1 [10])
     -- TODO we don't have useful classification logic for multiple adversaries yet – if a selectable
     -- adversary is slow, it might be discarded before it reaches critical length because the faster
     -- ones have served k blocks off the honest chain if their fork anchor is further down the line.
@@ -51,7 +52,7 @@ prop_longRangeAttack honestFreq advFreqs = do
 
   -- TODO: not existsSelectableAdversary ==> immutableTipBeforeFork svSelectedChain
 
-  pure $ withMaxSuccess 10 $
+  pure $
     classify genesisWindowAfterIntersection "Full genesis window after intersection" $
     allAdversariesSelectable
     ==>

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -21,11 +21,12 @@ import           Test.Tasty
 import           Test.Tasty.QuickCheck
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TestBlock (TestBlock, unTestHash)
+import           Test.Util.TestEnv (adjustQuickCheckTests)
 
 tests :: TestTree
 tests = testGroup "rollback" [
-  testProperty "can rollback" (prop_rollback True),
-  testProperty "cannot rollback" (prop_rollback False)
+    adjustQuickCheckTests (`div` 10) $ testProperty "can rollback" (prop_rollback True),
+    adjustQuickCheckTests (`div` 10) $ testProperty "cannot rollback" (prop_rollback False)
   ]
 
 -- | @prop_rollback True@ tests that the selection of the node under test

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -25,7 +25,11 @@ import           Test.Util.TestEnv (adjustQuickCheckTests)
 
 tests :: TestTree
 tests = testGroup "rollback" [
+    -- NOTE: The property @prop_rollback True@ discards a lot of inputs, making
+    -- it quite flakey. We increase the maximum number of discarded tests per
+    -- successful ones so as to make this test more reliable.
     adjustQuickCheckTests (`div` 10) $
+    localOption (QuickCheckMaxRatio 100) $
     testProperty "can rollback" (prop_rollback True)
     ,
     adjustQuickCheckTests (`div` 10) $

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -25,8 +25,11 @@ import           Test.Util.TestEnv (adjustQuickCheckTests)
 
 tests :: TestTree
 tests = testGroup "rollback" [
-    adjustQuickCheckTests (`div` 10) $ testProperty "can rollback" (prop_rollback True),
-    adjustQuickCheckTests (`div` 10) $ testProperty "cannot rollback" (prop_rollback False)
+    adjustQuickCheckTests (`div` 10) $
+    testProperty "can rollback" (prop_rollback True)
+    ,
+    adjustQuickCheckTests (`div` 10) $
+    testProperty "cannot rollback" (prop_rollback False)
   ]
 
 -- | @prop_rollback True@ tests that the selection of the node under test

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -25,9 +25,10 @@ import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 import           Test.Util.Orphans.IOLike ()
+import           Test.Util.TestEnv (adjustQuickCheckTests)
 
 tests :: TestTree
-tests = testProperty "timeouts" prop_timeouts
+tests = adjustQuickCheckTests (`div` 10) $ testProperty "timeouts" prop_timeouts
 
 prop_timeouts :: QC.Gen QC.Property
 prop_timeouts = do
@@ -44,7 +45,7 @@ prop_timeouts = do
           (fromJust $ mustReplyTimeout (scChainSyncTimeouts schedulerConfig))
           (btTrunk $ gtBlockTree genesisTest)
 
-  pure $ withMaxSuccess 10 $ runSimOrThrow $
+  pure $ runSimOrThrow $
     runTest schedulerConfig genesisTest schedule $ \stateView ->
       case svChainSyncExceptions stateView of
         [] ->

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestEnv.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestEnv.hs
@@ -3,6 +3,7 @@
 -- | A @tasty@ command-line option for enabling nightly tests
 module Test.Util.TestEnv (
     TestEnv (..)
+  , adjustQuickCheckTests
   , askTestEnv
   , defaultMainWithTestEnv
   , defaultTestEnvConfig
@@ -66,3 +67,9 @@ instance IsOption TestEnv where
 
   -- Set of choices for test environment
   optionCLParser = mkOptionCLParser $ metavar "nightly|ci|dev"
+
+-- | Locally adjust the number of QuickCheck tests for the given test subtree.
+adjustQuickCheckTests :: (Int -> Int) -> TestTree -> TestTree
+adjustQuickCheckTests f =
+  adjustOption $ \(QuickCheckTests n) ->
+    QuickCheckTests $ if n == 0 then 0 else max 1 (f n)


### PR DESCRIPTION
For now, we have relied on `withMaxSuccess` to reduce the number of tests. This does not allow for an increase of the number of tests in CI or nightly. This PR uses the proper mechanism.