### PR TITLE
Do not even propagate future headers

### DIFF
--- a/ouroboros-consensus-diffusion/changelog.d/20231129_105548_nick.frisby_ChainSync_future.md
+++ b/ouroboros-consensus-diffusion/changelog.d/20231129_105548_nick.frisby_ChainSync_future.md
@@ -1,0 +1,23 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+
+### Breaking
+
+- Integrate the new `InFutureCheck` in the ChainSync client, which requires new
+  fields in `NodeKernalArgs`.

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -213,7 +213,7 @@ mkHandlers
   -- ^ Peer Sharing result computation callback
   -> Handlers       m addrNTN           blk
 mkHandlers
-      NodeKernelArgs {keepAliveRng, miniProtocolParameters}
+      NodeKernelArgs {chainSyncFutureCheck, keepAliveRng, miniProtocolParameters}
       NodeKernel {getChainDB, getMempool, getTopLevelConfig, getTracers = tracers}
       computePeers =
     Handlers {
@@ -224,6 +224,7 @@ mkHandlers
               (chainSyncPipeliningHighMark miniProtocolParameters))
             (contramap (TraceLabelPeer peer) (Node.chainSyncClientTracer tracers))
             getTopLevelConfig
+            chainSyncFutureCheck
             (defaultChainDbView getChainDB)
       , hChainSyncServer = \peer _version ->
           chainSyncHeadersServer

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
@@ -74,6 +74,7 @@ import           Ouroboros.Consensus.Fragment.InFuture (CheckInFuture,
                      ClockSkew)
 import qualified Ouroboros.Consensus.Fragment.InFuture as InFuture
 import           Ouroboros.Consensus.Ledger.Extended (ExtLedgerState (..))
+import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck as InFutureCheck
 import qualified Ouroboros.Consensus.Network.NodeToClient as NTC
 import qualified Ouroboros.Consensus.Network.NodeToNode as NTN
 import           Ouroboros.Consensus.Node.DbLock
@@ -392,6 +393,7 @@ runWith RunNodeArgs{..} encAddrNtN decAddrNtN LowLevelRunNodeArgs{..} =
                 cfg
                 rnTraceConsensus
                 btime
+                (InFutureCheck.realHeaderInFutureCheck llrnMaxClockSkew systemTime)
                 chainDB
           nodeKernel <- initNodeKernel nodeKernelArgs
           rnNodeKernelHook registry nodeKernel
@@ -639,6 +641,7 @@ mkNodeKernelArgs
   -> TopLevelConfig blk
   -> Tracers m (ConnectionId addrNTN) (ConnectionId addrNTC) blk
   -> BlockchainTime m
+  -> InFutureCheck.HeaderInFutureCheck m blk
   -> ChainDB m blk
   -> m (NodeKernelArgs m addrNTN (ConnectionId addrNTC) blk)
 mkNodeKernelArgs
@@ -648,6 +651,7 @@ mkNodeKernelArgs
   cfg
   tracers
   btime
+  chainSyncFutureCheck
   chainDB
   = do
     return NodeKernelArgs
@@ -657,6 +661,7 @@ mkNodeKernelArgs
       , btime
       , chainDB
       , initChainDB             = nodeInitChainDB
+      , chainSyncFutureCheck
       , blockFetchSize          = estimateBlockSize
       , mempoolCapacityOverride = NoMempoolCapacityBytesOverride
       , miniProtocolParameters  = defaultMiniProtocolParameters

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -55,6 +55,8 @@ import           Ouroboros.Consensus.Ledger.SupportsPeerSelection
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Mempool
 import qualified Ouroboros.Consensus.MiniProtocol.BlockFetch.ClientInterface as BlockFetchClientInterface
+import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck
+                     (HeaderInFutureCheck)
 import           Ouroboros.Consensus.Node.Run
 import           Ouroboros.Consensus.Node.Tracers
 import           Ouroboros.Consensus.Protocol.Abstract
