### PR TITLE
Make BlockSend a scheduled handler

### DIFF
--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Handlers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Handlers.hs
@@ -14,19 +14,24 @@ module Test.Consensus.PeerSimulator.Handlers (
     handlerBlockFetch
   , handlerFindIntersection
   , handlerRequestNext
+  , handlerSendBlocks
   ) where
 
-import           Cardano.Slotting.Slot (WithOrigin)
+import           Cardano.Slotting.Slot (WithOrigin (..))
 import           Control.Monad.Trans (lift)
 import           Control.Monad.Writer.Strict (MonadWriter (tell),
                      WriterT (runWriterT))
 import           Data.Coerce (coerce)
+import           Data.List (isSuffixOf)
+import qualified Data.List.NonEmpty as NonEmpty
 import           Data.Maybe (fromJust, fromMaybe)
 import           Ouroboros.Consensus.Block (HasHeader, Header, HeaderHash,
-                     Point (GenesisPoint), castPoint, getHeader, withOrigin)
+                     Point (GenesisPoint), blockHash, castPoint, getHeader,
+                     withOrigin)
 import           Ouroboros.Consensus.Util.Condense (Condense (..))
 import           Ouroboros.Consensus.Util.IOLike (IOLike, STM, StrictTVar,
                      readTVar, writeTVar)
+import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block (blockPoint, getTipPoint)
 import           Ouroboros.Network.BlockFetch.ClientState
@@ -35,18 +40,40 @@ import qualified Test.Consensus.BlockTree as BT
 import           Test.Consensus.BlockTree (BlockTree)
 import           Test.Consensus.Network.AnchoredFragment.Extras (intersectWith)
 import           Test.Consensus.PeerSimulator.ScheduledBlockFetchServer
-                     (BlockFetch (..))
+                     (BlockFetch (..), SendBlocks (..))
 import           Test.Consensus.PeerSimulator.ScheduledChainSyncServer
                      (FindIntersect (..),
                      RequestNext (AwaitReply, RollBackward, RollForward))
-import           Test.Consensus.PeerSimulator.Trace (terseFrag, tersePoint)
+import           Test.Consensus.PeerSimulator.Trace (terseBlock, terseFrag,
+                     tersePoint)
 import           Test.Consensus.PointSchedule
 import           Test.Util.Orphans.IOLike ()
-import           Test.Util.TestBlock (TestBlock, TestHash)
+import           Test.Util.TestBlock (TestBlock, TestHash (TestHash))
 
 
 toPoint :: (HasHeader block, HeaderHash block ~ TestHash) => WithOrigin block -> Point TestBlock
 toPoint = castPoint . withOrigin GenesisPoint blockPoint
+
+-- | More efficient implementation of a check used in some of the handlers,
+-- determining whether the first argument is on the chain that ends in the
+-- second argument.
+-- We would usually call @withinFragmentBounds@ for this, but since we're
+-- using 'TestBlock', looking at the hash is cheaper.
+isAncestorOf ::
+  HasHeader blk1 =>
+  HasHeader blk2 =>
+  HeaderHash blk1 ~ TestHash =>
+  HeaderHash blk2 ~ TestHash =>
+  WithOrigin blk1 ->
+  WithOrigin blk2 ->
+  Bool
+isAncestorOf (At ancestor) (At descendant) =
+  isSuffixOf (NonEmpty.toList hashA) (NonEmpty.toList hashD)
+  where
+    TestHash hashA = blockHash ancestor
+    TestHash hashD = blockHash descendant
+isAncestorOf (At _) Origin = False
+isAncestorOf Origin _ = True
 
 -- | Handle a @MsgFindIntersect@ message.
 --
@@ -148,6 +175,16 @@ handlerRequestNext currentIntersection blockTree points =
 
     trace = tell . pure
 
