### PR TITLE
db-analyser: add option to output results of "benchmark ledger ops " as JSON

### DIFF
--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -450,6 +450,9 @@ library unstable-cardano-tools
     Cardano.Node.Protocol.Types
     Cardano.Node.Types
     Cardano.Tools.DBAnalyser.Analysis
+    Cardano.Tools.DBAnalyser.Analysis.BenchmarkLedgerOps.FileWriting
+    Cardano.Tools.DBAnalyser.Analysis.BenchmarkLedgerOps.Metadata
+    Cardano.Tools.DBAnalyser.Analysis.BenchmarkLedgerOps.SlotDataPoint
     Cardano.Tools.DBAnalyser.Block.Byron
     Cardano.Tools.DBAnalyser.Block.Cardano
     Cardano.Tools.DBAnalyser.Block.Shelley
@@ -479,7 +482,6 @@ library unstable-cardano-tools
     Cardano.Node.Protocol.Cardano
     Cardano.Node.Protocol.Conway
     Cardano.Node.Protocol.Shelley
-    Cardano.Tools.DBAnalyser.Analysis.BenchmarkLedgerOps.SlotDataPoint
 
   build-depends:
     , aeson

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Analysis/BenchmarkLedgerOps/FileWriting.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Analysis/BenchmarkLedgerOps/FileWriting.hs
@@ -1,0 +1,124 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Cardano.Tools.DBAnalyser.Analysis.BenchmarkLedgerOps.FileWriting (
+    -- * Output format
+    OutputFormat
+  , getOutputFormat
+    -- * File writing functions
+  , writeDataPoint
+  , writeHeader
+  , writeMetadata
+  ) where
+
+import           Cardano.Slotting.Slot (SlotNo (unSlotNo))
+import qualified Cardano.Tools.DBAnalyser.Analysis.BenchmarkLedgerOps.Metadata as BenchmarkLedgerOps.Metadata
+import           Cardano.Tools.DBAnalyser.Analysis.BenchmarkLedgerOps.SlotDataPoint
+                     (SlotDataPoint)
+import qualified Cardano.Tools.DBAnalyser.Analysis.BenchmarkLedgerOps.SlotDataPoint as DP
+import           Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy as BSL
+import qualified Data.Text.IO as Text.IO
+import           System.FilePath.Posix (takeExtension)
+import qualified System.IO as IO
+import qualified Text.Builder as Builder
+import           Text.Builder (Builder, decimal, intercalate)
+
+{-------------------------------------------------------------------------------
+  Output format
+-------------------------------------------------------------------------------}
+
+data OutputFormat = CSV | JSON
+  deriving (Show, Eq)
+
+-- | Use the provided 'Maybe FilePath' to determine the output format.
+--
+-- The output format is based on the extension (see 'OutputFormat').
+--
+-- If the extension is not supported the output format defaults to
+-- CSV, and this function prints a warning informing the user of this
+-- choice.
+getOutputFormat :: Maybe FilePath -> IO OutputFormat
+getOutputFormat (Just filePath) =
+    case takeExtension filePath of
+    ".csv"  -> pure CSV
+    ".json" -> pure JSON
+    ext     -> do
+      IO.hPutStr IO.stderr $ "Unsupported extension '" <> ext <> "'. Defaulting to CSV."
+      pure CSV
+getOutputFormat Nothing         = pure CSV
+
+
+{-------------------------------------------------------------------------------
+  File writing functions
+-------------------------------------------------------------------------------}
+
+-- | Separator used for CSV output.
+csvSeparator :: Builder
+csvSeparator = "\t"
+
+-- | Write a header for the data points.
+--
+-- This is only needed for the CSV output format.
+writeHeader :: IO.Handle -> OutputFormat -> IO ()
+writeHeader outFileHandle CSV  =
+     Text.IO.hPutStrLn outFileHandle
+   $ Builder.run
+   $ showHeaders csvSeparator
+writeHeader _             JSON = pure ()
+
+-- | NOTE: This function is not thread safe.
+writeDataPoint ::
+     IO.Handle
+  -> OutputFormat
+  -> SlotDataPoint
+  -> IO ()
+writeDataPoint outFileHandle CSV  slotDataPoint =
+      Text.IO.hPutStrLn outFileHandle
+    $ Builder.run
+    $ showData slotDataPoint csvSeparator
+writeDataPoint outFileHandle JSON slotDataPoint =
+  BSL.hPut outFileHandle $ Aeson.encode slotDataPoint
+
+-- | Write metadata to a JSON file if this is the selected
+-- format. Perform a no-op otherwise.
+writeMetadata :: IO.Handle -> OutputFormat -> IO ()
+writeMetadata _outFileHandle CSV  = pure ()
+writeMetadata  outFileHandle JSON =
+  BenchmarkLedgerOps.Metadata.getMetadata
+  >>= BSL.hPut outFileHandle . Aeson.encode
+
+{-------------------------------------------------------------------------------
+  Operations to assist CSV printing
+-------------------------------------------------------------------------------}
+
+-- | Return the headers that correspond to the fields of 'SlotDataPoint'.
+--
+-- The position of each header matches the position in which the corresponding
+-- field value is returned in 'showData'. Eg, if show headers returns:
+--
+-- > "slot slotGap totalTime" ...
+--
+-- then the third value returned by 'showData' will correspond to 'totalTime'.
+showHeaders :: Builder -> Builder
+showHeaders sep = intercalate sep $ fmap fst           showHeadersAndData
+
+showData :: SlotDataPoint -> Builder -> Builder
+showData dp sep = intercalate sep $ fmap (($ dp) . snd) showHeadersAndData
+
+showHeadersAndData :: [(Builder, SlotDataPoint -> Builder)]
+showHeadersAndData =
+    [ ("slot"                  , decimal . unSlotNo . DP.slot)
+    , ("slotGap"               , decimal . DP.slotGap)
+    , ("totalTime"             , decimal . DP.totalTime)
+    , ("mut"                   , decimal . DP.mut)
+    , ("gc"                    , decimal . DP.gc)
+    , ("majGcCount"            , decimal . DP.majGcCount)
+    , ("minGcCount"            , decimal . DP.minGcCount)
+    , ("allocatedBytes"        , decimal . DP.allocatedBytes)
+    , ("mut_forecast"          , decimal . DP.mut_forecast)
+    , ("mut_headerTick"        , decimal . DP.mut_headerTick)
+    , ("mut_headerApply"       , decimal . DP.mut_headerApply)
+    , ("mut_blockTick"         , decimal . DP.mut_blockTick)
+    , ("mut_blockApply"        , decimal . DP.mut_blockApply)
+    , ("...era-specific stats" , Builder.intercalate csvSeparator . DP.unBlockStats . DP.blockStats)
+    ]

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Analysis/BenchmarkLedgerOps/Metadata.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Analysis/BenchmarkLedgerOps/Metadata.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+-- | Functions related to obtaining information about the 'db-analyser' run.
+--
+-- Metadata includes information such as:
+--
+-- - RTS flags.
+-- - Compiler version.
+-- - OS and architecture.
+--
+-- See 'Metadata' and 'getMetadata' for more details.
+--
+module Cardano.Tools.DBAnalyser.Analysis.BenchmarkLedgerOps.Metadata (
+    Metadata (..)
+  , getMetadata
+  ) where
+
+import           Cardano.Tools.GitRev (gitRev)
+import           Data.Aeson (ToJSON)
+import qualified Data.Aeson as Aeson
+import qualified Data.Text as T
+import qualified Data.Version
+import           Data.Word (Word32, Word64)
+import           GHC.Generics (Generic)
+import qualified GHC.RTS.Flags as RTS
+import qualified System.Info
+
+data Metadata = Metadata {
+    rtsGCMaxStkSize             :: Word32
+  , rtsGCMaxHeapSize            :: Word32
+  , rtsConcurrentCtxtSwitchTime :: Word64
+  , rtsParNCapabilities         :: Word32
+  , compilerVersion             :: String
+  , compilerName                :: String
+  , operatingSystem             :: String
+  , machineArchitecture         :: String
+  , gitRevison                  :: String
+  } deriving (Generic, Show, Eq)
+
+instance ToJSON Metadata where
+  toEncoding = Aeson.genericToEncoding Aeson.defaultOptions
+
+getMetadata :: IO Metadata
+getMetadata = do
+  rtsFlags <- RTS.getRTSFlags
+  pure $ Metadata {
+      rtsGCMaxStkSize             = RTS.maxStkSize     $ RTS.gcFlags rtsFlags
+    , rtsGCMaxHeapSize            = RTS.maxHeapSize    $ RTS.gcFlags rtsFlags
+    , rtsConcurrentCtxtSwitchTime = RTS.ctxtSwitchTime $ RTS.concurrentFlags rtsFlags
+    , rtsParNCapabilities         = RTS.nCapabilities  $ RTS.parFlags rtsFlags
+    , compilerVersion             = Data.Version.showVersion System.Info.compilerVersion
+    , compilerName                = System.Info.compilerName
+    , operatingSystem             = System.Info.os
+    , machineArchitecture         = System.Info.arch
+    , gitRevison                  = T.unpack gitRev
+    }


### PR DESCRIPTION
Part of #230 

TODOs:

- [x] Add roundtrip test for `BenchmarkLedgerOps.Metadata`.
- [x] Reference the latest commit hash (see https://github.com/input-output-hk/ouroboros-consensus/pull/519).
- [x] Decide if any implementation is necessary to ensure we use the same RTS flags as `cardano-node` (perhaps we need to modify the `cabal` file or the `nix` derivation that builds `db-analyser`.
- [x] Output: `minor_gcs = GC.gcs - GC.major_gcs`.
- [x] Output `GC.allocated_bytes`
- [x] Remove roundtripping test and keep them in a branch (delete after ~1 year).