### PR TITLE
Add Renate to list of contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -361,6 +361,8 @@ The core contributors to consensus codebase are:
 
 -   [Damian Nadales](https://github.com/dnadales)
 
+-   [Renate Eilers](https://github.com/RenateEilers)
+
 # Code of conduct
 
 See [Cardano engineering


### PR DESCRIPTION
# Description

This PR adds Renate to the list of contributors in order to solve the urgent lack of Renates in the list of contributors.