+-- REVIEW: We call this a lot, and I assume it creates some significant overhead.
+-- We should figure out a cheaper way to achieve what we're doing with the result.
+-- Since we're in TestBlock, we can at least check whether a block can extend another block,
+-- but then we won't be able to generalize later.
+fragmentUpTo :: BlockTree TestBlock -> String -> Point TestBlock -> AnchoredFragment TestBlock
+fragmentUpTo blockTree desc b =
+  fromMaybe fatal (BT.findFragment b blockTree)
+  where
+    fatal = error ("BlockFetch: Could not find " ++ desc ++ " in the block tree")
+
 -- | Handle the BlockFetch message (it actually has only one unnamed entry point).
 --
 -- If the requested range ends not after BP, send them.
@@ -160,44 +197,144 @@ handlerBlockFetch ::
   ChainRange (Point TestBlock) ->
   AdvertisedPoints ->
   STM m (Maybe BlockFetch, [String])
-handlerBlockFetch blockTree (ChainRange from to) AdvertisedPoints {header = HeaderPoint hp, block = BlockPoint bp} =
-  runWriterT (serveFromBpFragment (AF.sliceRange bpChain from to))
+handlerBlockFetch blockTree (ChainRange from to) AdvertisedPoints {header = HeaderPoint hp} =
+  runWriterT (serveFromBpFragment (AF.sliceRange hpChain from to))
   where
-    -- Check whether the requested range is contained in the fragment before the block point.
-    -- We may only serve the full range; if the server has only some of the blocks, it must refuse.
+    -- Check whether the requested range is contained in the fragment before the header point.
+    -- We may only initiate batch serving if the full range is available; if the server has only some of the blocks, it
+    -- must refuse.
     serveFromBpFragment = \case
       Just slice -> do
-        trace ("Sending slice " ++ terseFrag slice)
+        trace ("Starting batch for slice " ++ terseFrag slice)
         pure (Just (StartBatch (AF.toOldestFirst slice)))
       Nothing    -> do
-        -- If we cannot serve blocks from the BP chain, decide whether to yield control to the scheduler
-        -- or serve blocks anyway.
-        --
-        -- If the @to@ point is not part of the HP chain but BP is, we must have switched to a fork without ensuring
-        -- that BP advances to the last HP advertised on the old chain.
-        -- This should be a precondition violation, but because it would make the schedule generator more complex, we
-        -- simply serve the missing blocks anyway here.
-        --
-        -- Otherwise, we simply have to wait for BP to advance sufficiently, and we block without sending
-        -- a message, to simulate a slow response.
-        case not (AF.withinFragmentBounds to hpChain) && AF.withinFragmentBounds (toPoint bp) hpChain of
-          True ->
-            case AF.sliceRange (fragmentUpTo "requested point" to) from to of
-              Just slice -> do
-                trace "Sending range due to incomplete fork switch"
-                pure (Just (StartBatch (AF.toOldestFirst slice)))
-              Nothing    -> error "BlockFetch: Client requested blocks that aren't in the block tree"
-          False  -> do
-            trace ("Waiting for next tick for range: " ++ tersePoint from ++ " -> " ++ tersePoint to)
-            pure Nothing
+        trace ("Waiting for next tick for range: " ++ tersePoint from ++ " -> " ++ tersePoint to)
+        pure Nothing
 
-    bpChain = fragmentUpTo "block point" (toPoint bp)
-
-    hpChain = fragmentUpTo "header point" (toPoint hp)
+    hpChain = fragmentUpTo blockTree "header point" (toPoint hp)
 
     trace = tell . pure
 
