### PR TITLE
enable NodeToNode V13 protocol

### DIFF
--- a/ouroboros-consensus-cardano/changelog.d/20231127_134955_alexander.esgen_enable_n2n_13.md
+++ b/ouroboros-consensus-cardano/changelog.d/20231127_134955_alexander.esgen_enable_n2n_13.md
@@ -1,0 +1,3 @@
+### Non-Breaking
+
+- Enable `NodeToNodeV_13` protocol.

--- a/ouroboros-consensus-cardano/changelog.d/20231127_154208_alexander.esgen_enable_n2n_13.md
+++ b/ouroboros-consensus-cardano/changelog.d/20231127_154208_alexander.esgen_enable_n2n_13.md
@@ -1,0 +1,4 @@
+### Non-Breaking
+
+- New tests to check that all network versions are supported by the Shelley and
+  Cardano blocks.

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -310,6 +310,7 @@ test-suite shelley-test
     Test.Consensus.Shelley.Coherence
     Test.Consensus.Shelley.Golden
     Test.Consensus.Shelley.Serialisation
+    Test.Consensus.Shelley.SupportedNetworkProtocolVersion
     Test.ThreadNet.Shelley
 
   build-depends:
@@ -331,7 +332,10 @@ test-suite shelley-test
     , ouroboros-consensus-protocol
     , ouroboros-consensus:{ouroboros-consensus, unstable-consensus-testlib}
     , QuickCheck
+    , sop-core
+    , strict-sop-core
     , tasty
+    , tasty-hunit
     , tasty-quickcheck
     , unstable-shelley-testlib
 
@@ -392,6 +396,7 @@ test-suite cardano-test
     Test.Consensus.Cardano.MiniProtocol.LocalTxSubmission.ByteStringTxParser
     Test.Consensus.Cardano.MiniProtocol.LocalTxSubmission.Server
     Test.Consensus.Cardano.Serialisation
+    Test.Consensus.Cardano.SupportedNetworkProtocolVersion
     Test.ThreadNet.AllegraMary
     Test.ThreadNet.Cardano
     Test.ThreadNet.MaryAlonzo

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Node.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Node.hs
@@ -544,6 +544,7 @@ instance CardanoHardForkConstraints c
       , (NodeToNodeV_10, CardanoNodeToNodeVersion6)
       , (NodeToNodeV_11, CardanoNodeToNodeVersion6)
       , (NodeToNodeV_12, CardanoNodeToNodeVersion7)
+      , (NodeToNodeV_13, CardanoNodeToNodeVersion7)
       ]
 
   supportedNodeToClientVersions _ = Map.fromList $

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/NetworkProtocolVersion.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/NetworkProtocolVersion.hs
@@ -52,6 +52,7 @@ instance SupportedNetworkProtocolVersion (ShelleyBlock proto era) where
       , (NodeToNodeV_10, ShelleyNodeToNodeVersion1)
       , (NodeToNodeV_11, ShelleyNodeToNodeVersion1)
       , (NodeToNodeV_12, ShelleyNodeToNodeVersion1)
