### PR TITLE
cardano-tools: allow to reference latest git commit hash

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,6 +51,7 @@
             inputs.iohkNix.overlays.crypto
             inputs.haskellNix.overlay
             inputs.iohkNix.overlays.haskell-nix-crypto
+            inputs.iohkNix.overlays.haskell-nix-extra
             (import ./nix/tools.nix inputs)
             (import ./nix/haskell.nix inputs)
             (import ./nix/pdfs.nix)

--- a/nix/ci.nix
+++ b/nix/ci.nix
@@ -12,14 +12,16 @@ let
       projectHsPkgsNoAsserts =
         haskellLib.selectProjectPackages hsPkgs.projectVariants.noAsserts.hsPkgs;
       noCross = buildSystem == hsPkgs.pkgs.stdenv.hostPlatform.system;
+      set-git-revs =
+        lib.mapAttrsRecursiveCond (as: !lib.isDerivation as) (pa: pkgs.set-git-rev);
     in
     {
       libs =
         haskellLib.collectComponents' "library" projectHsPkgs;
       exes =
-        haskellLib.collectComponents' "exes" projectHsPkgs;
+        set-git-revs (haskellLib.collectComponents' "exes" projectHsPkgs);
       exesNoAsserts =
-        haskellLib.collectComponents' "exes" projectHsPkgsNoAsserts;
+        set-git-revs (haskellLib.collectComponents' "exes" projectHsPkgsNoAsserts);
       benchmarks =
         haskellLib.collectComponents' "benchmarks" projectHsPkgs;
       tests =

--- a/ouroboros-consensus-cardano/app/db-analyser.hs
+++ b/ouroboros-consensus-cardano/app/db-analyser.hs
@@ -18,10 +18,12 @@ module Main (main) where
 import           Cardano.Crypto.Init (cryptoInit)
 import           Cardano.Tools.DBAnalyser.Run
 import           Cardano.Tools.DBAnalyser.Types
+import           Cardano.Tools.GitRev (gitRev)
 import           Control.Monad (void)
+import qualified Data.Text as T
 import           DBAnalyser.Parsers
-import           Options.Applicative (execParser, fullDesc, helper, info,
-                     progDesc, (<**>))
+import           Options.Applicative (execParser, footer, fullDesc, helper,
+                     info, progDesc, (<**>))
 
 
 main :: IO ()
@@ -39,4 +41,5 @@ getCmdLine = execParser opts
     opts = info (parseCmdLine <**> helper) (mconcat [
           fullDesc
         , progDesc "Simple framework used to analyse a Chain DB"
+        , footer $ "ouroboros-consensus commit: " <> T.unpack gitRev
         ])

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -457,6 +457,7 @@ library unstable-cardano-tools
     Cardano.Tools.DBSynthesizer.Types
     Cardano.Tools.DBTruncater.Run
     Cardano.Tools.DBTruncater.Types
+    Cardano.Tools.GitRev
     Cardano.Tools.ImmDBServer.Diffusion
     Cardano.Tools.ImmDBServer.MiniProtocols
 
@@ -483,6 +484,7 @@ library unstable-cardano-tools
     , cardano-crypto
     , cardano-crypto-class
     , cardano-crypto-wrapper
+    , cardano-git-rev
     , cardano-ledger-allegra
     , cardano-ledger-alonzo
     , cardano-ledger-api
@@ -503,6 +505,7 @@ library unstable-cardano-tools
     , directory
     , filepath
     , fs-api                         ^>=0.2
+    , githash
     , microlens
     , mtl
     , network
@@ -535,6 +538,7 @@ executable db-analyser
     , optparse-applicative
     , ouroboros-consensus
     , ouroboros-consensus-cardano:{ouroboros-consensus-cardano, unstable-cardano-tools}
+    , text
 
   other-modules:  DBAnalyser.Parsers
 

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/GitRev.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/GitRev.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell   #-}
+
+module Cardano.Tools.GitRev (gitRev) where
+
+import qualified Cardano.Git.Rev
+import           Data.Text (Text)
+import qualified Data.Text as T
+import           GitHash (giDirty, giHash, tGitInfoCwdTry)
+
+-- | A string representing what ouroboros-consensus git commit this code was
+-- built from. No particular format should be assumed.
+gitRev :: Text
+gitRev
+  | T.all (== '0') rev = "unavailable (git info missing at build time)"
+  | otherwise          = rev
+  where
+    rev =
+        $$(let eGitInfo = $$tGitInfoCwdTry in
+           -- Local binding only to avoid redundant pattern match warning
+           case eGitInfo of
+             Right gitInfo ->
+               [||T.pack (giHash gitInfo) <> if giDirty gitInfo then "-dirty" else ""||]
+             -- In case of failure, try cardano-git-rev (where the commit hash
+             -- can be embedded later).
+             Left _ -> [||Cardano.Git.Rev.gitRev||]
+          )


### PR DESCRIPTION
This PR enables to reference the commit hash in any of our cardano-tools. This works both when building via Cabal and Nix.

As an example, run one of

    cabal run db-analyser -- -h
    nix run .#db-analyser -- -h

and observe the commit hash at the bottom.

When the commit hash can't be obtained (eg because there is no `git` in the PATH, or the libraries were built in a context where the `.git` directory is not available), then the commit hash will be all zeroes.