@@ -132,6 +134,7 @@ data NodeKernelArgs m addrNTN addrNTC blk = NodeKernelArgs {
     , btime                   :: BlockchainTime m
     , chainDB                 :: ChainDB m blk
     , initChainDB             :: StorageConfig blk -> InitChainDB m blk -> m ()
+    , chainSyncFutureCheck    :: HeaderInFutureCheck m blk
     , blockFetchSize          :: Header blk -> SizeInBytes
     , mempoolCapacityOverride :: MempoolCapacityBytesOverride
     , miniProtocolParameters  :: MiniProtocolParameters

--- a/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
@@ -70,6 +70,7 @@ import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Mempool
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client as CSClient
+import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck as InFutureCheck
 import qualified Ouroboros.Consensus.Network.NodeToNode as NTN
 import           Ouroboros.Consensus.Node.ExitPolicy
 import           Ouroboros.Consensus.Node.InitStorage
@@ -974,6 +975,10 @@ runThreadNetwork systemTime ThreadNetworkArgs
             , btime
             , chainDB
             , initChainDB             = nodeInitChainDB
+            , chainSyncFutureCheck    =
+                  InFutureCheck.realHeaderInFutureCheck
+                    InFuture.defaultClockSkew
+                    (OracularClock.finiteSystemTime clock)
             , blockFetchSize          = estimateBlockSize
             , mempoolCapacityOverride = NoMempoolCapacityBytesOverride
             , keepAliveRng            = kaRng

--- a/ouroboros-consensus/changelog.d/20231129_105543_nick.frisby_ChainSync_future.md
+++ b/ouroboros-consensus/changelog.d/20231129_105543_nick.frisby_ChainSync_future.md
@@ -1,0 +1,24 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+### Breaking
+
+- Added a new `InFutureCheck` to the ChainSync client, which requires
+  additional arguments to the 'chainSyncClient' definition. The node no longer
+  propagates headers/blocks from the future: a ChainSync client thread now
+  sleeps until the received header is no longer from the future.

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -484,6 +484,7 @@ test-suite consensus-test
   build-depends:
     , async
     , base
+    , base-deriving-via
     , cardano-binary
     , cardano-crypto-class
     , cardano-slotting
@@ -505,6 +506,7 @@ test-suite consensus-test
     , ouroboros-network-protocols:{ouroboros-network-protocols, testlib}
     , QuickCheck
     , quickcheck-state-machine
+    , quiet
     , random
     , serialise
     , si-timers

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -141,6 +141,7 @@ library
     Ouroboros.Consensus.MiniProtocol.BlockFetch.ClientInterface
     Ouroboros.Consensus.MiniProtocol.BlockFetch.Server
     Ouroboros.Consensus.MiniProtocol.ChainSync.Client
+    Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck
     Ouroboros.Consensus.MiniProtocol.ChainSync.Server
     Ouroboros.Consensus.MiniProtocol.LocalStateQuery.Server
     Ouroboros.Consensus.MiniProtocol.LocalTxMonitor.Server

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Fragment/InFuture.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Fragment/InFuture.hs
@@ -16,8 +16,9 @@ module Ouroboros.Consensus.Fragment.InFuture (
     -- * Clock skew
   , clockSkewInSeconds
   , defaultClockSkew
-    -- ** opaque
+    -- ** not exporting the constructor
   , ClockSkew
+  , unClockSkew
     -- * Testing
   , dontCheck
   , miracle

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client/InFutureCheck.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client/InFutureCheck.hs
@@ -1,0 +1,145 @@
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleContexts          #-}
+{-# LANGUAGE GADTs                     #-}
+{-# LANGUAGE ScopedTypeVariables       #-}
+{-# LANGUAGE StandaloneDeriving        #-}
+{-# LANGUAGE TypeApplications          #-}
+
+module Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck (
+    -- * Interface
+    HeaderInFutureCheck (..)
+    -- * Real Implementation
+  , HeaderArrivalException (..)
+  , realHeaderInFutureCheck
+  ) where
+
+import           Control.Exception (Exception)
+import           Control.Monad (guard, unless)
+import           Control.Monad.Class.MonadTimer.SI (MonadDelay, threadDelay)
+import           Control.Monad.Except (Except, liftEither)
+import           Data.Proxy (Proxy (Proxy))
+import           Data.Time.Clock (NominalDiffTime)
+import           Data.Type.Equality ((:~:) (Refl))
+import           Data.Typeable (eqT)
+import           Ouroboros.Consensus.Block.Abstract (Header)
+import           Ouroboros.Consensus.Block.RealPoint (RealPoint,
+                     headerRealPoint, realPointSlot)
+import           Ouroboros.Consensus.BlockchainTime.WallClock.Types
+                     (RelativeTime, SystemTime, diffRelTime, systemTimeCurrent)
+import           Ouroboros.Consensus.Fragment.InFuture (ClockSkew, unClockSkew)
+import           Ouroboros.Consensus.HardFork.Abstract (HasHardForkHistory,
+                     hardForkSummary)
+import           Ouroboros.Consensus.HardFork.History (PastHorizonException)
+import           Ouroboros.Consensus.HardFork.History.Qry (runQuery,
+                     slotToWallclock)
+import           Ouroboros.Consensus.Ledger.Basics (LedgerConfig, LedgerState)
+import           Ouroboros.Consensus.Util.Time (nominalDelay)
+import           Ouroboros.Network.Block (HasHeader)
+
+{-------------------------------------------------------------------------------
+  Interface
+-------------------------------------------------------------------------------}
+
+-- | The interface a ChainSync client needs in order to check the arrival time
+-- of headers.
+--
+-- Instead of alphabetical, the fields are in the order in which the ChainSync
+-- client logic will invoke them for each header.
+data HeaderInFutureCheck m blk = forall arrival judgment. HeaderInFutureCheck {
+    proxyArrival :: Proxy arrival
+  ,
+    -- | This is ideally called _immediately_ upon the header arriving.
+    recordHeaderArrival :: Header blk -> m arrival
+  ,
+    -- | Judge what to do about the header's arrival time.
+    --
+    -- Note that this may be called after a delay, hence @arrival@ contains at
+    -- least the arrival time.
+    --
+    -- In particular, such a delay might be caused by waiting for the
+    -- intersection with the local selection to change after this function
+    -- returns 'Ouroboros.Consensus.HardFork.HistoryPastHorizon'.
+    judgeHeaderArrival ::
+         LedgerConfig blk
+      -> LedgerState blk
+      -> arrival
+      -> Except PastHorizonException judgment
+  ,
+    -- | Enact the judgment.
+    --
+    -- If @Just@ is returned, an exception should be raised.
+    handleHeaderArrival :: judgment -> m (Maybe HeaderArrivalException)
+  }
+
+{-------------------------------------------------------------------------------
+  Real implmementation
+-------------------------------------------------------------------------------}
+
+data HeaderArrivalException =
+  -- | The header arrived so early that its issuer either minted it before
+  -- their clock reached its slot onset or else the difference between their
+  -- clock and ours is more severe than we're configured to tolerate.
+  --
+  -- INVARIANT: @'tolerableClockSkew' < negate 'ageUponArrival'@
+  forall blk. HasHeader blk => FarFutureHeaderException {
+      ageUponArrival     :: !NominalDiffTime
+    ,
+      arrivedPoint       :: !(RealPoint blk)
+    ,
+      arrivalTime        :: !RelativeTime
+    ,
+      tolerableClockSkew :: !NominalDiffTime
+    }
+
+deriving instance Show HeaderArrivalException
+
+instance Exception HeaderArrivalException
+
+instance Eq HeaderArrivalException where
+  (==)
+    (FarFutureHeaderException l0 (l1 :: RealPoint l) l2 l3)
+    (FarFutureHeaderException r0 (r1 :: RealPoint r) r2 r3)
+    = case eqT @l @r of
+        Nothing   -> False
+        Just Refl -> (l0, l1, l2, l3) == (r0, r1, r2, r3)
+
+realHeaderInFutureCheck ::
+  ( HasHeader blk
+  , HasHeader (Header blk)
+  , HasHardForkHistory blk
+  , MonadDelay m
+  )
+  => ClockSkew -> SystemTime m -> HeaderInFutureCheck m blk
+realHeaderInFutureCheck skew systemTime = HeaderInFutureCheck {
+    proxyArrival        = Proxy
+  , recordHeaderArrival = \hdr -> do
+        (,) (headerRealPoint hdr) <$> systemTimeCurrent systemTime
+  , judgeHeaderArrival = \lcfg lst (p, arrivalTime_) -> do
+        let qry       = slotToWallclock (realPointSlot p)
+            hfSummary = hardForkSummary lcfg lst
+              -- TODO cache this in the KnownIntersectionState? Or even in the
+              -- LedgerDB?
+        (onset, _slotLength) <- liftEither $ runQuery qry hfSummary
+        pure (p, arrivalTime_, onset)
+  , handleHeaderArrival = \(p, arrivalTime_, onset) -> do
+        let ageUponArrival_ = arrivalTime_ `diffRelTime` onset
+            tooEarly        = unClockSkew skew < negate ageUponArrival_
+              -- TODO leap seconds?
+
+        -- this delay is the simple part of Ouroboros Chronos
+        unless tooEarly $ do
+            now <- systemTimeCurrent systemTime
+            let ageNow         = now `diffRelTime` onset
+                syntheticDelay = negate ageNow
+            threadDelay $ nominalDelay syntheticDelay   -- TODO leap seconds?
+               -- recall that threadDelay ignores negative arguments
+
+        pure $ do
+            guard tooEarly   -- no exception if within skew
+            pure FarFutureHeaderException {
+                ageUponArrival     = ageUponArrival_
+              , arrivedPoint       = p
+              , arrivalTime        = arrivalTime_
+              , tolerableClockSkew = unClockSkew skew
+              }
+  }

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/Time.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/Time.hs
@@ -1,10 +1,21 @@
 module Ouroboros.Consensus.Util.Time (
-    -- Conversions
-    nominalDelay
+    multipleNominalDelay
+  , nominalDelay
   , secondsToNominalDiffTime
   ) where
 
 import           Data.Time (DiffTime, NominalDiffTime)
+
+{-------------------------------------------------------------------------------
+  Operations
+-------------------------------------------------------------------------------}
+
+-- | Multiply a 'NominalDiffTime' by an integer
+--
+-- The right conversions to use are somewhat tricky. The key fact is that
+-- 'fromIntegral' interprets its argument as seconds.
+multipleNominalDelay :: Integral a => NominalDiffTime -> a -> NominalDiffTime
+multipleNominalDelay dur i = dur * fromIntegral i
 
 {-------------------------------------------------------------------------------
   Conversions


### PR DESCRIPTION
@njd42 and I came up with this idea a couple weeks ago, during a chat about the vagaries of NTP/clocks/etc.

See the commit message of the 'consensus: do not even propagate future headers' commit.

The main concrete benefits:

- It's a step towards Chronos and that helps simplify/ground our story around future blocks.
- A network-load optimization of sorts: if someone with a horribly out of sync clock sends a block 60 seconds early, the direct neighbors won't even propagate it.