-    fragmentUpTo sort b =
-      fromMaybe (fatal sort) (BT.findFragment b blockTree)
+{-
+If we cannot serve blocks from the BP chain, we need to decide whether to yield control to the scheduler
+or serve blocks anyway.
 
-    fatal sort = error ("BlockFetch: Could not find " ++ sort ++ " in the block tree")
+If the next block to deliver is part of the HP chain, we have to wait for BP to advance
+sufficiently, and we block without sending a message, to simulate a slow response.
+
+If the next block to deliver is not part of the HP chain, we must have switched to a fork without
+ensuring that BP advances to the last HP advertised on the old chain.
+While BP is not on the same chain as HP we wait, because BP might still advance to
+allow the next block to be sent. If BP is in the same chain as HP, we interpret
+that BP has left the old branch, and the requested blocks should be sent at this
+time.
+
+The cases to consider follow:
+
+ 0 1 2 3 4 5 6
+ x-x-x-x-x-x-x
+         ^BP ^HP
+       \-x-x-x
+         ^next
+✅ send the blocks because a rollback happened
+
+ 0 1 2 3 4 5 6
+ x-x-x-x-x-x-x
+   ^BP       ^HP
+       \-x-x-x
+         ^next
+
+❌ BP might still go on the fork where next is, so don't send the blocks yet
+
+ 0 1 2 3 4 5 6
+ x-x-x-x-x-x-x
+   ^BP
+     \-x-x-x-x
+       ^next ^HP
+
+❌ BP could still go on the fork where next is, don't send the blocks yet
+
+ 0 1 2 3 4 5 6
+ x-x-x-x-x-x-x
+     ^BP
+   \-x-x-x-x-x
+     ^next   ^HP
+
+❌ BP could still go on the fork where next is, don't send the blocks yet
+
+ 0 1 2 3 4 5 6
+ x-x-x-x-x-x-x
+     ^BP
+   \-x-x-x-x-x
+     ^next
+   \-x-x-x-x-x
+       ^HP
+
+❌ BP could still go on the fork where next is, don't send the blocks yet
+
+ 0 1 2 3 4 5 6
+ x-x-x-x-x-x-x
+     ^HP
+   \-x-x-x-x-x
+     ^next   ^BP
+
+✅ send the blocks because BP is after next
+
+ 0 1 2 3 4 5 6
+ x-x-x-x-x-x-x
+     ^HP
+   \-x-x-x-x-x
+     ^BP   ^next
+
+❌ BP could still advance past next, don't send the blocks yet
+
+-}
+handlerSendBlocks ::
+  forall m .
+  IOLike m =>
+  [TestBlock] ->
+  AdvertisedPoints ->
+  STM m (Maybe SendBlocks, [String])
+handlerSendBlocks blocks AdvertisedPoints {header = HeaderPoint hp, block = BlockPoint bp} =
+  runWriterT (checkDone blocks)
+  where
+    checkDone = \case
+      [] -> do
+        trace "Batch done"
+        pure (Just BatchDone)
+      (next : future) ->
+        blocksLeft next future
+
+    blocksLeft next future
+      | isAncestorOf (At next) bp
+      || compensateForScheduleRollback next
+      = do
+        trace ("Sending " ++ terseBlock next)
+        pure (Just (SendBlock next future))
+
+      | otherwise
+      = do
+        trace "BP is behind"
+        pure Nothing
+
+    -- Here we encode the conditions for the special situation mentioned above.
+    -- These use aliases for @withinFragmentBounds@ to illustrate what we're testing.
+    -- The names don't precisely match semantically, but it's difficult to understand the
+    -- circumstances otherwise.
+    --
+    -- The involved points are BP, HP, and @next@, which is the block we're deciding whether to
+    -- send or not.
+    --
+    -- Remember that at this point, we already know that we cannot send @next@ regularly, i.e.
+    -- @next@ is not on the chain leading up to BP.
+    -- The conditions in which we send @next@ to compensate for rollbacks are:
+    --
+    -- * @next@ is not on the chain leading up to HP – HP moved to another chain, and
+    --
+    -- * BP is in the same chain as HP and is not an ancestor of @next@ - BP also moved away from the chain of @next@.
+    --
+    -- Precondition: @not (isAncestorOf (At next) bp)@
+    compensateForScheduleRollback next =
+      not (isAncestorOf (At next) hp) && isAncestorOf bp hp && not (isAncestorOf bp (At next))
+
+    trace = tell . pure


### PR DESCRIPTION
The previous implementation of the scheduled BlockFetch server used BP as an indicator of whether to start sending a range of blocks.

That meant that when the client requested some blocks that were within bounds of HP, but BP wasn't beyond the _latest_ block of the requested range, we would stall until a later tick, and send the entire range of blocks in that tick.

We now decided that it would be a better manifestation of the test plan if BP controlled whether an _individual_ block is sent within a given tick.
Therefore, we now use HP to transition to sending a batch, then hook into the scheduler before sending each block.
