### PR TITLE
Constrain `quickcheck-state-machine` to `^>=0.7` in testlib

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -361,7 +361,7 @@ library unstable-consensus-testlib
     , ouroboros-network-mock
     , pretty-simple
     , QuickCheck
-    , quickcheck-state-machine
+    , quickcheck-state-machine                                ^>=0.7
     , quiet
     , random
     , serialise


### PR DESCRIPTION
Mirroring a revision from CHaP: https://github.com/input-output-hk/cardano-haskell-packages/pull/578

`quickcheck-state-machine-0.8` vendors its own `ToExpr` instead of using the one from `tree-diff`, so we get compilation failures.

We already have such a constraint in a test suite, but CHaP ignores those.