### PR TITLE
Normalise adjustment of number of QuickCheck tests

### DIFF
--- a/ouroboros-consensus-cardano/test/byron-test/Test/ThreadNet/Byron.hs
+++ b/ouroboros-consensus-cardano/test/byron-test/Test/ThreadNet/Byron.hs
@@ -77,6 +77,7 @@ import           Test.Util.HardFork.Future (singleEraFuture)
 import           Test.Util.Orphans.Arbitrary ()
 import           Test.Util.Slots (NumSlots (..))
 import qualified Test.Util.Stream as Stream
+import           Test.Util.TestEnv (adjustQuickCheckTests)
 
 data TestSetup = TestSetup
   { setupEBBs         :: ProduceEBBs
@@ -136,7 +137,7 @@ tests = testGroup "Byron" $
     [ testProperty "trivial join plan is considered deterministic"
         $ \TestSetup{setupK = k, setupTestConfig = TestConfig{numCoreNodes}} ->
           prop_deterministicPlan $ byronPBftParams k numCoreNodes
-    , adjustOption (\(QuickCheckTests n) -> QuickCheckTests (1 `max` (div n 10))) $
+    , adjustQuickCheckTests (`div` 10) $
       -- as of merging PR #773, this test case fails without the commit that
       -- introduces the InvalidRollForward exception
       --
@@ -281,7 +282,7 @@ tests = testGroup "Byron" $
             , setupVersion    = (NodeToNodeV_7, ByronNodeToNodeVersion1)
             }
     , -- Byron runs are slow, so do 10x less of this narrow test
-      adjustOption (\(QuickCheckTests i) -> QuickCheckTests $ max 1 $ i `div` 10) $
+      adjustQuickCheckTests (`div` 10) $
       testProperty "re-delegation via NodeRekey" $ \seed w ->
           let ncn = NumCoreNodes 5
               k :: Num a => a

--- a/ouroboros-consensus-cardano/test/byron-test/Test/ThreadNet/DualByron.hs
+++ b/ouroboros-consensus-cardano/test/byron-test/Test/ThreadNet/DualByron.hs
@@ -53,10 +53,11 @@ import           Test.ThreadNet.Util.NodeRestarts (noRestarts)
 import           Test.ThreadNet.Util.NodeToNodeVersion (newestVersion)
 import           Test.Util.HardFork.Future (singleEraFuture)
 import           Test.Util.Slots (NumSlots (..))
+import           Test.Util.TestEnv (adjustQuickCheckTests)
 
 tests :: TestTree
 tests = testGroup "DualByron" [
-      localOption (QuickCheckTests 10) $ testProperty "convergence" $ prop_convergence
+      adjustQuickCheckTests (`div` 10) $ testProperty "convergence" $ prop_convergence
     ]
 
 -- These tests are very expensive, due to the Byron generators

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/Consensus/Cardano/ByronCompatibility.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/Consensus/Cardano/ByronCompatibility.hs
@@ -49,9 +49,14 @@ import           Test.Tasty.QuickCheck
 import           Test.Util.Orphans.Arbitrary ()
 import           Test.Util.Serialisation.Roundtrip
 import           Test.Util.Serialisation.SomeResult (SomeResult (..))
+import           Test.Util.TestEnv (adjustQuickCheckTests)
 
 tests :: TestTree
-tests = adjustOption reduceTests $
+tests =
+  -- | We're not trying to find edge cases in the roundtrip tests, we just
+  -- want to check compatibility. In case of incompatibility, the first test
+  -- will probably fail already.
+  adjustQuickCheckTests (`div` 10) $
     testGroup "Byron compatibility" [
         testGroup "Byron to Cardano" [
               testProperty "roundtrip block" $
@@ -74,11 +79,6 @@ tests = adjustOption reduceTests $
                 roundtrip_SerialiseNodeToClient (const CheckCBORValidity) cardanoToByronCodeConfig
             ]
       ]
-  where
-    -- | We're not trying to find edge cases in the roundtrip tests, we just
-    -- want to check compatibility. In case of incompatibility, the first test
-    -- will probably fail already.
-    reduceTests (QuickCheckTests n) = QuickCheckTests (1 `max` (div n 10))
 
 byronCodecConfig :: CodecConfig ByronBlock
 byronCodecConfig = ByronCodecConfig epochSlots

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/AllegraMary.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/AllegraMary.hs
@@ -144,8 +144,7 @@ instance Arbitrary TestSetup where
   -- TODO shrink
 
 tests :: TestTree
-tests = localOption (QuickCheckTests 100) $
-        testGroup "AllegraMary ThreadNet" [
+tests = testGroup "AllegraMary ThreadNet" [
           askTestEnv $ adjustTestEnv $ testProperty "simple convergence" prop_simple_allegraMary_convergence
         ]
     where

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/AllegraMary.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/AllegraMary.hs
@@ -151,10 +151,7 @@ tests = testGroup "AllegraMary ThreadNet" [
       adjustTestEnv :: TestTree -> TestEnv -> TestTree
       adjustTestEnv tree = \case
         Nightly -> tree
-        _       ->
-          -- These tests are slow, so we settle for running fewer of them in this test
-          -- suite since it is invoked frequently (eg CI for each push).
-          adjustQuickCheckTests (`div` 10) tree
+        _       -> adjustQuickCheckTests (`div` 10) tree
 
 prop_simple_allegraMary_convergence :: TestSetup -> Property
 prop_simple_allegraMary_convergence TestSetup

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/AllegraMary.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/AllegraMary.hs
@@ -143,15 +143,6 @@ instance Arbitrary TestSetup where
 
   -- TODO shrink
 
--- | Run relatively fewer tests
---
--- These tests are slow, so we settle for running fewer of them in this test
--- suite since it is invoked frequently (eg CI for each push).
-oneTenthTestCount :: QuickCheckTests -> QuickCheckTests
-oneTenthTestCount (QuickCheckTests n) = QuickCheckTests $
-    if 0 == n then 0 else
-    max 1 $ n `div` 10
-
 tests :: TestTree
 tests = localOption (QuickCheckTests 100) $
         testGroup "AllegraMary ThreadNet" [
@@ -161,7 +152,10 @@ tests = localOption (QuickCheckTests 100) $
       adjustTestEnv :: TestTree -> TestEnv -> TestTree
       adjustTestEnv tree = \case
         Nightly -> tree
-        _       -> adjustOption oneTenthTestCount tree
+        _       ->
+          -- These tests are slow, so we settle for running fewer of them in this test
+          -- suite since it is invoked frequently (eg CI for each push).
+          adjustQuickCheckTests (`div` 10) tree
 
 prop_simple_allegraMary_convergence :: TestSetup -> Property
 prop_simple_allegraMary_convergence TestSetup

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/Cardano.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/Cardano.hs
@@ -153,10 +153,7 @@ tests = testGroup "Cardano ThreadNet" [
       adjustTestMode :: TestTree -> TestEnv ->  TestTree
       adjustTestMode tree = \case
         Nightly -> tree
-        _       ->
-          -- These tests are slow, so we settle for running fewer of them in this test
-          -- suite since it is invoked frequently (eg CI for each push).
-          adjustQuickCheckTests (\n -> (2 * n) `div` 5) tree
+        _       -> adjustQuickCheckTests (\n -> (2 * n) `div` 5) tree
 
 prop_simple_cardano_convergence :: TestSetup -> Property
 prop_simple_cardano_convergence TestSetup

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/Cardano.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/Cardano.hs
@@ -144,8 +144,7 @@ instance Arbitrary TestSetup where
   -- TODO shrink
 
 tests :: TestTree
-tests = localOption (QuickCheckTests 100) $
-        testGroup "Cardano ThreadNet" [
+tests = testGroup "Cardano ThreadNet" [
           let name = "simple convergence" in
           askTestEnv $ adjustTestMode $
             testProperty name prop_simple_cardano_convergence

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/MaryAlonzo.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/MaryAlonzo.hs
@@ -156,10 +156,7 @@ tests = testGroup "MaryAlonzo ThreadNet" [
       adjustTestMode :: TestTree -> TestEnv -> TestTree
       adjustTestMode tree = \case
         Nightly -> tree
-        _       ->
-          -- These tests are slow, so we settle for running fewer of them in this test
-          -- suite since it is invoked frequently (eg CI for each push).
-          adjustQuickCheckTests (`div` 10) tree
+        _       -> adjustQuickCheckTests (`div` 10) tree
 
 prop_simple_allegraAlonzo_convergence :: TestSetup -> Property
 prop_simple_allegraAlonzo_convergence TestSetup

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/MaryAlonzo.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/MaryAlonzo.hs
@@ -145,15 +145,6 @@ instance Arbitrary TestSetup where
 
   -- TODO shrink
 
--- | Run relatively fewer tests
---
--- These tests are slow, so we settle for running fewer of them in this test
--- suite since it is invoked frequently (eg CI for each push).
-oneTenthTestCount :: QuickCheckTests -> QuickCheckTests
-oneTenthTestCount (QuickCheckTests n) = QuickCheckTests $
-    if 0 == n then 0 else
-    max 1 $ n `div` 10
-
 tests :: TestTree
 tests = localOption (QuickCheckTests 100) $
         testGroup "MaryAlonzo ThreadNet" [
@@ -166,7 +157,10 @@ tests = localOption (QuickCheckTests 100) $
       adjustTestMode :: TestTree -> TestEnv -> TestTree
       adjustTestMode tree = \case
         Nightly -> tree
-        _       -> adjustOption oneTenthTestCount tree
+        _       ->
+          -- These tests are slow, so we settle for running fewer of them in this test
+          -- suite since it is invoked frequently (eg CI for each push).
+          adjustQuickCheckTests (`div` 10) tree
 
 prop_simple_allegraAlonzo_convergence :: TestSetup -> Property
 prop_simple_allegraAlonzo_convergence TestSetup

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/MaryAlonzo.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/MaryAlonzo.hs
@@ -146,8 +146,7 @@ instance Arbitrary TestSetup where
   -- TODO shrink
 
 tests :: TestTree
-tests = localOption (QuickCheckTests 100) $
-        testGroup "MaryAlonzo ThreadNet" [
+tests = testGroup "MaryAlonzo ThreadNet" [
           let name = "simple convergence" in
           askTestEnv $ adjustTestMode $
             testProperty name prop_simple_allegraAlonzo_convergence

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/ShelleyAllegra.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/ShelleyAllegra.hs
@@ -143,15 +143,6 @@ instance Arbitrary TestSetup where
 
   -- TODO shrink
 
--- | Run relatively fewer tests
---
--- These tests are slow, so we settle for running fewer of them in this test
--- suite since it is invoked frequently (eg CI for each push).
-oneTenthTestCount :: QuickCheckTests -> QuickCheckTests
-oneTenthTestCount (QuickCheckTests n) = QuickCheckTests $
-    if 0 == n then 0 else
-    max 1 $ n `div` 10
-
 tests :: TestTree
 tests = testGroup "ShelleyAllegra ThreadNet" $
     [ let name = "simple convergence" in
@@ -163,7 +154,10 @@ tests = testGroup "ShelleyAllegra ThreadNet" $
       adjustTestMode :: TestTree -> TestEnv -> TestTree
       adjustTestMode tree = \case
         Nightly -> tree
-        _       -> adjustOption oneTenthTestCount tree
+        _       ->
+          -- These tests are slow, so we settle for running fewer of them in this test
+          -- suite since it is invoked frequently (eg CI for each push).
+          adjustQuickCheckTests (`div` 10) tree
 
 prop_simple_shelleyAllegra_convergence :: TestSetup -> Property
 prop_simple_shelleyAllegra_convergence TestSetup

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/ShelleyAllegra.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/ShelleyAllegra.hs
@@ -154,10 +154,7 @@ tests = testGroup "ShelleyAllegra ThreadNet" $
       adjustTestMode :: TestTree -> TestEnv -> TestTree
       adjustTestMode tree = \case
         Nightly -> tree
-        _       ->
-          -- These tests are slow, so we settle for running fewer of them in this test
-          -- suite since it is invoked frequently (eg CI for each push).
-          adjustQuickCheckTests (`div` 10) tree
+        _       -> adjustQuickCheckTests (`div` 10) tree
 
 prop_simple_shelleyAllegra_convergence :: TestSetup -> Property
 prop_simple_shelleyAllegra_convergence TestSetup

--- a/ouroboros-consensus-cardano/test/shelley-test/Test/ThreadNet/Shelley.hs
+++ b/ouroboros-consensus-cardano/test/shelley-test/Test/ThreadNet/Shelley.hs
@@ -151,10 +151,7 @@ tests = testGroup "Shelley ThreadNet"
       askTestEnv $ \case
           Nightly -> testProperty name $ \(NightlyTestSetup setup) ->
             prop_simple_real_tpraos_convergence setup
-          _      ->
-            -- These tests are slow, so we settle for running fewer of them in this test
-            -- suite since it is invoked frequently (eg CI for each push).
-            adjustQuickCheckTests (`div` 5) $ testProperty name prop_simple_real_tpraos_convergence
+          _      -> adjustQuickCheckTests (`div` 5) $ testProperty name prop_simple_real_tpraos_convergence
     ]
 
 prop_simple_real_tpraos_convergence :: TestSetup -> Property

--- a/ouroboros-consensus-cardano/test/shelley-test/Test/ThreadNet/Shelley.hs
+++ b/ouroboros-consensus-cardano/test/shelley-test/Test/ThreadNet/Shelley.hs
@@ -145,22 +145,16 @@ instance Arbitrary NightlyTestSetup where
               }
           }
 
--- | Run relatively fewer tests
---
--- These tests are slow, so we settle for running fewer of them in this test
--- suite since it is invoked frequently (eg CI for each push).
-fifthTestCount :: QuickCheckTests -> QuickCheckTests
-fifthTestCount (QuickCheckTests n) = QuickCheckTests $
-    if 0 == n then 0 else
-    max 1 $ n `div` 5
-
 tests :: TestTree
 tests = localOption (QuickCheckTests 100) $ testGroup "Shelley ThreadNet"
     [ let name = "simple convergence" in
       askTestEnv $ \case
           Nightly -> testProperty name $ \(NightlyTestSetup setup) ->
             prop_simple_real_tpraos_convergence setup
-          _      -> adjustOption fifthTestCount $ testProperty name prop_simple_real_tpraos_convergence
+          _      ->
+            -- These tests are slow, so we settle for running fewer of them in this test
+            -- suite since it is invoked frequently (eg CI for each push).
+            adjustQuickCheckTests (`div` 5) $ testProperty name prop_simple_real_tpraos_convergence
     ]
 
 prop_simple_real_tpraos_convergence :: TestSetup -> Property

--- a/ouroboros-consensus-cardano/test/shelley-test/Test/ThreadNet/Shelley.hs
+++ b/ouroboros-consensus-cardano/test/shelley-test/Test/ThreadNet/Shelley.hs
@@ -146,7 +146,7 @@ instance Arbitrary NightlyTestSetup where
           }
 
 tests :: TestTree
-tests = localOption (QuickCheckTests 100) $ testGroup "Shelley ThreadNet"
+tests = testGroup "Shelley ThreadNet"
     [ let name = "simple convergence" in
       askTestEnv $ \case
           Nightly -> testProperty name $ \(NightlyTestSetup setup) ->

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Serialisation/Roundtrip.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Serialisation/Roundtrip.hs
@@ -82,6 +82,7 @@ import           Test.Tasty.QuickCheck
 import           Test.Util.Orphans.Arbitrary ()
 import           Test.Util.Serialisation.Examples (Examples (..), Labelled)
 import           Test.Util.Serialisation.SomeResult (SomeResult (..))
+import           Test.Util.TestEnv (adjustQuickCheckTests)
 import           Text.Pretty.Simple (pShow)
 
 {------------------------------------------------------------------------------
@@ -301,7 +302,7 @@ roundtrip_SerialiseDisk ccfg dictNestedHdr =
                 nestedHdr
       -- Since the 'LedgerState' is a large data structure, we lower the
       -- number of tests to avoid slowing down the testsuite too much
-    , adjustOption (\(QuickCheckTests n) -> QuickCheckTests (1 `max` (div n 10))) $
+    , adjustQuickCheckTests (`div` 10) $
       rt (Proxy @(LedgerState blk)) "LedgerState"
     , rt (Proxy @(AnnTip blk)) "AnnTip"
     , rt (Proxy @(ChainDepState (BlockProtocol blk))) "ChainDepState"

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestEnv.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestEnv.hs
@@ -3,6 +3,7 @@
 -- | A @tasty@ command-line option for enabling nightly tests
 module Test.Util.TestEnv (
     TestEnv (..)
+  , adjustQuickCheckTests
   , askTestEnv
   , defaultMainWithTestEnv
   , defaultTestEnvConfig
@@ -66,3 +67,11 @@ instance IsOption TestEnv where
 
   -- Set of choices for test environment
   optionCLParser = mkOptionCLParser $ metavar "nightly|ci|dev"
+
+-- | Locally adjust the number of QuickCheck tests for the given test subtree.
+-- Unless the previous number of tests was exactly '0', the result will always
+-- be at least '1'.
+adjustQuickCheckTests :: (Int -> Int) -> TestTree -> TestTree
+adjustQuickCheckTests f =
+  adjustOption $ \(QuickCheckTests n) ->
+    QuickCheckTests $ if n == 0 then 0 else (max 1 (f n))

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestEnv.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestEnv.hs
@@ -70,7 +70,11 @@ instance IsOption TestEnv where
 
 -- | Locally adjust the number of QuickCheck tests for the given test subtree.
 -- Unless the previous number of tests was exactly '0', the result will always
--- be at least '1'.
+-- be at least '1'. For instance:
+--
+-- > adjustQuickCheckTests (`div` 10)
+--
+-- will reduce the default number of tests by 10.
 --
 -- This matters in particular with tests that take a long time; in that case, we
 -- settle for running fewer tests, while still scaling with the different test

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestEnv.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestEnv.hs
@@ -71,7 +71,13 @@ instance IsOption TestEnv where
 -- | Locally adjust the number of QuickCheck tests for the given test subtree.
 -- Unless the previous number of tests was exactly '0', the result will always
 -- be at least '1'.
+--
+-- This matters in particular with tests that take a long time; in that case, we
+-- settle for running fewer tests, while still scaling with the different test
+-- environments (nightly, ci, dev). This function should almost always be
+-- preferred to @localOption (QuickCheckTests ...)@ which sets the number of
+-- tests regarless of the test environment.
 adjustQuickCheckTests :: (Int -> Int) -> TestTree -> TestTree
 adjustQuickCheckTests f =
   adjustOption $ \(QuickCheckTests n) ->
-    QuickCheckTests $ if n == 0 then 0 else (max 1 (f n))
+    QuickCheckTests $ if n == 0 then 0 else max 1 (f n)

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/BlockchainTime/Simple.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/BlockchainTime/Simple.hs
@@ -64,13 +64,14 @@ import           Test.Tasty.QuickCheck hiding (Fixed)
 import           Test.Util.Orphans.Arbitrary (genNominalDiffTime50Years)
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.Range
+import           Test.Util.TestEnv (adjustQuickCheckTests)
 import           Test.Util.Time
 
 tests :: TestTree
 tests = testGroup "WallClock" [
-      localOption (QuickCheckTests 10) $ testProperty "delayNextSlot" prop_delayNextSlot
+      adjustQuickCheckTests (`div` 10) $ testProperty "delayNextSlot" prop_delayNextSlot
     , testProperty "delayClockShift"   prop_delayClockShift
-    , localOption (QuickCheckTests 1)  $ testProperty "delayNoClockShift" prop_delayNoClockShift
+    , adjustQuickCheckTests (const 1)  $ testProperty "delayNoClockShift" prop_delayNoClockShift
     ]
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -153,8 +153,8 @@ import qualified Test.StateMachine.Labelling as C
 import qualified Test.StateMachine.Sequential as QSM
 import qualified Test.StateMachine.Types as QSM
 import qualified Test.StateMachine.Types.Rank2 as Rank2
-import           Test.Tasty (TestTree, localOption, testGroup)
-import           Test.Tasty.QuickCheck (QuickCheckTests (..), testProperty)
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.QuickCheck (testProperty)
 import           Test.Util.ChainDB
 import           Test.Util.ChunkInfo
 import           Test.Util.Orphans.ToExpr ()
@@ -162,6 +162,7 @@ import           Test.Util.QuickCheck
 import qualified Test.Util.RefEnv as RE
 import           Test.Util.RefEnv (RefEnv)
 import           Test.Util.SOP
+import           Test.Util.TestEnv (adjustQuickCheckTests)
 import           Test.Util.Tracer (recordingTracerIORef)
 import           Test.Util.WithEq
 
@@ -1703,5 +1704,5 @@ mkArgs cfg chunkInfo initLedger registry nodeDBs tracer (MaxClockSkew maxClockSk
 
 tests :: TestTree
 tests = testGroup "ChainDB q-s-m"
-    [ localOption (QuickCheckTests 100000) $ testProperty "sequential" prop_sequential
+    [ adjustQuickCheckTests (* 100) $ testProperty "sequential" prop_sequential
     ]


### PR DESCRIPTION
_This PR has been initially devised as part of the Genesis project, in https://github.com/input-output-hk/ouroboros-consensus/pull/496. It now targets `main` because we believe it might benefit the project as a whole._

### Description

This PR aims at normalising the adjustments of the number of QuickCheck tests in the whole codebase.

`ouroboros-consensus:unstable-consensus-testlib` provides utilities in a module `Test.Util.TestEnv` to help describing a difference of behaviour of tests when ran in a `dev` (default), `ci` or `nightly` environment. This is typically used to change the number of test cases that QuickCheck generates. This number will be 100 in `dev`, 10,000 in `ci` and 100,000 in `nightly` by default.

Now, for some tests, 100 is too much and so we end up wanting to run ten times less than that (or any other ratio, really). The proper way to do this without hard-coding a value (say 10 tests) which would then be the same independently of the environment is by adjusting the value option `QuickCheckTests`, with something like:
```haskell
adjustOption (\(QuickCheckTests n) -> QuickCheckTests (1 `max` (div n 10)))
  :: TestTree -> TestTree
```

This is what is being done in various places of the code base in slightly different ways. This PR introduces a helper `adjustQuickCheckTests` and uses it consistently across the code base. This helper allows writing “let's run 10⨉ less tests” as
```haskell
adjustQuickCheckTests (`div` 10)
  :: TestTree -> TestTree
```

### Bonus questions

I have two bonus questions which I think could be taken care of in this PR.

First, I have seen in various place a helper:
```haskell
adjustTestEnv :: TestTree -> TestEnv -> TestTree
adjustTestEnv tree = \case
  Nightly -> tree
  _       -> adjustQuickCheckTests (`div` 10) tree
```
I have the impression that this could be simplified as simply ``adjustQuickCheckTests (`div` 10)``. What do you think?

Second, a lot of places hardcode a number of tests with `localOption (QuickCheckTests 14)` for instance. I would be tempted to replace this by something like ``adjustQuickCheckTests (`div` 7)``, which would give a similar result but would behave better when test environments are indeed used in CI or nightly. What do you think?