### PR TITLE
ChainSync client: remove redundant `DoesntFit` check

### DIFF
--- a/ouroboros-consensus/changelog.d/20231127_103519_alexander.esgen_remove_CS_DoesntFit.md
+++ b/ouroboros-consensus/changelog.d/20231127_103519_alexander.esgen_remove_CS_DoesntFit.md
@@ -1,0 +1,3 @@
+### Breaking
+
+ - ChainSync client: remove redundant `DoesntFit` exception


### PR DESCRIPTION
Checking the previous hash of an incoming header is already done by `validateHeader`, via `validateEnvelope` here:

https://github.com/input-output-hk/ouroboros-consensus/blob/82dd1f3afeac3bc8a47910619011c8f1f863ee13/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HeaderValidation.hs#L311-L312

According to the git blame, this seems to be a historical leftover, and we can safely remove it.