+      , (NodeToNodeV_13, ShelleyNodeToNodeVersion1)
       ]
   supportedNodeToClientVersions _ = Map.fromList [
         (NodeToClientV_9,  ShelleyNodeToClientVersion5)

--- a/ouroboros-consensus-cardano/test/cardano-test/Main.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Main.hs
@@ -6,6 +6,7 @@ import qualified Test.Consensus.Cardano.ByronCompatibility
 import qualified Test.Consensus.Cardano.Golden
 import qualified Test.Consensus.Cardano.MiniProtocol.LocalTxSubmission.Server
 import qualified Test.Consensus.Cardano.Serialisation
+import qualified Test.Consensus.Cardano.SupportedNetworkProtocolVersion
 import           Test.Tasty
 import qualified Test.ThreadNet.AllegraMary
 import qualified Test.ThreadNet.Cardano
@@ -26,6 +27,7 @@ tests =
   [ Test.Consensus.Cardano.ByronCompatibility.tests
   , Test.Consensus.Cardano.Golden.tests
   , Test.Consensus.Cardano.Serialisation.tests
+  , Test.Consensus.Cardano.SupportedNetworkProtocolVersion.tests
   , Test.ThreadNet.AllegraMary.tests
   , Test.ThreadNet.Cardano.tests
   , Test.ThreadNet.MaryAlonzo.tests

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/Consensus/Cardano/SupportedNetworkProtocolVersion.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/Consensus/Cardano/SupportedNetworkProtocolVersion.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Consensus.Cardano.SupportedNetworkProtocolVersion (tests) where
+
+import           Data.Proxy
+import           Ouroboros.Consensus.Cardano
+import           Ouroboros.Consensus.Cardano.Block
+import           Ouroboros.Consensus.Protocol.Praos.Translate ()
+import           Ouroboros.Consensus.Shelley.Ledger.SupportsProtocol ()
+import           Test.Tasty
+import           Test.Tasty.HUnit
+import           Test.Util.SupportedNetworkProtocolVersion
+
+tests :: TestTree
+tests =
+      testCase "Cardano exhaustive network protocol versions"
+    $ exhaustiveSupportedNetworkProtocolVersions
+        (Proxy @(CardanoBlock StandardCrypto))

--- a/ouroboros-consensus-cardano/test/shelley-test/Main.hs
+++ b/ouroboros-consensus-cardano/test/shelley-test/Main.hs
@@ -3,6 +3,7 @@ module Main (main) where
 import qualified Test.Consensus.Shelley.Coherence (tests)
 import qualified Test.Consensus.Shelley.Golden (tests)
 import qualified Test.Consensus.Shelley.Serialisation (tests)
+import qualified Test.Consensus.Shelley.SupportedNetworkProtocolVersion (tests)
 import           Test.Tasty
 import qualified Test.ThreadNet.Shelley (tests)
 import           Test.Util.TestEnv (defaultMainWithTestEnv,
@@ -17,5 +18,6 @@ tests =
   [ Test.Consensus.Shelley.Coherence.tests
   , Test.Consensus.Shelley.Golden.tests
   , Test.Consensus.Shelley.Serialisation.tests
+  , Test.Consensus.Shelley.SupportedNetworkProtocolVersion.tests
   , Test.ThreadNet.Shelley.tests
   ]

--- a/ouroboros-consensus-cardano/test/shelley-test/Test/Consensus/Shelley/SupportedNetworkProtocolVersion.hs
+++ b/ouroboros-consensus-cardano/test/shelley-test/Test/Consensus/Shelley/SupportedNetworkProtocolVersion.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Consensus.Shelley.SupportedNetworkProtocolVersion (tests) where
+
+import           Data.Proxy
+import           Data.SOP.BasicFunctors
+import           Data.SOP.Constraint
+import           Data.SOP.Strict
+import           Data.Typeable (Typeable)
+import           Ouroboros.Consensus.Cardano.Block
+import           Ouroboros.Consensus.Node.NetworkProtocolVersion
+                     (SupportedNetworkProtocolVersion)
+import           Ouroboros.Consensus.Protocol.Praos.Translate ()
+import           Ouroboros.Consensus.Shelley.Ledger.SupportsProtocol ()
+import           Test.Tasty
+import           Test.Tasty.HUnit
+import           Test.Util.SupportedNetworkProtocolVersion
+
+tests :: TestTree
+tests =
+      testCase "Shelley exhaustive network protocol versions"
+    . sequence_
+    . hcollapse
+    . hcmap
+        (Proxy @(And Typeable SupportedNetworkProtocolVersion))
+        (K . exhaustiveSupportedNetworkProtocolVersions)
+    $ shelleyBlocks
+  where
+    shelleyBlocks :: NP Proxy (CardanoShelleyEras StandardCrypto)
+    shelleyBlocks = hpure Proxy

--- a/ouroboros-consensus/changelog.d/20231127_154213_alexander.esgen_enable_n2n_13.md
+++ b/ouroboros-consensus/changelog.d/20231127_154213_alexander.esgen_enable_n2n_13.md
@@ -1,0 +1,3 @@
+### Non-Breaking
+
+- New internal testing module.

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -326,6 +326,7 @@ library unstable-consensus-testlib
     Test.Util.SOP
     Test.Util.Split
     Test.Util.Stream
+    Test.Util.SupportedNetworkProtocolVersion
     Test.Util.TestBlock
     Test.Util.TestEnv
     Test.Util.Time
@@ -371,6 +372,7 @@ library unstable-consensus-testlib
     , tasty
     , tasty-expected-failure
     , tasty-golden
+    , tasty-hunit
     , tasty-quickcheck
     , template-haskell
     , text

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/SupportedNetworkProtocolVersion.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/SupportedNetworkProtocolVersion.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Test.Util.SupportedNetworkProtocolVersion (exhaustiveSupportedNetworkProtocolVersions) where
+
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import           Data.Proxy
+import qualified Data.Set as Set
+import           Data.Typeable
+import           Ouroboros.Consensus.Node.NetworkProtocolVersion
+import           Test.Tasty.HUnit
+
+-- | Make sure that 'supportedNodeToNodeVersions' and
+-- 'supportedNodeToClientVersions' contain entries for all 'NodeToNodeVersion's
+-- and 'NodeToClientVersion', respectively.
+exhaustiveSupportedNetworkProtocolVersions ::
+     forall blk. (Typeable blk, SupportedNetworkProtocolVersion blk)
+  => Proxy blk
+  -> Assertion
+exhaustiveSupportedNetworkProtocolVersions p = do
+    testVersions supportedNodeToNodeVersions
+    testVersions supportedNodeToClientVersions
+  where
+    testVersions ::
+         (Show v, Ord v, Enum v, Bounded v)
+      => (Proxy blk -> Map v a)
+      -> Assertion
+    testVersions f =
+        assertBool
+          (   "unmapped versions for " <> show (typeRep p) <> ": "
+           <> show (Set.toList unmappedVersions)
+          )
+          (Set.null unmappedVersions)
+      where
+        unmappedVersions = allVersions Set.\\ mappedVersions
+        allVersions      = Set.fromList [minBound .. maxBound]
+        mappedVersions   = Map.keysSet $ f p


### PR DESCRIPTION
The largest available n2n version is v13. This makes it possible to negotiate for it provided that the experimental protocols flag is set.

Also add a test that we can catch this in CI in the future.