### PR TITLE
Bundle arguments to ChainSync.Client and internally refactor the core definition

### DIFF
--- a/ouroboros-consensus-diffusion/changelog.d/20231206_171853_nick.frisby_ChainSync_refactor.md
+++ b/ouroboros-consensus-diffusion/changelog.d/20231206_171853_nick.frisby_ChainSync_refactor.md
@@ -1,0 +1,24 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+
+### Breaking
+
+- The upstream ChainSync client refactoring required changes to NodeKernelArgs
+  and Handlers.
+

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
@@ -641,7 +641,7 @@ mkNodeKernelArgs
   -> TopLevelConfig blk
   -> Tracers m (ConnectionId addrNTN) (ConnectionId addrNTC) blk
   -> BlockchainTime m
-  -> InFutureCheck.HeaderInFutureCheck m blk
+  -> InFutureCheck.SomeHeaderInFutureCheck m blk
   -> ChainDB m blk
   -> m (NodeKernelArgs m addrNTN (ConnectionId addrNTC) blk)
 mkNodeKernelArgs

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node/ExitPolicy.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node/ExitPolicy.hs
@@ -5,7 +5,7 @@ module Ouroboros.Consensus.Node.ExitPolicy (
   , ReturnPolicy
   ) where
 
-import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client
+import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client as CSClient
 import           Ouroboros.Network.ExitPolicy
 
 
@@ -13,7 +13,7 @@ import           Ouroboros.Network.ExitPolicy
 -- `chain-sync` results.
 --
 data NodeToNodeInitiatorResult =
-    ChainSyncInitiatorResult !ChainSyncClientResult
+    ChainSyncInitiatorResult !CSClient.ChainSyncClientResult
   | NoInitiatorResult
 
 
@@ -22,10 +22,10 @@ returnPolicy NoInitiatorResult = ReconnectDelay 10
 returnPolicy (ChainSyncInitiatorResult result) = case result of
   -- TODO: it would be nice to have additional context to predict when we will
   -- be ready to reconnect.
-  ForkTooDeep      _ _ourTip _theirTip -> ReconnectDelay 120
-  NoMoreIntersection _ourTip _theirTip -> ReconnectDelay 120
-  RolledBackPastIntersection
-                   _ _ourTip _theirTip -> ReconnectDelay 180
+  CSClient.ForkTooDeep      _ _ourTip _theirTip -> ReconnectDelay 120
+  CSClient.NoMoreIntersection _ourTip _theirTip -> ReconnectDelay 120
+  CSClient.RolledBackPastIntersection
+                            _ _ourTip _theirTip -> ReconnectDelay 180
   -- the outbound-governor asked for hot to warm demotion; it's up to the
   -- governor to decide to promote the peer to hot.
-  AskedToTerminate                     -> ReconnectDelay 10
+  CSClient.AskedToTerminate                     -> ReconnectDelay 10

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -56,7 +56,7 @@ import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Mempool
 import qualified Ouroboros.Consensus.MiniProtocol.BlockFetch.ClientInterface as BlockFetchClientInterface
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck
-                     (HeaderInFutureCheck)
+                     (SomeHeaderInFutureCheck)
 import           Ouroboros.Consensus.Node.Run
 import           Ouroboros.Consensus.Node.Tracers
 import           Ouroboros.Consensus.Protocol.Abstract
@@ -134,7 +134,7 @@ data NodeKernelArgs m addrNTN addrNTC blk = NodeKernelArgs {
     , btime                   :: BlockchainTime m
     , chainDB                 :: ChainDB m blk
     , initChainDB             :: StorageConfig blk -> InitChainDB m blk -> m ()
-    , chainSyncFutureCheck    :: HeaderInFutureCheck m blk
+    , chainSyncFutureCheck    :: SomeHeaderInFutureCheck m blk
     , blockFetchSize          :: Header blk -> SizeInBytes
     , mempoolCapacityOverride :: MempoolCapacityBytesOverride
     , miniProtocolParameters  :: MiniProtocolParameters

--- a/ouroboros-consensus/bench/ChainSync-client-bench/Bench/Consensus/ChainSyncClient/Driver.hs
+++ b/ouroboros-consensus/bench/ChainSync-client-bench/Bench/Consensus/ChainSyncClient/Driver.hs
@@ -1,0 +1,143 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE LambdaCase   #-}
+
+module Bench.Consensus.ChainSyncClient.Driver (mainWith) where
+
+import           Control.Monad (when)
+import qualified Data.Array.IO as UA
+import           Data.Int (Int64)
+import           Data.Time.Clock (diffTimeToPicoseconds)
+import qualified Data.Time.Clock.System as SysTime
+import qualified Data.Time.Clock.TAI as TAI
+import           Data.Word (Word32)
+import           System.Environment (getArgs)
+import           Text.Read (readMaybe)
+
+-- | The argument to the function under test
+--
+-- This is comparable to the "size" argument in QuickCheck.
+newtype X = X Int64
+
+{-# INLINE mainWith #-}
+mainWith :: (Int64 -> IO ()) -> IO ()
+mainWith fut = do
+    xx <- getArgs >>= \case
+        [loStr, hiStr]
+          | Just lo <- readMaybe loStr
+          , Just hi <- readMaybe hiStr
+          -> pure (X lo, X hi)
+        _ -> fail "Pass min and max index as arguments $1 and $2"
+
+    let zz@(!lo, !hi) = mkMeasurementIndexInterval xx
+
+    -- all the extraneous allocation happens up front
+    --
+    -- TODO except the getSystemTime FFI overhead. I haven't find a
+    -- platform-agnostic package for reading the clock into a pre-allocated
+    -- buffer (eg via Storable)
+    varStarts <- newTimeArray_ zz
+    varStops  <- newTimeArray_ zz
+
+    let go !z = do
+            recordTimeArray varStarts z
+            let X i = fst $ coords z in fut i
+            recordTimeArray varStops  z
+            when (z < hi) $ go (incrMeasurementIndex z)
+    go lo
+
+    -- and all the rendering overhead happens after the fact
+    render varStarts varStops zz
+
+-----
+
+-- | 0-based index into the samples for a specific 'X' value
+newtype RepetitionIndex = RepetitionIndex Int64
+
+-- | 0-based index into the cross product @'X' * 'RepetitionIndex'@
+newtype MeasurementIndex = MeasurementIndex Int64
+  deriving (Eq, Ord, UA.Ix)
+
+-- | Reduces variance by the sqrt of this, if the distribution is normal
+samplesPerX :: Int64
+samplesPerX = 1000
+
+-- | The interval of 'MeasurentIndexes' necessary to represent 'samplesPerX'
+-- samples of each 'X' in the given interval
+mkMeasurementIndexInterval :: (X, X) -> (MeasurementIndex, MeasurementIndex)
+mkMeasurementIndexInterval (X lo, X hi) =
+    ( MeasurementIndex (firstSample lo)
+    , MeasurementIndex (firstSample (hi + 1) - 1)
+    )
+  where
+    firstSample x = samplesPerX * x
+
+-- | The inverse of the mapping that underlies 'mkMeasurementIndexInterval'
+coords :: MeasurementIndex -> (X, RepetitionIndex)
+coords (MeasurementIndex z) =
+    (X q, RepetitionIndex r)
+  where
+    (q, r) = z `quotRem` samplesPerX
+
+-- | Increment
+incrMeasurementIndex :: MeasurementIndex -> MeasurementIndex
+incrMeasurementIndex (MeasurementIndex z) = MeasurementIndex $ z + 1
+
+-----
+
+-- | Dump all measurements to the screen, along with their coordinates
+render :: TimeArray -> TimeArray -> (MeasurementIndex, MeasurementIndex) -> IO ()
+render varStarts varStops zz = do
+    putStrLn "# Uuid RelativeSample Index Nanoseconds"
+    mapM_ each (UA.range zz)
+  where
+    each z = do
+        let (X x, RepetitionIndex y) = coords z
+        start <- readTimeArray varStarts z
+        stop  <- readTimeArray varStops  z
+        let dur = stop `diffPico` start
+        putStrLn $ unwords [let MeasurementIndex i = z in show i, show y, show x, show dur]
+
+-----
+
+-- | An array of wall clock measurements
+--
+-- Unboxed arrays to minimize the resource usage of the benchmark
+-- driver/harness.
+data TimeArray = TimeArray !(UA.IOUArray MeasurementIndex Int64) !(UA.IOUArray MeasurementIndex Word32)
+
+newTimeArray_ :: (MeasurementIndex, MeasurementIndex) -> IO TimeArray
+newTimeArray_ zz = do
+    seconds <- UA.newArray_ zz
+    nanos   <- UA.newArray_ zz
+    pure $ TimeArray seconds nanos
+
+{-# INLINE recordTimeArray #-}
+recordTimeArray :: TimeArray -> MeasurementIndex -> IO ()
+recordTimeArray tarr = \z -> do
+    tm <- SysTime.getSystemTime
+    let SysTime.MkSystemTime {
+            SysTime.systemSeconds     = a
+          , SysTime.systemNanoseconds = b
+          } = tm
+    UA.writeArray seconds z a
+    UA.writeArray nanos   z b
+  where
+    TimeArray seconds nanos = tarr
+
+readTimeArray :: TimeArray -> MeasurementIndex -> IO SysTime.SystemTime
+readTimeArray tarr = \z -> do
+    a <- UA.readArray seconds z
+    b <- UA.readArray nanos   z
+    pure SysTime.MkSystemTime {
+        SysTime.systemSeconds     = a
+      , SysTime.systemNanoseconds = b
+      }
+  where
+    TimeArray seconds nanos = tarr
+
+diffPico :: SysTime.SystemTime -> SysTime.SystemTime -> Integer
+diffPico stop start =
+    diffTimeToPicoseconds $ stop' `TAI.diffAbsoluteTime` start'
+  where
+    stop'  = SysTime.systemToTAITime stop
+    start' = SysTime.systemToTAITime start

--- a/ouroboros-consensus/bench/ChainSync-client-bench/Main.hs
+++ b/ouroboros-consensus/bench/ChainSync-client-bench/Main.hs
@@ -1,0 +1,292 @@
+{-# LANGUAGE LambdaCase     #-}
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Main (main) where
+
+import           Bench.Consensus.ChainSyncClient.Driver (mainWith)
+import           Cardano.Crypto.DSIGN.Mock
+import           Control.Monad (void)
+import           Control.Tracer (contramap, debugTracer, nullTracer)
+import           Data.IORef (newIORef, readIORef, writeIORef)
+import qualified Data.List.NonEmpty as NE
+import qualified Data.Map.Strict as Map
+import           Network.TypedProtocol.Channel
+import           Network.TypedProtocol.Driver.Simple
+import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.BlockchainTime
+import           Ouroboros.Consensus.Config
+import           Ouroboros.Consensus.Fragment.InFuture (clockSkewInSeconds)
+import qualified Ouroboros.Consensus.HardFork.History as HardFork
+import qualified Ouroboros.Consensus.HeaderStateHistory as HeaderStateHistory
+import qualified Ouroboros.Consensus.HeaderValidation as HV
+import qualified Ouroboros.Consensus.Ledger.Extended as Extended
+import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client as CSClient
+import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck as InFutureCheck
+import           Ouroboros.Consensus.MiniProtocol.ChainSync.Server
+                     (chainSyncServerForFollower)
+import           Ouroboros.Consensus.Node.NetworkProtocolVersion
+                     (NodeToNodeVersion)
+import           Ouroboros.Consensus.Node.ProtocolInfo
+import           Ouroboros.Consensus.NodeId
+import           Ouroboros.Consensus.Protocol.BFT
+import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
+import           Ouroboros.Consensus.Util.IOLike
+import           Ouroboros.Consensus.Util.ResourceRegistry
+import           Ouroboros.Consensus.Util.STM (Fingerprint (..),
+                     WithFingerprint (..))
+import           Ouroboros.Consensus.Util.Time (secondsToNominalDiffTime)
+import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
+import qualified Ouroboros.Network.AnchoredFragment as AF
+import qualified Ouroboros.Network.AnchoredSeq as AS
+import           Ouroboros.Network.Block (ChainUpdate (AddBlock, RollBack),
+                     Tip (TipGenesis), tipFromHeader)
+import           Ouroboros.Network.ControlMessage (ControlMessage (Continue))
+import           Ouroboros.Network.Protocol.ChainSync.ClientPipelined
+import           Ouroboros.Network.Protocol.ChainSync.Codec (codecChainSyncId)
+import           Ouroboros.Network.Protocol.ChainSync.PipelineDecision
+                     (pipelineDecisionLowHighMark)
+import           Ouroboros.Network.Protocol.ChainSync.Server
+import           Test.Util.Orphans.Arbitrary ()
+import           Test.Util.Orphans.IOLike ()
+import qualified Test.Util.TestBlock as TB
+
+type B = TB.TestBlock
+type H = Header B
+
+main :: IO ()
+main = mainWith $ \n -> do
+    varCandidate <- newTVarIO $ AF.Empty AF.AnchorGenesis
+
+    varServerTip <- newTVarIO TipGenesis
+    follower     <- mkFollower varServerTip
+
+    oneBenchRun
+        varCandidate
+        varServerTip
+        follower
+        (fromIntegral n)
+
+{-# INLINE oneBenchRun #-}
+oneBenchRun ::
+     StrictTVar IO (AnchoredFragment H)
+  -> StrictTVar IO (Tip B)
+  -> ChainDB.Follower IO B (ChainDB.WithPoint B H)
+  -> Int
+  -> IO ()
+oneBenchRun
+    varCandidate
+    varServerTip
+    follower
+    n
+  =
+    withRegistry $ \registry -> do
+        (clientChannel, serverChannel) <- createConnectedChannels
+        void
+          $ forkLinkedThread registry "ChainSyncServer"
+          $ runPeer nullTracer codecChainSyncId serverChannel
+          $ chainSyncServerPeer server
+        void
+          $ forkLinkedThread registry "ChainSyncClient"
+          $ void
+          $ runPipelinedPeer nullTracer codecChainSyncId clientChannel
+          $ chainSyncClientPeerPipelined client
+
+        atomically $ do
+            candidate <- readTVar varCandidate
+            check $ case pointHash $ AF.headPoint candidate of
+                BlockHash (TB.TestHash ne) -> fromIntegral n < NE.head ne
+                _                          -> False
+  where
+    -- This test is designed so that the initial ledger state suffices for
+    -- everything the ChainSync client needs to do.
+    chainDbView :: CSClient.ChainDbView IO B
+    chainDbView = CSClient.ChainDbView {
+        CSClient.getCurrentChain       = pure $ AF.Empty AF.AnchorGenesis
+      , CSClient.getHeaderStateHistory =
+            pure
+          $ HeaderStateHistory.HeaderStateHistory
+          $ AS.Empty
+          $ HV.genesisHeaderState ()
+      , CSClient.getIsInvalidBlock     = pure invalidBlock
+      , CSClient.getPastLedger         = pure . oracularLedgerDB
+      }
+
+    headerInFutureCheck ::
+        InFutureCheck.SomeHeaderInFutureCheck IO B
+    headerInFutureCheck =
+        InFutureCheck.realHeaderInFutureCheck
+            (clockSkewInSeconds 0)
+            inTheYearOneBillion
+
+    client :: CSClient.Consensus ChainSyncClientPipelined B IO
+    client =
+        CSClient.chainSyncClient
+            (pipelineDecisionLowHighMark 10 20)
+            (nullTracer `asTypeOf` contramap show debugTracer)
+            topConfig
+            headerInFutureCheck
+            chainDbView
+            (maxBound :: NodeToNodeVersion)
+            (return Continue)
+            nullTracer
+            varCandidate
+
+    server :: ChainSyncServer H (Point B) (Tip B) IO ()
+    server =
+        chainSyncServerForFollower
+            nullTracer
+            (readTVar varServerTip)
+            follower
+
+-----
+
+-- | No invalid blocks in this benchmark
+invalidBlock ::
+    WithFingerprint
+        (HeaderHash blk -> Maybe (ChainDB.InvalidBlockReason blk))
+invalidBlock =
+    WithFingerprint isInvalidBlock fp
+  where
+    isInvalidBlock _hash = Nothing
+    fp                   = Fingerprint $ fromIntegral (0 :: Int)
+
+-- | Ignore time in this benchmark
+--
+-- This is clock fixed at billion years after the start of the chain. That
+-- should trivialize the in-future check: no header will be from the future.
+inTheYearOneBillion :: SystemTime IO
+inTheYearOneBillion = SystemTime {
+    systemTimeWait    = pure ()
+  , systemTimeCurrent = pure $ RelativeTime $
+      secondsToNominalDiffTime $
+          86400   -- seconds in a day
+        * 365   -- days in a year
+        * 1e9
+  }
+
+oracularLedgerDB :: Point B -> Maybe (Extended.ExtLedgerState B)
+oracularLedgerDB p =
+    Just Extended.ExtLedgerState {
+        Extended.headerState = HV.HeaderState {
+            HV.headerStateTip      = case pointToWithOriginRealPoint p of
+                Origin       -> Origin
+                NotOrigin rp -> NotOrigin $ HV.AnnTip {
+                    HV.annTipSlotNo  = realPointSlot rp
+                  , HV.annTipInfo    = realPointHash rp
+                  , HV.annTipBlockNo =
+                        testBlockHashBlockNo (realPointHash rp)
+                  }
+          , HV.headerStateChainDep = ()
+          }
+      , Extended.ledgerState = TB.TestLedger {
+            TB.lastAppliedPoint      = p
+          , TB.payloadDependentState = ()
+          }
+    }
+
+-- | A convenient fact about 'TB.TestBlock'
+testBlockHashBlockNo :: TB.TestHash -> BlockNo
+testBlockHashBlockNo (TB.TestHash ne) = BlockNo $ fromIntegral $ length ne
+
+-----
+
+kInt :: Int
+kInt = 5
+
+securityParam :: SecurityParam
+securityParam = SecurityParam $ fromIntegral kInt
+
+initialChain :: NE.NonEmpty B
+initialChain =
+    NE.fromList
+  $ take kInt
+  $ iterate TB.successorBlock
+  $ TB.firstBlock 0
+
+-----
+
+slotLengthInSeconds :: Int
+slotLengthInSeconds = 1
+
+slotLength :: SlotLength
+slotLength = slotLengthFromSec $ toEnum slotLengthInSeconds
+
+numCoreNodes :: NumCoreNodes
+numCoreNodes = NumCoreNodes 2
+
+topConfig :: TopLevelConfig B
+topConfig = TopLevelConfig {
+    topLevelConfigProtocol = BftConfig {
+        bftParams  = BftParams {
+                         bftSecurityParam = securityParam
+                       , bftNumNodes      = numCoreNodes
+                       }
+      , bftSignKey = SignKeyMockDSIGN 0
+      , bftVerKeys = Map.fromList [
+                         (CoreId (CoreNodeId 0), VerKeyMockDSIGN 0)
+                       , (CoreId (CoreNodeId 1), VerKeyMockDSIGN 1)
+                       ]
+      }
+  , topLevelConfigLedger  = eraParams
+  , topLevelConfigBlock   = TB.TestBlockConfig numCoreNodes
+  , topLevelConfigCodec   = TB.TestBlockCodecConfig
+  , topLevelConfigStorage = TB.TestBlockStorageConfig
+  }
+  where
+    eraParams :: HardFork.EraParams
+    eraParams = HardFork.defaultEraParams securityParam slotLength
+
+-----
+
+data FollowerState =
+    Resting !(RealPoint B)
+  | Switching !(Point B) !(NE.NonEmpty B)
+  | Switched !(NE.NonEmpty B)
+
+-- | A 'ChaindB.Follower' that merely switches between each of the
+-- `kInt`-length chains, in the order enumerated by 'TB.updateToNextNumeral'.
+--
+-- INVARIANT: the chains are never longer than 'kInt' and are 'kInt' long
+-- infinitely often.
+mkFollower ::
+     StrictTVar IO (Tip B)
+  -> IO (ChainDB.Follower IO B (ChainDB.WithPoint B H))
+mkFollower varTip = do
+    varState <- newIORef $ Resting $ blockRealPoint $ NE.last initialChain
+
+    let wrap blk = ChainDB.WithPoint (getHeader blk) (blockPoint blk)
+
+    let next = readIORef varState >>= \case
+            Switching ipoint blks -> do
+                writeIORef varState $ Switched blks
+                atomically $ writeTVar varTip $ tipFromHeader $ NE.last blks
+                pure $ RollBack ipoint
+            Switched blks -> do
+                let blk = NE.head blks
+                writeIORef varState $ case NE.nonEmpty (NE.tail blks) of
+                    Nothing    -> Resting $ blockRealPoint blk
+                    Just blks' -> Switched blks'
+                atomically $ writeTVar varTip $ tipFromHeader $ NE.last blks
+                pure $ AddBlock $ wrap blk
+            Resting rp -> do
+                let (ipoint, blks) = TB.updateToNextNumeral rp
+                writeIORef varState $ Switched blks
+                atomically $ writeTVar varTip $ tipFromHeader $ NE.last blks
+                pure $ RollBack ipoint
+
+    pure ChainDB.Follower {
+        ChainDB.followerClose               = pure ()
+      , ChainDB.followerInstruction         = Just <$> next
+      , ChainDB.followerInstructionBlocking = next
+      , ChainDB.followerForward             = \case
+            GenesisPoint : _ -> do
+                writeIORef varState $ Switching GenesisPoint initialChain
+                pure $ Just GenesisPoint
+
+            ps -> error $ "impossible! " <> unlines (map show ps)
+                -- The client begins with an empty local chain, so this is the
+                -- only possible input at the handshake.
+                --
+                -- Moreover, no chain is longer than k, so the there can never
+                -- another FindIntersect.
+      }

--- a/ouroboros-consensus/bench/ChainSync-client-bench/Main.hs
+++ b/ouroboros-consensus/bench/ChainSync-client-bench/Main.hs
@@ -121,15 +121,20 @@ oneBenchRun
     client :: CSClient.Consensus ChainSyncClientPipelined B IO
     client =
         CSClient.chainSyncClient
-            (pipelineDecisionLowHighMark 10 20)
-            (nullTracer `asTypeOf` contramap show debugTracer)
-            topConfig
-            headerInFutureCheck
-            chainDbView
-            (maxBound :: NodeToNodeVersion)
-            (return Continue)
-            nullTracer
-            varCandidate
+            CSClient.ConfigEnv {
+                CSClient.chainDbView
+              , CSClient.cfg                     = topConfig
+              , CSClient.tracer                  = nullTracer `asTypeOf` contramap show debugTracer
+              , CSClient.someHeaderInFutureCheck = headerInFutureCheck
+              , CSClient.mkPipelineDecision0     =
+                    pipelineDecisionLowHighMark 10 20
+              }
+            CSClient.DynamicEnv {
+                CSClient.version             = maxBound :: NodeToNodeVersion
+              , CSClient.controlMessageSTM   = return Continue
+              , CSClient.headerMetricsTracer = nullTracer
+              , CSClient.varCandidate
+              }
 
     server :: ChainSyncServer H (Point B) (Tip B) IO ()
     server =

--- a/ouroboros-consensus/changelog.d/20231206_171848_nick.frisby_ChainSync_refactor.md
+++ b/ouroboros-consensus/changelog.d/20231206_171848_nick.frisby_ChainSync_refactor.md
@@ -1,0 +1,27 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+
+### Breaking
+
+- Bundled up the arguments to the ChainSync client into new record types,
+  `ConfigEnv` and `DynamicEnv`.
+
+- Also introduced a `SomeHeaderInFutureCheck` that binds the existential type
+  variables separately from the actual payload of the `HeaderInFutureCheck`
+  record type.

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -40,6 +40,16 @@ common common-test
   import:      common-lib
   ghc-options: -threaded -rtsopts
 
+common common-bench
+  import:      common-test
+  ghc-options: -threaded -rtsopts
+
+  -- We use this option to avoid skewed results due to changes in cache-line
+  -- alignment. See
+  -- https://github.com/Bodigrim/tasty-bench#comparison-against-baseline
+  if impl(ghc >=8.6)
+    ghc-options: -fproc-alignment=64
+
 library
   import:          common-lib
   hs-source-dirs:  src/ouroboros-consensus
@@ -624,9 +634,10 @@ test-suite storage-test
     , vector
 
 benchmark mempool-bench
-  type:             exitcode-stdio-1.0
-  hs-source-dirs:   bench/mempool-bench
-  main-is:          Main.hs
+  import:         common-bench
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: bench/mempool-bench
+  main-is:        Main.hs
   other-modules:
     Bench.Consensus.Mempool
     Bench.Consensus.Mempool.TestBlock
@@ -652,15 +663,21 @@ benchmark mempool-bench
     , unstable-consensus-testlib
     , unstable-mempool-test-utils
 
-  default-language: Haskell2010
-  ghc-options:
-    -Wall -Wcompat -Wincomplete-uni-patterns
-    -Wincomplete-record-updates -Wpartial-fields -Widentities
-    -Wredundant-constraints -Wmissing-export-lists -Wunused-packages
-    -Wno-unticked-promoted-constructors -rtsopts -with-rtsopts=-A32m
-
-  -- We use this option to avoid skewed results due to changes in cache-line
-  -- alignment. See
-  -- https://github.com/Bodigrim/tasty-bench#comparison-against-baseline
-  if impl(ghc >=8.6)
-    ghc-options: -fproc-alignment=64
+benchmark ChainSync-client-bench
+  import:         common-bench
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: bench/ChainSync-client-bench
+  main-is:        Main.hs
+  other-modules:  Bench.Consensus.ChainSyncClient.Driver
+  build-depends:
+    , array
+    , base
+    , cardano-crypto-class
+    , containers
+    , contra-tracer
+    , ouroboros-consensus
+    , ouroboros-network-api
+    , ouroboros-network-protocols
+    , time
+    , typed-protocols-examples
+    , unstable-consensus-testlib

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -110,76 +110,87 @@ import           Ouroboros.Network.PeerSelection.PeerMetric.Type
 import           Ouroboros.Network.Protocol.ChainSync.ClientPipelined
 import           Ouroboros.Network.Protocol.ChainSync.PipelineDecision
 
-type Consensus (client :: Type -> Type -> Type -> (Type -> Type) -> Type -> Type) blk m =
-   client (Header blk) (Point blk) (Tip blk) m ChainSyncClientResult
+-- | Merely a helpful abbreviation
+type Consensus
+        (client :: Type -> Type -> Type -> (Type -> Type) -> Type -> Type)
+        blk
+        m
+  = client (Header blk) (Point blk) (Tip blk) m ChainSyncClientResult
 
 -- | Abstract over the ChainDB
 data ChainDbView m blk = ChainDbView {
-      getCurrentChain       :: STM m (AnchoredFragment (Header blk))
-    , getHeaderStateHistory :: STM m (HeaderStateHistory blk)
-    , getPastLedger         :: Point blk -> STM m (Maybe (ExtLedgerState blk))
-    , getIsInvalidBlock     :: STM m (WithFingerprint (HeaderHash blk -> Maybe (InvalidBlockReason blk)))
-    }
+    getCurrentChain :: STM m (AnchoredFragment (Header blk))
+  ,
+    getHeaderStateHistory :: STM m (HeaderStateHistory blk)
+  ,
+    getPastLedger :: Point blk -> STM m (Maybe (ExtLedgerState blk))
+  ,
+    getIsInvalidBlock ::
+      STM m
+          (WithFingerprint
+              (HeaderHash blk -> Maybe (InvalidBlockReason blk)))
+  }
 
 defaultChainDbView ::
      (IOLike m, LedgerSupportsProtocol blk)
   => ChainDB m blk -> ChainDbView m blk
 defaultChainDbView chainDB = ChainDbView {
-      getCurrentChain       = ChainDB.getCurrentChain       chainDB
-    , getHeaderStateHistory = ChainDB.getHeaderStateHistory chainDB
-    , getPastLedger         = ChainDB.getPastLedger         chainDB
-    , getIsInvalidBlock     = ChainDB.getIsInvalidBlock     chainDB
-    }
+    getCurrentChain       = ChainDB.getCurrentChain       chainDB
+  , getHeaderStateHistory = ChainDB.getHeaderStateHistory chainDB
+  , getPastLedger         = ChainDB.getPastLedger         chainDB
+  , getIsInvalidBlock     = ChainDB.getIsInvalidBlock     chainDB
+  }
 
--- newtype wrappers to avoid confusing our tip with their tip.
+-- | A newtype wrapper to avoid confusing our tip with their tip.
 newtype Their a = Their { unTheir :: a }
   deriving stock   (Eq)
   deriving newtype (Show, NoThunks)
 
-newtype Our   a = Our   { unOur   :: a }
+-- | A newtype wrapper to avoid confusing our tip with their tip.
+newtype Our a = Our { unOur :: a }
   deriving stock   (Eq)
   deriving newtype (Show, NoThunks)
 
+bracketChainSyncClient ::
+    ( IOLike m
+    , Ord peer
+    , LedgerSupportsProtocol blk
+    )
+ => Tracer m (TraceChainSyncClientEvent blk)
+ -> ChainDbView m blk
+ -> StrictTVar m (Map peer (StrictTVar m (AnchoredFragment (Header blk))))
+    -- ^ The candidate chains, we need the whole map because we
+    -- (de)register nodes (@peer@).
+ -> peer
+ -> NodeToNodeVersion
+ -> (StrictTVar m (AnchoredFragment (Header blk)) -> m a)
+ -> m a
 bracketChainSyncClient
-    :: ( IOLike m
-       , Ord peer
-       , LedgerSupportsProtocol blk
-       )
-    => Tracer m (TraceChainSyncClientEvent blk)
-    -> ChainDbView m blk
-    -> StrictTVar m (Map peer (StrictTVar m (AnchoredFragment (Header blk))))
-       -- ^ The candidate chains, we need the whole map because we
-       -- (de)register nodes (@peer@).
-    -> peer
-    -> NodeToNodeVersion
-    -> (    StrictTVar m (AnchoredFragment (Header blk))
-         -> m a
-       )
-    -> m a
-bracketChainSyncClient tracer ChainDbView { getIsInvalidBlock }
-                       varCandidates
-                       peer version body =
+    tracer
+    ChainDbView { getIsInvalidBlock }
+    varCandidates
+    peer
+    version
+    body
+  =
     bracket newCandidateVar releaseCandidateVar
-      $ \varCandidate ->
-      withWatcher
-        "ChainSync.Client.rejectInvalidBlocks"
-        (invalidBlockWatcher varCandidate)
-        $ body varCandidate
+  $ \varCandidate ->
+        withWatcher
+            "ChainSync.Client.rejectInvalidBlocks"
+            (invalidBlockWatcher varCandidate)
+      $ body varCandidate
   where
     newCandidateVar = do
-      varCandidate <- newTVarIO $ AF.Empty AF.AnchorGenesis
-      atomically $ modifyTVar varCandidates $ Map.insert peer varCandidate
-      return varCandidate
+        varCandidate <- newTVarIO $ AF.Empty AF.AnchorGenesis
+        atomically $ modifyTVar varCandidates $ Map.insert peer varCandidate
+        return varCandidate
 
     releaseCandidateVar _ = do
-      atomically $ modifyTVar varCandidates $ Map.delete peer
+        atomically $ modifyTVar varCandidates $ Map.delete peer
 
     invalidBlockWatcher varCandidate =
-      invalidBlockRejector
-        tracer
-        version
-        getIsInvalidBlock
-        (readTVar varCandidate)
+        invalidBlockRejector
+            tracer version getIsInvalidBlock (readTVar varCandidate)
 
 -- Our task: after connecting to an upstream node, try to maintain an
 -- up-to-date header-only fragment representing their chain. We maintain
@@ -231,8 +242,8 @@ bracketChainSyncClient tracer ChainDbView { getIsInvalidBlock }
 --
 -- The size of the downloaded candidate fragment ('theirFrag') and the
 -- corresponding header state history ('theirHeaderStateHistory', which has the
--- same size as 'theirFrag') is limited by how far in the future the ledger view
--- can forecast.
+-- same size as 'theirFrag') is limited by how far in the future the ledger
+-- view can forecast.
 --
 -- For PBFT (Byron), we can forecast up to @2k@ slots ahead. Assuming a chain
 -- density of 100%, this means the look-ahead is @2k@ headers. For mainnet this
@@ -258,8 +269,9 @@ bracketChainSyncClient tracer ChainDbView { getIsInvalidBlock }
 --
 -- Note that the 'ourFrag' and 'theirFrag' share anchors /at all times/. In the
 -- figure above, the first three headers on 'ourFrag' are thus also on
--- 'theirFrag'. The further away the most recent intersection is from the anchor
--- point, the more headers 'theirFrag' and 'ourFrag' will have in common.
+-- 'theirFrag'. The further away the most recent intersection is from the
+-- anchor point, the more headers 'theirFrag' and 'ourFrag' will have in
+-- common.
 --
 -- In the \"worst\" case 'theirFrag' has the following length:
 --
@@ -277,9 +289,9 @@ bracketChainSyncClient tracer ChainDbView { getIsInvalidBlock }
 -- 6480 = 8640@ headers. The header state history will have the same length.
 --
 -- This worst case can happen when:
--- * We are more than 6480 or respectively 8640 blocks behind, bulk syncing, and
---   the BlockFetch client and/or the ChainDB can't keep up with the ChainSync
---   client.
+-- * We are more than 6480 or respectively 8640 blocks behind, bulk syncing,
+--   and the BlockFetch client and/or the ChainDB can't keep up with the
+--   ChainSync client.
 -- * When our clock is running behind such that we are not adopting the
 --   corresponding blocks because we think they are from the future.
 -- * When an attacker is serving us headers from the future.
@@ -299,32 +311,38 @@ data UnknownIntersectionState blk = UnknownIntersectionState {
     -- with the candidate.
     --
     -- INVARIANT: 'ourFrag' contains @k@ headers, unless close to genesis.
-  , ourHeaderStateHistory :: !(HeaderStateHistory blk)
+  ,
+    ourHeaderStateHistory :: !(HeaderStateHistory blk)
     -- ^ 'HeaderStateHistory' corresponding to the tip (most recent block) of
     -- 'ourFrag'.
   }
   deriving (Generic)
 
-instance ( LedgerSupportsProtocol blk
-         ) => NoThunks (UnknownIntersectionState blk) where
-  showTypeOf _ = show $ typeRep (Proxy @(UnknownIntersectionState blk))
+instance
+     LedgerSupportsProtocol blk
+  => NoThunks (UnknownIntersectionState blk) where
+    showTypeOf _ = show $ typeRep (Proxy @(UnknownIntersectionState blk))
 
 -- | State used when the intersection between the candidate and the current
 -- chain is known.
 data KnownIntersectionState blk = KnownIntersectionState {
-    theirFrag               :: !(AnchoredFragment (Header blk))
-    -- ^ The candidate, the synched fragment of their chain.
+    mostRecentIntersection  :: !(Point blk)
+    -- ^ The most recent intersection point between 'theirFrag' and 'ourFrag'.
+    -- Note that this is not necessarily the anchor point of both 'theirFrag'
+    -- and 'ourFrag', they might have many more headers in common.
     --
-    -- See the \"Candidate fragment size\" note above.
-  , theirHeaderStateHistory :: !(HeaderStateHistory blk)
-    -- ^ 'HeaderStateHistory' corresponding to the tip (most recent block) of
-    -- 'theirFrag'.
+    -- INVARIANT:
+    -- @
+    -- (==)
+    --     (Just 'mostRecentIntersection')
+    --     ('AF.intersectionPoint' 'theirFrag' 'ourFrag')
+    -- @
     --
-    -- INVARIANT: the tips in 'theirHeaderStateHistory' correspond to the
-    -- headers in 'theirFrag', including the anchor.
-    --
-    -- See the \"Candidate fragment size\" note above.
-  , ourFrag                 :: !(AnchoredFragment (Header blk))
+    -- It follows from the invariants on 'ourFrag' that this point is within
+    -- the last @k@ headers of the current chain fragment, at time of
+    -- computing the 'KnownIntersectionState'.
+  ,
+    ourFrag                 :: !(AnchoredFragment (Header blk))
     -- ^ A view of the current chain fragment used to maintain the invariants
     -- with. Note that this might be temporarily out of date w.r.t. the actual
     -- current chain until we update it again.
@@ -335,50 +353,53 @@ data KnownIntersectionState blk = KnownIntersectionState {
     -- this follows that both fragments intersect. This also means that
     -- 'theirFrag' forks off within the last @k@ headers/blocks of the
     -- 'ourFrag'.
-  , mostRecentIntersection  :: !(Point blk)
-    -- ^ The most recent intersection point between 'theirFrag' and 'ourFrag'.
-    -- Note that this is not necessarily the anchor point of both 'theirFrag'
-    -- and 'ourFrag', they might have many more headers in common.
+  ,
+    theirFrag               :: !(AnchoredFragment (Header blk))
+    -- ^ The candidate, the synched fragment of their chain.
     --
-    -- INVARIANT:
-    -- > Just 'mostRecentIntersection' == 'AF.intersectionPoint' 'theirFrag' 'ourFrag'
+    -- See the \"Candidate fragment size\" note above.
+  ,
+    theirHeaderStateHistory :: !(HeaderStateHistory blk)
+    -- ^ 'HeaderStateHistory' corresponding to the tip (most recent block) of
+    -- 'theirFrag'.
     --
-    -- It follows from the invariants on 'ourFrag' that this point is within
-    -- the last @k@ headers of the current chain fragment, at time of
-    -- computing the 'KnownIntersectionState'.
+    -- INVARIANT: the tips in 'theirHeaderStateHistory' correspond to the
+    -- headers in 'theirFrag', including the anchor.
+    --
+    -- See the \"Candidate fragment size\" note above.
   }
   deriving (Generic)
 
-instance ( LedgerSupportsProtocol blk
-         ) => NoThunks (KnownIntersectionState blk) where
-  showTypeOf _ = show $ typeRep (Proxy @(KnownIntersectionState blk))
+instance
+     LedgerSupportsProtocol blk
+  => NoThunks (KnownIntersectionState blk) where
+    showTypeOf _ = show $ typeRep (Proxy @(KnownIntersectionState blk))
 
-checkKnownIntersectionInvariants
-  :: ( HasHeader blk
-     , HasHeader (Header blk)
-     , HasAnnTip blk
-     , ConsensusProtocol (BlockProtocol blk)
-     )
-  => ConsensusConfig (BlockProtocol blk)
-  -> KnownIntersectionState blk
-  -> Either String ()
-checkKnownIntersectionInvariants cfg KnownIntersectionState
-                                     { ourFrag
-                                     , theirFrag
-                                     , theirHeaderStateHistory
-                                     , mostRecentIntersection
-                                     }
+checkKnownIntersectionInvariants ::
+    ( HasHeader blk
+    , HasHeader (Header blk)
+    , HasAnnTip blk
+    , ConsensusProtocol (BlockProtocol blk)
+    )
+ => ConsensusConfig (BlockProtocol blk)
+ -> KnownIntersectionState blk
+ -> Either String ()
+checkKnownIntersectionInvariants cfg kis
     -- 'theirHeaderStateHistory' invariant
     | let HeaderStateHistory snapshots = theirHeaderStateHistory
           historyTips  = headerStateTip        <$> AS.toOldestFirst snapshots
           fragmentTips = NotOrigin . getAnnTip <$> AF.toOldestFirst theirFrag
-          historyAnchorPoint =
-            withOriginRealPointToPoint $
-              annTipRealPoint <$> headerStateTip (AS.anchor snapshots)
+
           fragmentAnchorPoint = castPoint $ AF.anchorPoint theirFrag
-    , historyTips /= fragmentTips || historyAnchorPoint /= fragmentAnchorPoint
+          historyAnchorPoint  =
+              withOriginRealPointToPoint
+            $ annTipRealPoint <$> headerStateTip (AS.anchor snapshots)
+    ,    historyTips        /= fragmentTips
+      ||
+         historyAnchorPoint /= fragmentAnchorPoint
     = throwError $ unwords
-      [ "The tips in theirHeaderStateHistory didn't match the headers in theirFrag:"
+      [ "The tips in theirHeaderStateHistory"
+      , "didn't match the headers in theirFrag:"
       , show historyTips
       , "vs"
       , show fragmentTips
@@ -389,7 +410,7 @@ checkKnownIntersectionInvariants cfg KnownIntersectionState
       ]
 
     -- 'ourFrag' invariants
-    | let nbHeaders = AF.length ourFrag
+    | let nbHeaders      = AF.length ourFrag
           ourAnchorPoint = AF.anchorPoint ourFrag
     , nbHeaders < fromIntegral k
     , ourAnchorPoint /= GenesisPoint
@@ -402,7 +423,7 @@ checkKnownIntersectionInvariants cfg KnownIntersectionState
       , show ourAnchorPoint
       ]
 
-    | let ourFragAnchor = AF.anchorPoint ourFrag
+    | let ourFragAnchor   = AF.anchorPoint ourFrag
           theirFragAnchor = AF.anchorPoint theirFrag
     , ourFragAnchor /= theirFragAnchor
     = throwError $ unwords
@@ -414,7 +435,7 @@ checkKnownIntersectionInvariants cfg KnownIntersectionState
 
     -- 'mostRecentIntersection' invariant
     | let actualMostRecentIntersection =
-            castPoint <$> AF.intersectionPoint theirFrag ourFrag
+              castPoint <$> AF.intersectionPoint theirFrag ourFrag
     , Just mostRecentIntersection /= actualMostRecentIntersection
     = throwError $ unwords
       [ "mostRecentIntersection not the most recent intersection"
@@ -429,16 +450,23 @@ checkKnownIntersectionInvariants cfg KnownIntersectionState
   where
     SecurityParam k = protocolSecurityParam cfg
 
-assertKnownIntersectionInvariants
-  :: ( HasHeader blk
-     , HasHeader (Header blk)
-     , HasAnnTip blk
-     , ConsensusProtocol (BlockProtocol blk)
-     , HasCallStack
-     )
-  => ConsensusConfig (BlockProtocol blk)
-  -> KnownIntersectionState blk
-  -> KnownIntersectionState blk
+    KnownIntersectionState {
+        mostRecentIntersection
+      , ourFrag
+      , theirFrag
+      , theirHeaderStateHistory
+      } = kis
+
+assertKnownIntersectionInvariants ::
+    ( HasHeader blk
+    , HasHeader (Header blk)
+    , HasAnnTip blk
+    , ConsensusProtocol (BlockProtocol blk)
+    , HasCallStack
+    )
+ => ConsensusConfig (BlockProtocol blk)
+ -> KnownIntersectionState blk
+ -> KnownIntersectionState blk
 assertKnownIntersectionInvariants cfg kis =
     assertWithMsg (checkKnownIntersectionInvariants cfg kis) kis
 
@@ -450,101 +478,103 @@ assertKnownIntersectionInvariants cfg kis =
 --
 -- These are available before the diffusion layer is online.
 data ConfigEnv m blk = ConfigEnv {
-      mkPipelineDecision0     :: MkPipelineDecision
-      -- ^ The pipelining decider to use after 'MsgFoundIntersect' arrives
-    , tracer                  :: Tracer m (TraceChainSyncClientEvent blk)
-    , cfg                     :: TopLevelConfig blk
-    , someHeaderInFutureCheck :: InFutureCheck.SomeHeaderInFutureCheck m blk
-    , chainDbView             :: ChainDbView m blk
-    }
+    mkPipelineDecision0     :: MkPipelineDecision
+    -- ^ The pipelining decider to use after 'MsgFoundIntersect' arrives
+  , tracer                  :: Tracer m (TraceChainSyncClientEvent blk)
+  , cfg                     :: TopLevelConfig blk
+  , someHeaderInFutureCheck :: InFutureCheck.SomeHeaderInFutureCheck m blk
+  , chainDbView             :: ChainDbView m blk
+  }
 
 -- | Arguments determined dynamically
 --
 -- These are available only after the diffusion layer is online and/or on per
 -- client basis.
 data DynamicEnv m blk = DynamicEnv {
-      version                 :: NodeToNodeVersion
-    , controlMessageSTM       :: ControlMessageSTM m
-    , headerMetricsTracer     :: HeaderMetricsTracer m
-    , varCandidate            :: StrictTVar m (AnchoredFragment (Header blk))
-    }
+    version             :: NodeToNodeVersion
+  , controlMessageSTM   :: ControlMessageSTM m
+  , headerMetricsTracer :: HeaderMetricsTracer m
+  , varCandidate        :: StrictTVar m (AnchoredFragment (Header blk))
+  }
 
 -- | General values collectively needed by the top-level entry points
 data InternalEnv m blk arrival judgment = InternalEnv {
-      -- | "Drain the pipe": collect and discard all in-flight responses and
-      -- finally execute the given action.
-      drainThePipe
-        :: forall s n. NoThunks s
-        => Nat n
-        -> Stateful m blk s (ClientPipelinedStIdle 'Z)
-        -> Stateful m blk s (ClientPipelinedStIdle n)
-    ,
-      -- | Disconnect from the upstream node by throwing the given exception.
-      -- The cleanup is handled in 'bracketChainSyncClient'.
-      disconnect
-        :: forall m' a. MonadThrow m'
-        => ChainSyncClientException
-        -> m' a
-    ,
-      headerInFutureCheck
-        :: InFutureCheck.HeaderInFutureCheck m blk arrival judgment
-    ,
-      -- | A combinator necessary whenever relying on a
-      -- 'KnownIntersectionState', since it's always possible that that
-      -- intersection will go stale.
-      --
-      -- Look at the current chain fragment that may have been updated in the
-      -- background. Check whether the candidate fragment still intersects with
-      -- it. If so, update the 'KnownIntersectionState' and trim the candidate
-      -- fragment to the new current chain fragment's anchor point. If not,
-      -- return 'Nothing'.
-      --
-      -- INVARIANT: This a read-only STM transaction.
-      intersectsWithCurrentChain
-        :: KnownIntersectionState blk
-        -> STM m (UpdatedIntersectionState blk ())
-    ,
-      -- | Gracefully terminate the connection with the upstream node with the
-      -- given result.
-      terminate
-        :: ChainSyncClientResult
-        -> m (Consensus (ClientPipelinedStIdle 'Z) blk m)
-    ,
-      -- | Same as 'terminate', but first 'drainThePipe'.
-      terminateAfterDrain
-        :: forall n.
-           Nat n
-        -> ChainSyncClientResult
-        -> m (Consensus (ClientPipelinedStIdle n) blk m)
-    ,
-      -- | Trace any 'ChainSyncClientException' if thrown.
-      traceException :: forall a. m a -> m a
-    }
+    drainThePipe ::
+      forall s n.
+         NoThunks s
+      => Nat n
+      -> Stateful m blk s (ClientPipelinedStIdle 'Z)
+      -> Stateful m blk s (ClientPipelinedStIdle n)
+    -- ^ "Drain the pipe": collect and discard all in-flight responses and
+    -- finally execute the given action.
+  ,
+    disconnect ::
+      forall m' a.
+         MonadThrow m'
+      => ChainSyncClientException
+      -> m' a
+    -- ^ Disconnect from the upstream node by throwing the given exception.
+    -- The cleanup is handled in 'bracketChainSyncClient'.
+  ,
+    headerInFutureCheck ::
+        InFutureCheck.HeaderInFutureCheck m blk arrival judgment
+  ,
+    intersectsWithCurrentChain ::
+        KnownIntersectionState blk
+     -> STM m (UpdatedIntersectionState blk ())
+    -- ^ A combinator necessary whenever relying on a
+    -- 'KnownIntersectionState', since it's always possible that that
+    -- intersection will go stale.
+    --
+    -- Look at the current chain fragment that may have been updated in the
+    -- background. Check whether the candidate fragment still intersects with
+    -- it. If so, update the 'KnownIntersectionState' and trim the candidate
+    -- fragment to the new current chain fragment's anchor point. If not,
+    -- return 'Nothing'.
+    --
+    -- INVARIANT: This a read-only STM transaction.
+  ,
+    terminate ::
+        ChainSyncClientResult
+     -> m (Consensus (ClientPipelinedStIdle 'Z) blk m)
+    -- ^ Gracefully terminate the connection with the upstream node with the
+    -- given result.
+  ,
+    terminateAfterDrain ::
+      forall n.
+         Nat n
+      -> ChainSyncClientResult
+      -> m (Consensus (ClientPipelinedStIdle n) blk m)
+    -- ^ Same as 'terminate', but first 'drainThePipe'.
+  ,
+    traceException :: forall a. m a -> m a
+    -- ^ Trace any 'ChainSyncClientException' if thrown.
+  }
 
 -- | Chain sync client
 --
 -- This never terminates. In case of a failure, a 'ChainSyncClientException'
 -- is thrown. The network layer classifies exception such that the
 -- corresponding peer will never be chosen again.
-chainSyncClient
-    :: forall m blk.
-       ( IOLike m
-       , LedgerSupportsProtocol blk
-       )
-    => ConfigEnv m blk
-    -> DynamicEnv m blk
-    -> Consensus ChainSyncClientPipelined blk m
-chainSyncClient cfgEnv dynEnv = case someHeaderInFutureCheck cfgEnv of
-    InFutureCheck.SomeHeaderInFutureCheck headerInFutureCheck ->
-        ChainSyncClientPipelined
-      $ continueWithState ()
-      $ -- Start ChainSync by looking for an intersection between our current
-        -- chain fragment and their chain.
-        findIntersectionTop
-          cfgEnv
-          dynEnv
-          (mkIntEnv headerInFutureCheck)
-          (ForkTooDeep GenesisPoint)
+chainSyncClient :: forall m blk.
+     ( IOLike m
+     , LedgerSupportsProtocol blk
+     )
+  => ConfigEnv m blk
+  -> DynamicEnv m blk
+  -> Consensus ChainSyncClientPipelined blk m
+chainSyncClient cfgEnv dynEnv =
+    case someHeaderInFutureCheck cfgEnv of
+        InFutureCheck.SomeHeaderInFutureCheck headerInFutureCheck ->
+            ChainSyncClientPipelined
+          $ continueWithState ()
+          $ -- Start ChainSync by looking for an intersection between our
+            -- current chain fragment and their chain.
+            findIntersectionTop
+                cfgEnv
+                dynEnv
+                (mkIntEnv headerInFutureCheck)
+                (ForkTooDeep GenesisPoint)
   where
     ConfigEnv {
         cfg
@@ -556,110 +586,121 @@ chainSyncClient cfgEnv dynEnv = case someHeaderInFutureCheck cfgEnv of
         getCurrentChain
       } = chainDbView
 
-    mkIntEnv
-      :: InFutureCheck.HeaderInFutureCheck m blk arrival judgment
-      -> InternalEnv                       m blk arrival judgment
+    mkIntEnv ::
+        InFutureCheck.HeaderInFutureCheck m blk arrival judgment
+     -> InternalEnv                       m blk arrival judgment
     mkIntEnv hifc = InternalEnv {
         drainThePipe
-      , disconnect                 = throwIO
-      , headerInFutureCheck        = hifc
-      , intersectsWithCurrentChain
-      , terminate
-      , terminateAfterDrain        = \n result ->
+      ,
+        disconnect = throwIO
+      ,
+        headerInFutureCheck = hifc
+      ,
+        intersectsWithCurrentChain
+      ,
+        terminate
+      ,
+        terminateAfterDrain = \n result ->
             continueWithState ()
           $ drainThePipe n
-          $ Stateful $ const $ terminate result
-      , traceException             = \m -> do
-          m `catch` \(e :: ChainSyncClientException) -> do
-            traceWith tracer $ TraceException e
-            throwIO e
+          $ Stateful $ \() -> terminate result
+      ,
+        traceException = \m -> do
+            m `catch` \(e :: ChainSyncClientException) -> do
+                traceWith tracer $ TraceException e
+                throwIO e
       }
 
-    drainThePipe
-      :: forall s n. NoThunks s
+    drainThePipe ::
+      forall s n.
+         NoThunks s
       => Nat n
       -> Stateful m blk s (ClientPipelinedStIdle 'Z)
       -> Stateful m blk s (ClientPipelinedStIdle n)
-    drainThePipe        =     \n0 m ->
-      let
-        go :: forall n'. Nat n'
-           -> s
-           -> m (Consensus (ClientPipelinedStIdle n') blk m)
-        go n s = case n of
-          Zero    -> continueWithState s m
-          Succ n' -> return $ CollectResponse Nothing $ ClientStNext
-            { recvMsgRollForward  = \_hdr _tip -> go n' s
-            , recvMsgRollBackward = \_pt  _tip -> go n' s
-            }
+    drainThePipe n0 m =
+      let go ::
+            forall n'.
+               Nat n'
+            -> s
+            -> m (Consensus (ClientPipelinedStIdle n') blk m)
+          go n s = case n of
+              Zero    -> continueWithState s m
+              Succ n' -> return $ CollectResponse Nothing $ ClientStNext {
+                  recvMsgRollForward  = \_hdr _tip -> go n' s
+                , recvMsgRollBackward = \_pt  _tip -> go n' s
+                }
       in Stateful $ go n0
 
-    terminate
-      :: ChainSyncClientResult
-      -> m (Consensus (ClientPipelinedStIdle 'Z) blk m)
+    terminate ::
+        ChainSyncClientResult
+     -> m (Consensus (ClientPipelinedStIdle 'Z) blk m)
     terminate res = do
-      traceWith tracer (TraceTermination res)
-      pure (SendMsgDone res)
+        traceWith tracer (TraceTermination res)
+        pure (SendMsgDone res)
 
-    intersectsWithCurrentChain
-      :: KnownIntersectionState blk
-      -> STM m (UpdatedIntersectionState blk ())
-    intersectsWithCurrentChain kis@KnownIntersectionState
-                               { theirFrag
-                               , theirHeaderStateHistory
-                               , ourFrag
-                               } = do
-      ourFrag' <- getCurrentChain
-      if
-        | AF.headPoint ourFrag == AF.headPoint ourFrag' ->
-          -- Our current chain didn't change, and changes to their chain that
-          -- might affect the intersection point are handled elsewhere
-          -- ('rollBackward'), so we have nothing to do.
-          return $ StillIntersects () kis
+    intersectsWithCurrentChain ::
+        KnownIntersectionState blk
+     -> STM m (UpdatedIntersectionState blk ())
+    intersectsWithCurrentChain kis = do
+        let KnownIntersectionState {
+                ourFrag
+              , theirFrag
+              , theirHeaderStateHistory
+              } = kis
+        ourFrag' <- getCurrentChain
 
-        | Just (intersection, trimmedCandidateFrag) <- cross ourFrag' theirFrag
-          -- Even though our current chain changed it still intersects with
-          -- candidate fragment, so update the 'ourFrag' field and trim the
-          -- candidate fragment to the same anchor point.
-          --
-          -- Note that this is the only place we need to trim. Headers on
-          -- their chain can only become unnecessary (eligible for trimming)
-          -- in two ways: 1. we adopted them, i.e., our chain changed (handled
-          -- in this function); 2. we will /never/ adopt them, which is
-          -- handled in the "no more intersection case".
-        , let -- We trim the 'HeaderStateHistory' to the same size as our
-              -- fragment so they keep in sync.
-              trimmedHeaderStateHistory' =
-                 HeaderStateHistory.trim
-                   (AF.length trimmedCandidateFrag)
-                   theirHeaderStateHistory ->
-          return $ StillIntersects () $
-            assertKnownIntersectionInvariants (configConsensus cfg) $
-              KnownIntersectionState {
-                  ourFrag                 = ourFrag'
-                , theirFrag               = trimmedCandidateFrag
-                , theirHeaderStateHistory = trimmedHeaderStateHistory'
-                , mostRecentIntersection  = castPoint intersection
-                }
+        -- Our current chain didn't change, and changes to their chain that
+        -- might affect the intersection point are handled elsewhere
+        -- ('rollBackward'), so we have nothing to do.
+        let noChange = AF.headPoint ourFrag == AF.headPoint ourFrag'
 
-        | otherwise -> return NoLongerIntersects
+        return $ if noChange then StillIntersects () kis else
+            case cross ourFrag' theirFrag of
+                Nothing -> NoLongerIntersects
+
+                Just (intersection, trimmedCandidate) ->
+                    -- Even though our current chain changed it still
+                    -- intersects with candidate fragment, so update the
+                    -- 'ourFrag' field and trim the candidate fragment to the
+                    -- same anchor point.
+                    --
+                    -- Note that this is the only place we need to trim.
+                    -- Headers on their chain can only become unnecessary
+                    -- (eligible for trimming) in two ways: 1. we adopted them,
+                    -- i.e., our chain changed (handled in this function); 2.
+                    -- we will /never/ adopt them, which is handled in the "no
+                    -- more intersection case".
+                    StillIntersects ()
+                  $ assertKnownIntersectionInvariants (configConsensus cfg)
+                  $ KnownIntersectionState {
+                        mostRecentIntersection  = castPoint intersection
+                      , ourFrag                 = ourFrag'
+                      , theirFrag               = trimmedCandidate
+                      , theirHeaderStateHistory =
+                            -- We trim the 'HeaderStateHistory' to the same
+                            -- size as our fragment so they keep in sync.
+                            HeaderStateHistory.trim
+                                (AF.length trimmedCandidate)
+                                theirHeaderStateHistory
+                      }
 
 {-------------------------------------------------------------------------------
   (Re-)Establishing a common intersection
 -------------------------------------------------------------------------------}
 
-findIntersectionTop
-    :: forall m blk arrival judgment.
-       ( IOLike m
-       , LedgerSupportsProtocol blk
-       )
-    => ConfigEnv m blk
-    -> DynamicEnv m blk
-    -> InternalEnv m blk arrival judgment
-    -> (Our (Tip blk) -> Their (Tip blk) -> ChainSyncClientResult)
-       -- ^ Exception to throw when no intersection is found.
-    -> Stateful m blk () (ClientPipelinedStIdle 'Z)
+findIntersectionTop ::
+  forall m blk arrival judgment.
+     ( IOLike m
+     , LedgerSupportsProtocol blk
+     )
+  => ConfigEnv m blk
+  -> DynamicEnv m blk
+  -> InternalEnv m blk arrival judgment
+  -> (Our (Tip blk) -> Their (Tip blk) -> ChainSyncClientResult)
+     -- ^ Exception to throw when no intersection is found.
+  -> Stateful m blk () (ClientPipelinedStIdle 'Z)
 findIntersectionTop cfgEnv dynEnv intEnv =
-    \mkResult -> findIntersection mkResult
+    findIntersection
   where
     ConfigEnv {
         tracer
@@ -682,116 +723,125 @@ findIntersectionTop cfgEnv dynEnv intEnv =
       , traceException
       } = intEnv
 
-    -- | Try to find an intersection by sending points of our current chain to
+    -- Try to find an intersection by sending points of our current chain to
     -- the server, if any of them intersect with their chain, roll back our
     -- chain to that point and start synching using that fragment. If none
     -- intersect, disconnect by throwing the exception obtained by calling the
     -- passed function.
-    findIntersection
-      :: (Our (Tip blk) -> Their (Tip blk) -> ChainSyncClientResult)
-         -- ^ Exception to throw when no intersection is found.
-      -> Stateful m blk () (ClientPipelinedStIdle 'Z)
+    findIntersection ::
+        (Our (Tip blk) -> Their (Tip blk) -> ChainSyncClientResult)
+        -- ^ Exception to throw when no intersection is found.
+     -> Stateful m blk () (ClientPipelinedStIdle 'Z)
     findIntersection mkResult = Stateful $ \() -> do
-      (ourFrag, ourHeaderStateHistory) <- atomically $ (,)
-        <$> getCurrentChain
-        <*> getHeaderStateHistory
-      -- We select points from the last @k@ headers of our current chain. This
-      -- means that if an intersection is found for one of these points, it
-      -- was an intersection within the last @k@ blocks of our current chain.
-      -- If not, we could never switch to this candidate chain anyway.
-      let maxOffset = fromIntegral (AF.length ourFrag)
-          k         = protocolSecurityParam (configConsensus cfg)
-          offsets   = mkOffsets k maxOffset
-          points    = map castPoint
-                    $ AF.selectPoints (map fromIntegral offsets) ourFrag
-          uis = UnknownIntersectionState {
-              ourFrag               = ourFrag
-            , ourHeaderStateHistory = ourHeaderStateHistory
-            }
-      return $ SendMsgFindIntersect points $ ClientPipelinedStIntersect
-        { recvMsgIntersectFound = \i theirTip' ->
-            continueWithState uis $
-              intersectFound (castPoint i) (Their theirTip')
-        , recvMsgIntersectNotFound = \theirTip' ->
-            terminate $
-              mkResult
-                (ourTipFromChain ourFrag)
-                (Their theirTip')
-        }
+        (ourFrag, ourHeaderStateHistory) <- atomically $ (,)
+            <$> getCurrentChain
+            <*> getHeaderStateHistory
+        -- This means that if an intersection is found for one of these points,
+        -- it was an intersection within the last @k@ blocks of our current
+        -- chain. If not, we could never switch to this candidate chain anyway.
+        let maxOffset = fromIntegral (AF.length ourFrag)
+            k         = protocolSecurityParam (configConsensus cfg)
+            offsets   = mkOffsets k maxOffset
+            points    =
+                map castPoint
+              $ AF.selectPoints (map fromIntegral offsets) ourFrag
 
-    -- | One of the points we sent intersected our chain. This intersection
-    -- point will become the new tip of the candidate fragment.
-    intersectFound :: Point blk  -- ^ Intersection
-                   -> Their (Tip blk)
-                   -> Stateful m blk
-                        (UnknownIntersectionState blk)
-                        (ClientPipelinedStIdle 'Z)
-    intersectFound intersection theirTip
-                 = Stateful $ \UnknownIntersectionState
-                     { ourFrag
-                     , ourHeaderStateHistory
-                     } -> do
-      traceWith tracer $
-        TraceFoundIntersection intersection (ourTipFromChain ourFrag) theirTip
-      traceException $ do
-        -- Roll back the current chain fragment to the @intersection@.
-        --
-        -- While the primitives in the ChainSync protocol are "roll back",
-        -- "roll forward (apply block)", etc. The /real/ primitive is "switch
-        -- to fork", which means that a roll back is always followed by
-        -- applying at least as many blocks that we rolled back.
-        --
-        -- This is important for 'rewindHeaderStateHistory', which can only roll
-        -- back up to @k@ blocks, /once/, i.e., we cannot keep rolling back the
-        -- same chain state multiple times, because that would mean that we
-        -- store the chain state for the /whole chain/, all the way to genesis.
-        --
-        -- So the rewind below is fine when we are switching to a fork (i.e.
-        -- it is followed by rolling forward again), but we need some
-        -- guarantees that the ChainSync protocol /does/ in fact give us a
-        -- switch-to-fork instead of a true rollback.
-        (theirFrag, theirHeaderStateHistory) <- do
-          case attemptRollback intersection (ourFrag, ourHeaderStateHistory) of
-            Just (c, d) -> return (c, d)
-            -- The @intersection@ is not on our fragment, even though
-            -- we sent only points from our fragment to find an
-            -- intersection with. The node must have sent us an invalid
-            -- intersection point.
-            Nothing -> disconnect $
-              InvalidIntersection
-                intersection
-                (ourTipFromChain ourFrag)
-                theirTip
-        atomically $ do
-          writeTVar varCandidate theirFrag
-        let kis = assertKnownIntersectionInvariants (configConsensus cfg) $
-              KnownIntersectionState
-                { theirFrag               = theirFrag
-                , theirHeaderStateHistory = theirHeaderStateHistory
-                , ourFrag                 = ourFrag
-                , mostRecentIntersection  = intersection
-                }
-        continueWithState kis $
-          knownIntersectionStateTop cfgEnv dynEnv intEnv theirTip
+            uis = UnknownIntersectionState {
+                ourFrag               = ourFrag
+              , ourHeaderStateHistory = ourHeaderStateHistory
+              }
+
+        return
+          $ SendMsgFindIntersect points
+          $ ClientPipelinedStIntersect {
+                recvMsgIntersectFound    = \i theirTip' ->
+                    continueWithState uis
+                  $ intersectFound (castPoint i) (Their theirTip')
+              ,
+                recvMsgIntersectNotFound = \theirTip' ->
+                    terminate
+                  $ mkResult (ourTipFromChain ourFrag) (Their theirTip')
+              }
+
+    -- One of the points we sent intersected our chain. This intersection point
+    -- will become the new tip of the candidate fragment.
+    intersectFound ::
+        Point blk  -- ^ Intersection
+     -> Their (Tip blk)
+     -> Stateful m blk
+            (UnknownIntersectionState blk)
+            (ClientPipelinedStIdle 'Z)
+    intersectFound intersection theirTip = Stateful $ \uis -> do
+        let UnknownIntersectionState {
+                ourFrag
+              , ourHeaderStateHistory
+              } = uis
+        traceWith tracer $
+            TraceFoundIntersection
+                intersection (ourTipFromChain ourFrag) theirTip
+        traceException $ do
+            -- Roll back the current chain fragment to the @intersection@.
+            --
+            -- While the primitives in the ChainSync protocol are "roll back",
+            -- "roll forward (apply block)", etc. The /real/ primitive is
+            -- "switch to fork", which means that a roll back is always
+            -- followed by applying at least as many blocks that we rolled
+            -- back.
+            --
+            -- This is important for 'rewindHeaderStateHistory', which can only
+            -- roll back up to @k@ blocks, /once/, i.e., we cannot keep rolling
+            -- back the same chain state multiple times, because that would
+            -- mean that we store the chain state for the /whole chain/, all
+            -- the way to genesis.
+            --
+            -- So the rewind below is fine when we are switching to a fork
+            -- (i.e. it is followed by rolling forward again), but we need some
+            -- guarantees that the ChainSync protocol /does/ in fact give us a
+            -- switch-to-fork instead of a true rollback.
+            (theirFrag, theirHeaderStateHistory) <- do
+                case attemptRollback
+                         intersection
+                         (ourFrag, ourHeaderStateHistory)
+                  of
+                    Just (c, d) -> return (c, d)
+                    Nothing ->
+                        -- The @intersection@ is not on our fragment, even
+                        -- though we sent only points from our fragment to find
+                        -- an intersection with. The node must have sent us an
+                        -- invalid intersection point.
+                        disconnect
+                      $ InvalidIntersection
+                            intersection (ourTipFromChain ourFrag) theirTip
+            atomically $ writeTVar varCandidate theirFrag
+            let kis =
+                   assertKnownIntersectionInvariants (configConsensus cfg)
+                 $ KnownIntersectionState {
+                       mostRecentIntersection  = intersection
+                     , ourFrag
+                     , theirFrag
+                     , theirHeaderStateHistory
+                     }
+            continueWithState kis $
+                knownIntersectionStateTop cfgEnv dynEnv intEnv theirTip
 
 {-------------------------------------------------------------------------------
   Processing 'MsgRollForward' and 'MsgRollBackward'
 -------------------------------------------------------------------------------}
 
-knownIntersectionStateTop
-    :: forall m blk arrival judgment.
-       ( IOLike m
-       , LedgerSupportsProtocol blk
-       )
-    => ConfigEnv m blk
-    -> DynamicEnv m blk
-    -> InternalEnv m blk arrival judgment
-    -> Their (Tip blk)
-    -> Stateful m blk
+knownIntersectionStateTop ::
+  forall m blk arrival judgment.
+     ( IOLike m
+     , LedgerSupportsProtocol blk
+     )
+  => ConfigEnv m blk
+  -> DynamicEnv m blk
+  -> InternalEnv m blk arrival judgment
+  -> Their (Tip blk)
+  -> Stateful m blk
          (KnownIntersectionState blk)
          (ClientPipelinedStIdle 'Z)
 knownIntersectionStateTop cfgEnv dynEnv intEnv =
-    \theirTip -> nextStep mkPipelineDecision0 Zero theirTip
+    nextStep mkPipelineDecision0 Zero
       -- The 'MkPiplineDecision' and @'Nat' n@ arguments below could safely be
       -- merged into the 'KnownIntersectionState' record type, but it's
       -- unfortunately quite awkward to do so.
@@ -820,7 +870,7 @@ knownIntersectionStateTop cfgEnv dynEnv intEnv =
         recordHeaderArrival
       } = headerInFutureCheck
 
-    -- | Request the next message (roll forward or backward), unless our chain
+    -- Request the next message (roll forward or backward), unless our chain
     -- has changed such that it no longer intersects with the candidate, in
     -- which case we initiate the intersection finding part of the protocol.
     --
@@ -830,181 +880,246 @@ knownIntersectionStateTop cfgEnv dynEnv intEnv =
     --
     -- This is also the place where we checked whether we're asked to terminate
     -- by the mux layer.
-    nextStep :: MkPipelineDecision
-             -> Nat n
-             -> Their (Tip blk)
-             -> Stateful m blk
-                  (KnownIntersectionState blk)
-                  (ClientPipelinedStIdle n)
+    nextStep ::
+        MkPipelineDecision
+     -> Nat n
+     -> Their (Tip blk)
+     -> Stateful m blk
+            (KnownIntersectionState blk)
+            (ClientPipelinedStIdle n)
     nextStep mkPipelineDecision n theirTip = Stateful $ \kis -> do
-      atomically controlMessageSTM >>= \case
-        -- We have been asked to terminate the client
-        Terminate ->
-          terminateAfterDrain n $ AskedToTerminate
-        _continue -> do
-          mKis' <- atomically $ intersectsWithCurrentChain kis
-          case mKis' of
-            StillIntersects () kis'@KnownIntersectionState { theirFrag } -> do
-              -- Our chain (tip) didn't change or if it did, it still intersects
-              -- with the candidate fragment, so we can continue requesting the
-              -- next block.
-              atomically $ writeTVar varCandidate theirFrag
-              let candTipBlockNo = AF.headBlockNo theirFrag
-              return $
-                requestNext kis' mkPipelineDecision n theirTip candTipBlockNo
-            NoLongerIntersects -> do
-              -- Our chain (tip) has changed and it no longer intersects with
-              -- the candidate fragment, so we have to find a new intersection,
-              -- but first drain the pipe.
-              continueWithState ()
-                $ drainThePipe n
-                $ findIntersectionTop cfgEnv dynEnv intEnv NoMoreIntersection
+        atomically controlMessageSTM >>= \case
+            -- We have been asked to terminate the client
+            Terminate -> terminateAfterDrain n $ AskedToTerminate
+            _continue -> do
+                atomically (intersectsWithCurrentChain kis) >>= \case
+                    -- Our chain (tip) didn't change or if it did, it still
+                    -- intersects with the candidate fragment, so we can
+                    -- continue requesting the next block.
+                    StillIntersects () kis' -> do
+                        let KnownIntersectionState {
+                                theirFrag
+                              } = kis'
+                        atomically $ writeTVar varCandidate theirFrag
+                        return $
+                            requestNext
+                                kis'
+                                mkPipelineDecision
+                                n
+                                theirTip
+                                (AF.headBlockNo theirFrag)
+                    -- Our chain (tip) has changed and it no longer intersects
+                    -- with the candidate fragment, so we have to find a new
+                    -- intersection, but first drain the pipe.
+                    NoLongerIntersects ->
+                        continueWithState ()
+                      $ drainThePipe n
+                      $ findIntersectionTop
+                          cfgEnv
+                          dynEnv
+                          intEnv
+                          NoMoreIntersection
 
-    requestNext :: KnownIntersectionState blk
-                -> MkPipelineDecision
-                -> Nat n
-                -> Their (Tip blk)
-                -> WithOrigin BlockNo
-                -> Consensus (ClientPipelinedStIdle n) blk m
+    requestNext ::
+        KnownIntersectionState blk
+     -> MkPipelineDecision
+     -> Nat n
+     -> Their (Tip blk)
+     -> WithOrigin BlockNo
+     -> Consensus (ClientPipelinedStIdle n) blk m
     requestNext kis mkPipelineDecision n theirTip candTipBlockNo =
+        let theirTipBlockNo = getTipBlockNo (unTheir theirTip)
+            decision        =
+              runPipelineDecision
+              mkPipelineDecision
+              n
+              candTipBlockNo
+              theirTipBlockNo
+        in
         case (n, decision) of
           (Zero, (Request, mkPipelineDecision')) ->
-            SendMsgRequestNext
-              (handleNext kis mkPipelineDecision' Zero)
-              (return $ handleNext kis mkPipelineDecision' Zero) -- when we have to wait
-          (_, (Pipeline, mkPipelineDecision')) ->
-            SendMsgRequestNextPipelined
-              (requestNext kis mkPipelineDecision' (Succ n) theirTip candTipBlockNo)
-          (Succ n', (CollectOrPipeline, mkPipelineDecision')) ->
-            CollectResponse
-              (Just $ pure $ SendMsgRequestNextPipelined $
-                requestNext kis mkPipelineDecision' (Succ n) theirTip candTipBlockNo)
-              (handleNext kis mkPipelineDecision' n')
-          (Succ n', (Collect, mkPipelineDecision')) ->
-            CollectResponse
-              Nothing
-              (handleNext kis mkPipelineDecision' n')
-      where
-        theirTipBlockNo = getTipBlockNo (unTheir theirTip)
-        decision = runPipelineDecision
-          mkPipelineDecision
-          n
-          candTipBlockNo
-          theirTipBlockNo
+              SendMsgRequestNext
+                  (handleNext kis mkPipelineDecision' Zero)
+                  ( -- when we have to wait
+                    return $ handleNext kis mkPipelineDecision' Zero
+                  )
 
-    handleNext :: KnownIntersectionState blk
-               -> MkPipelineDecision
-               -> Nat n
-               -> Consensus (ClientStNext n) blk m
-    handleNext kis mkPipelineDecision n = ClientStNext
-      { recvMsgRollForward  = \hdr theirTip -> do
-          traceWith tracer $ TraceDownloadedHeader hdr
-          continueWithState kis $
-            rollForward mkPipelineDecision n hdr (Their theirTip)
-      , recvMsgRollBackward = \intersection theirTip -> do
-          let intersection' :: Point blk
-              intersection' = castPoint intersection
-          traceWith tracer $ TraceRolledBack intersection'
-          continueWithState kis $
-            rollBackward mkPipelineDecision n intersection' (Their theirTip)
+          (_, (Pipeline, mkPipelineDecision')) ->
+              SendMsgRequestNextPipelined
+            $ requestNext
+                  kis
+                  mkPipelineDecision'
+                  (Succ n)
+                  theirTip
+                  candTipBlockNo
+
+          (Succ n', (CollectOrPipeline, mkPipelineDecision')) ->
+              CollectResponse
+                  (    Just
+                    $ pure
+                    $ SendMsgRequestNextPipelined
+                    $ requestNext
+                          kis
+                          mkPipelineDecision'
+                          (Succ n)
+                          theirTip
+                          candTipBlockNo
+                  )
+                  (handleNext kis mkPipelineDecision' n')
+
+          (Succ n', (Collect, mkPipelineDecision')) ->
+              CollectResponse
+                  Nothing
+                  (handleNext kis mkPipelineDecision' n')
+
+    handleNext ::
+        KnownIntersectionState blk
+     -> MkPipelineDecision
+     -> Nat n
+     -> Consensus (ClientStNext n) blk m
+    handleNext kis mkPipelineDecision n = ClientStNext {
+        recvMsgRollForward = \hdr theirTip -> do
+            traceWith tracer $ TraceDownloadedHeader hdr
+            continueWithState kis $
+                rollForward
+                    mkPipelineDecision
+                    n
+                    hdr
+                    (Their theirTip)
+      ,
+        recvMsgRollBackward = \intersection theirTip -> do
+            let intersection' :: Point blk
+                intersection' = castPoint intersection
+            traceWith tracer $ TraceRolledBack intersection'
+            continueWithState kis $
+                rollBackward
+                    mkPipelineDecision
+                    n
+                    intersection'
+                    (Their theirTip)
       }
 
-    rollForward :: MkPipelineDecision
-                -> Nat n
-                -> Header blk
-                -> Their (Tip blk)
-                -> Stateful m blk
-                     (KnownIntersectionState blk)
-                     (ClientPipelinedStIdle n)
-    rollForward mkPipelineDecision n hdr theirTip
-              = Stateful $ \kis -> traceException $ do
-        arrival     <- recordHeaderArrival hdr
-        arrivalTime <- getMonotonicTime
+    rollForward ::
+        MkPipelineDecision
+     -> Nat n
+     -> Header blk
+     -> Their (Tip blk)
+     -> Stateful m blk
+            (KnownIntersectionState blk)
+            (ClientPipelinedStIdle n)
+    rollForward mkPipelineDecision n hdr theirTip =
+        Stateful $ \kis -> traceException $ do
+            arrival     <- recordHeaderArrival hdr
+            arrivalTime <- getMonotonicTime
 
-        let slotNo = blockSlot hdr
+            let slotNo = blockSlot hdr
 
-        checkKnownInvalid cfgEnv dynEnv intEnv hdr
+            checkKnownInvalid cfgEnv dynEnv intEnv hdr
 
-        checkTime cfgEnv intEnv kis arrival slotNo >>= \case
-          NoLongerIntersects -> do
-            continueWithState ()
-              $ drainThePipe n
-              $ findIntersectionTop cfgEnv dynEnv intEnv NoMoreIntersection
+            checkTime cfgEnv intEnv kis arrival slotNo >>= \case
+                NoLongerIntersects ->
+                    continueWithState ()
+                  $ drainThePipe n
+                  $ findIntersectionTop
+                        cfgEnv
+                        dynEnv
+                        intEnv
+                        NoMoreIntersection
 
-          StillIntersects ledgerView kis' -> do
-            kis'' <- checkValid cfgEnv intEnv hdr theirTip kis' ledgerView
+                StillIntersects ledgerView kis' -> do
+                    kis'' <-
+                        checkValid cfgEnv intEnv hdr theirTip kis' ledgerView
 
-            atomically $ writeTVar varCandidate (theirFrag kis'')
-            atomically $ traceWith headerMetricsTracer (slotNo, arrivalTime)
+                    atomically $ writeTVar varCandidate (theirFrag kis'')
+                    atomically
+                      $ traceWith headerMetricsTracer (slotNo, arrivalTime)
 
-            continueWithState kis'' $ nextStep mkPipelineDecision n theirTip
+                    continueWithState kis''
+                      $ nextStep mkPipelineDecision n theirTip
 
-    rollBackward :: MkPipelineDecision
-                 -> Nat n
-                 -> Point blk
-                 -> Their (Tip blk)
-                 -> Stateful m blk
-                      (KnownIntersectionState blk)
-                      (ClientPipelinedStIdle n)
-    rollBackward mkPipelineDecision n rollBackPoint
-                 theirTip
-               = Stateful $ \KnownIntersectionState
-                   { theirFrag
-                   , theirHeaderStateHistory
-                   , ourFrag
-                   , mostRecentIntersection
-                   } -> traceException $ do
-        case attemptRollback rollBackPoint (theirFrag, theirHeaderStateHistory) of
-          -- Remember that we use our current chain fragment as the starting
-          -- point for the candidate's chain. Our fragment contained @k@
-          -- headers. At this point, the candidate fragment might have grown to
-          -- more than @k@ or rolled back to less than @k@ headers.
-          --
-          -- But now, it rolled back to some point that is not on the fragment,
-          -- which means that it tried to roll back to some point before one of
-          -- the last @k@ headers we initially started from. We could never
-          -- switch to this fork anyway, so just disconnect. Furthermore, our
-          -- current chain might have advanced in the meantime, so the point we
-          -- would have to roll back to might have been much further back than
-          -- @k@ blocks (> @k@ + the number of blocks we have advanced since
-          -- starting syncing).
-          --
-          -- INVARIANT: a candidate fragment contains @>=k@ headers (unless
-          -- near genesis, in which case we mean the total number of blocks in
-          -- the fragment) minus @r@ headers where @r <= k@. This ghost
-          -- variable @r@ indicates the number of headers we temporarily
-          -- rolled back. Such a rollback must always be followed by rolling
-          -- forward @s@ new headers where @s >= r@.
-          --
-          -- Thus, @k - r + s >= k@.
-          Nothing ->
-            terminateAfterDrain n $
-              RolledBackPastIntersection
-                rollBackPoint
-                (ourTipFromChain ourFrag)
-                theirTip
+    rollBackward ::
+        MkPipelineDecision
+     -> Nat n
+     -> Point blk
+     -> Their (Tip blk)
+     -> Stateful m blk
+          (KnownIntersectionState blk)
+          (ClientPipelinedStIdle n)
+    rollBackward mkPipelineDecision n rollBackPoint theirTip =
+        Stateful $ \kis ->
+            traceException
+          $ let KnownIntersectionState {
+                    mostRecentIntersection
+                  , ourFrag
+                  , theirFrag
+                  , theirHeaderStateHistory
+                  } = kis
+            in
+            case attemptRollback
+                     rollBackPoint
+                     (theirFrag, theirHeaderStateHistory)
+              of
+                Nothing ->
+                    -- Remember that we use our current chain fragment as the
+                    -- starting point for the candidate's chain. Our fragment
+                    -- contained @k@ headers. At this point, the candidate
+                    -- fragment might have grown to more than @k@ or rolled
+                    -- back to less than @k@ headers.
+                    --
+                    -- But now, it rolled back to some point that is not on the
+                    -- fragment, which means that it tried to roll back to some
+                    -- point before one of the last @k@ headers we initially
+                    -- started from. We could never switch to this fork anyway,
+                    -- so just disconnect. Furthermore, our current chain might
+                    -- have advanced in the meantime, so the point we would
+                    -- have to roll back to might have been much further back
+                    -- than @k@ blocks (> @k@ + the number of blocks we have
+                    -- advanced since starting syncing).
+                    --
+                    -- INVARIANT: a candidate fragment contains @>=k@ headers
+                    -- (unless near genesis, in which case we mean the total
+                    -- number of blocks in the fragment) minus @r@ headers
+                    -- where @r <= k@. This ghost variable @r@ indicates the
+                    -- number of headers we temporarily rolled back. Such a
+                    -- rollback must always be followed by rolling forward @s@
+                    -- new headers where @s >= r@.
+                    --
+                    -- Thus, @k - r + s >= k@.
+                    terminateAfterDrain n
+                  $ RolledBackPastIntersection
+                        rollBackPoint
+                        (ourTipFromChain ourFrag)
+                        theirTip
 
-          Just (theirFrag', theirHeaderStateHistory') -> do
-            -- We just rolled back to @rollBackPoint@, either our most recent
-            -- intersection was after or at @rollBackPoint@, in which case
-            -- @rollBackPoint@ becomes the new most recent intersection.
-            --
-            -- But if the most recent intersection was /before/ @rollBackPoint@,
-            -- then the most recent intersection doesn't change.
-            let mostRecentIntersection'
-                  | AF.withinFragmentBounds (castPoint rollBackPoint) ourFrag
-                  = rollBackPoint
-                  | otherwise
-                  = mostRecentIntersection
-                kis' = assertKnownIntersectionInvariants (configConsensus cfg) $
-                  KnownIntersectionState {
-                      theirFrag               = theirFrag'
-                    , theirHeaderStateHistory = theirHeaderStateHistory'
-                    , ourFrag                 = ourFrag
-                    , mostRecentIntersection  = mostRecentIntersection'
-                    }
-            atomically $ writeTVar varCandidate theirFrag'
-            continueWithState kis' $ nextStep mkPipelineDecision n theirTip
+                Just (theirFrag', theirHeaderStateHistory') -> do
+                  -- We just rolled back to @rollBackPoint@, either our most
+                  -- recent intersection was after or at @rollBackPoint@, in
+                  -- which case @rollBackPoint@ becomes the new most recent
+                  -- intersection.
+                  --
+                  -- But if the most recent intersection was /before/
+                  -- @rollBackPoint@, then the most recent intersection doesn't
+                  -- change.
+                  let mostRecentIntersection' =
+                          if   AF.withinFragmentBounds
+                                   (castPoint rollBackPoint)
+                                   ourFrag
+                          then rollBackPoint
+                          else mostRecentIntersection
+
+                      kis' =
+                          assertKnownIntersectionInvariants
+                              (configConsensus cfg)
+                        $ KnownIntersectionState {
+                              mostRecentIntersection  = mostRecentIntersection'
+                            , ourFrag                 = ourFrag
+                            , theirFrag               = theirFrag'
+                            , theirHeaderStateHistory = theirHeaderStateHistory'
+                            }
+                  atomically $ writeTVar varCandidate theirFrag'
+
+                  continueWithState kis' $
+                      nextStep mkPipelineDecision n theirTip
 
 {-------------------------------------------------------------------------------
   Header checks
@@ -1016,22 +1131,22 @@ knownIntersectionStateTop cfgEnv dynEnv intEnv =
 -- If the peer is sending headers quickly, the 'invalidBlockRejector' might
 -- miss one. So this call is a lightweight supplement. Note that neither check
 -- /must/ be 100% reliable.
-checkKnownInvalid
-    :: forall m blk arrival judgment.
-       ( IOLike m
-       , LedgerSupportsProtocol blk
-       )
-    => ConfigEnv m blk
-    -> DynamicEnv m blk
-    -> InternalEnv m blk arrival judgment
-    -> Header blk
-    -> m ()
+checkKnownInvalid ::
+  forall m blk arrival judgment.
+     ( IOLike m
+     , LedgerSupportsProtocol blk
+     )
+  => ConfigEnv m blk
+  -> DynamicEnv m blk
+  -> InternalEnv m blk arrival judgment
+  -> Header blk
+  -> m ()
 checkKnownInvalid cfgEnv dynEnv intEnv hdr = case scrutinee of
     GenesisHash    -> return ()
     BlockHash hash -> do
-      isInvalidBlock <- atomically $ forgetFingerprint <$> getIsInvalidBlock
-      whenJust (isInvalidBlock hash) $ \reason ->
-        disconnect $ InvalidBlock (headerPoint hdr) hash reason
+        isInvalidBlock <- atomically $ forgetFingerprint <$> getIsInvalidBlock
+        whenJust (isInvalidBlock hash) $ \reason ->
+            disconnect $ InvalidBlock (headerPoint hdr) hash reason
   where
     ConfigEnv {
         chainDbView
@@ -1049,12 +1164,12 @@ checkKnownInvalid cfgEnv dynEnv intEnv hdr = case scrutinee of
         disconnect
       } = intEnv
 
-    -- when pipelining, the tip of the candidate is forgiven when it's invalid
-    -- block, but not if it extends any invalid blocks
+    -- When pipelining, the tip of the candidate is forgiven for being an
+    -- invalid block, but not if it extends any invalid blocks.
     scrutinee = case isPipeliningEnabled version of
-      NotReceivingTentativeBlocks -> BlockHash (headerHash hdr)
-      -- Disconnect if the parent block of `hdr` is known to be invalid.
-      ReceivingTentativeBlocks    -> headerPrevHash hdr
+        NotReceivingTentativeBlocks -> BlockHash (headerHash hdr)
+        -- Disconnect if the parent block of `hdr` is known to be invalid.
+        ReceivingTentativeBlocks    -> headerPrevHash hdr
 
 -- | Manage the relationships between the header's slot, arrival time, and
 -- intersection with the local selection
@@ -1072,23 +1187,24 @@ checkKnownInvalid cfgEnv dynEnv intEnv hdr = case scrutinee of
 -- Finally, the client will block on the intersection a second time, if
 -- necessary, since it's possible for a ledger state to determine the slot's
 -- onset's timestamp without also determining the slot's 'LedgerView'.
-checkTime
-    :: forall m blk arrival judgment.
-       ( IOLike m
-       , LedgerSupportsProtocol blk
-       )
-    => ConfigEnv m blk
-    -> InternalEnv m blk arrival judgment
-    -> KnownIntersectionState blk
-    -> arrival
-    -> SlotNo
-    -> m (UpdatedIntersectionState blk (LedgerView (BlockProtocol blk)))
-checkTime cfgEnv intEnv = \kis arrival slotNo -> castEarlyExitIntersects $ do
-    Intersects kis2 lst        <- checkArrivalTime kis arrival
-    Intersects kis3 ledgerView <- case projectLedgerView slotNo lst of
-      Just ledgerView -> pure $ Intersects kis2 ledgerView
-      Nothing         -> readLedgerState kis2 (projectLedgerView slotNo)
-    pure $ Intersects kis3 ledgerView
+checkTime ::
+  forall m blk arrival judgment.
+     ( IOLike m
+     , LedgerSupportsProtocol blk
+     )
+  => ConfigEnv m blk
+  -> InternalEnv m blk arrival judgment
+  -> KnownIntersectionState blk
+  -> arrival
+  -> SlotNo
+  -> m (UpdatedIntersectionState blk (LedgerView (BlockProtocol blk)))
+checkTime cfgEnv intEnv =
+    \kis arrival slotNo -> castEarlyExitIntersects $ do
+        Intersects kis2 lst        <- checkArrivalTime kis arrival
+        Intersects kis3 ledgerView <- case projectLedgerView slotNo lst of
+            Just ledgerView -> pure $ Intersects kis2 ledgerView
+            Nothing         -> readLedgerState kis2 (projectLedgerView slotNo)
+        pure $ Intersects kis3 ledgerView
   where
     ConfigEnv {
         cfg
@@ -1114,103 +1230,121 @@ checkTime cfgEnv intEnv = \kis arrival slotNo -> castEarlyExitIntersects $ do
     -- so. Also return the ledger state used for the determination.
     --
     -- Relies on 'readLedgerState'.
-    checkArrivalTime :: KnownIntersectionState blk
-                     -> arrival
-                     -> WithEarlyExit m (Intersects blk (LedgerState blk))
+    checkArrivalTime ::
+         KnownIntersectionState blk
+      -> arrival
+      -> WithEarlyExit m (Intersects blk (LedgerState blk))
     checkArrivalTime kis arrival = do
-        Intersects kis' (lst, judgment) <- readLedgerState kis $ \lst ->
-          case runExcept $ judgeHeaderArrival (configLedger cfg) lst arrival of
-            Left PastHorizon{} -> Nothing
-            Right judgment     -> Just (lst, judgment)
+        Intersects kis' (lst, judgment) <- do
+            readLedgerState kis $ \lst ->
+                case   runExcept
+                     $ judgeHeaderArrival (configLedger cfg) lst arrival
+                  of
+                    Left PastHorizon{} -> Nothing
+                    Right judgment     -> Just (lst, judgment)
 
         -- For example, throw an exception if the header is from the far
         -- future.
         EarlyExit.lift $ handleHeaderArrival judgment >>= \case
-          Just exn -> disconnect (InFutureHeaderExceedsClockSkew exn)
-          Nothing  -> return $ Intersects kis' lst
+            Just exn -> disconnect (InFutureHeaderExceedsClockSkew exn)
+            Nothing  -> return $ Intersects kis' lst
 
     -- Block until the the ledger state at the intersection with the local
     -- selection returns 'Just'.
     --
     -- Exits early if the intersection no longer exists.
-    readLedgerState :: forall a. ()
-                    => KnownIntersectionState blk
-                    -> (LedgerState blk -> Maybe a)
-                    -> WithEarlyExit m (Intersects blk a)
+    readLedgerState ::
+      forall a.
+         KnownIntersectionState blk
+      -> (LedgerState blk -> Maybe a)
+      -> WithEarlyExit m (Intersects blk a)
     readLedgerState kis prj = castM $ readLedgerStateHelper kis prj
 
-    readLedgerStateHelper :: forall a. ()
-                          => KnownIntersectionState blk
-                          -> (LedgerState blk -> Maybe a)
-                          -> m (WithEarlyExit m (Intersects blk a))
+    readLedgerStateHelper ::
+      forall a.
+         KnownIntersectionState blk
+      -> (LedgerState blk -> Maybe a)
+      -> m (WithEarlyExit m (Intersects blk a))
     readLedgerStateHelper kis prj = atomically $ do
         -- We must first find the most recent intersection with the current
         -- chain. Note that this is cheap when the chain and candidate haven't
         -- changed.
         intersectsWithCurrentChain kis >>= \case
-          NoLongerIntersects      -> return exitEarly
-          StillIntersects () kis' -> do
-            let KnownIntersectionState { mostRecentIntersection } = kis'
-            lst <-
-              maybe
-                (error $
-                   "intersection not within last k blocks: " <> show mostRecentIntersection)
-                ledgerState
-                <$> getPastLedger mostRecentIntersection
-            case prj lst of
-              Nothing         -> retry
-              Just ledgerView -> return $ return $ Intersects kis' ledgerView
+            NoLongerIntersects      -> return exitEarly
+            StillIntersects () kis' -> do
+                let KnownIntersectionState {
+                        mostRecentIntersection
+                      } = kis'
+                lst <-
+                    fmap
+                      (maybe
+                           (error $
+                                 "intersection not within last k blocks: "
+                              <> show mostRecentIntersection
+                           )
+                           ledgerState
+                      )
+                  $ getPastLedger mostRecentIntersection
+                case prj lst of
+                    Nothing         -> retry
+                    Just ledgerView ->
+                        return $ return $ Intersects kis' ledgerView
 
     -- Returns 'Nothing' if the ledger state cannot forecast the ledger view
     -- that far into the future.
-    projectLedgerView :: SlotNo
-                      -> LedgerState blk
-                      -> Maybe (LedgerView (BlockProtocol blk))
+    projectLedgerView ::
+         SlotNo
+      -> LedgerState blk
+      -> Maybe (LedgerView (BlockProtocol blk))
     projectLedgerView slot lst =
         let forecast = ledgerViewForecastAt (configLedger cfg) lst
               -- TODO cache this in the KnownIntersectionState? Or even in the
               -- LedgerDB?
         in
         case runExcept $ forecastFor forecast slot of
-          -- The header is too far ahead of the intersection point with our
-          -- current chain. We have to wait until our chain and the
-          -- intersection have advanced far enough. This will wait on
-          -- changes to the current chain via the call to
-          -- 'intersectsWithCurrentChain' before it.
-          Left OutsideForecastRange{} -> Nothing
-          Right ledgerView            -> Just ledgerView
+            Right ledgerView            -> Just ledgerView
+            Left OutsideForecastRange{} ->
+                -- The header is too far ahead of the intersection point with
+                -- our current chain. We have to wait until our chain and the
+                -- intersection have advanced far enough. This will wait on
+                -- changes to the current chain via the call to
+                -- 'intersectsWithCurrentChain' before it.
+                Nothing
 
 -- | Update the 'KnownIntersectionState' according to the header, if it's valid
 --
 -- Crucially: disconnects if it isn't.
-checkValid
-    :: forall m blk arrival judgment.
-       ( IOLike m
-       , LedgerSupportsProtocol blk
-       )
-    => ConfigEnv m blk
-    -> InternalEnv m blk arrival judgment
-    -> Header blk
-    -> Their (Tip blk)
-    -> KnownIntersectionState blk
-    -> LedgerView (BlockProtocol blk)
-    -> m (KnownIntersectionState blk)
+checkValid ::
+  forall m blk arrival judgment.
+     ( IOLike m
+     , LedgerSupportsProtocol blk
+     )
+  => ConfigEnv m blk
+  -> InternalEnv m blk arrival judgment
+  -> Header blk
+  -> Their (Tip blk)
+  -> KnownIntersectionState blk
+  -> LedgerView (BlockProtocol blk)
+  -> m (KnownIntersectionState blk)
 checkValid cfgEnv intEnv hdr theirTip kis ledgerView = do
     let KnownIntersectionState {
-            ourFrag
+            mostRecentIntersection
+          , ourFrag
           , theirFrag
           , theirHeaderStateHistory
-          , mostRecentIntersection
-          }      = kis
-        hdrPoint = headerPoint hdr
+          } = kis
+
+    let hdrPoint = headerPoint hdr
 
     -- Validate header
     theirHeaderStateHistory' <-
-      case runExcept $ validateHeader cfg ledgerView hdr theirHeaderStateHistory of
-        Right theirHeaderStateHistory' -> return theirHeaderStateHistory'
-        Left  vErr ->
-          disconnect $
-            HeaderError hdrPoint vErr (ourTipFromChain ourFrag) theirTip
+        case   runExcept
+             $ validateHeader cfg ledgerView hdr theirHeaderStateHistory
+          of
+            Right theirHeaderStateHistory' -> return theirHeaderStateHistory'
+            Left  vErr ->
+                disconnect
+              $ HeaderError hdrPoint vErr (ourTipFromChain ourFrag) theirTip
 
     let theirFrag' = theirFrag :> hdr
         -- Advance the most recent intersection if we have the same
@@ -1218,19 +1352,20 @@ checkValid cfgEnv intEnv hdr theirTip kis ledgerView = do
         -- the intersection from scratch.
         mostRecentIntersection'
           | Just ourSuccessor <-
-              AF.successorBlock (castPoint mostRecentIntersection) ourFrag
+                AF.successorBlock (castPoint mostRecentIntersection) ourFrag
           , headerHash ourSuccessor == headerHash hdr
           = headerPoint hdr
           | otherwise
           = mostRecentIntersection
 
-    pure $ assertKnownIntersectionInvariants (configConsensus cfg) $
-          KnownIntersectionState {
-              theirFrag               = theirFrag'
-            , theirHeaderStateHistory = theirHeaderStateHistory'
-            , ourFrag                 = ourFrag
-            , mostRecentIntersection  = mostRecentIntersection'
-            }
+    pure
+      $ assertKnownIntersectionInvariants (configConsensus cfg)
+      $ KnownIntersectionState {
+            mostRecentIntersection  = mostRecentIntersection'
+          , ourFrag                 = ourFrag
+          , theirFrag               = theirFrag'
+          , theirHeaderStateHistory = theirHeaderStateHistory'
+          }
   where
     ConfigEnv {
         cfg
@@ -1245,31 +1380,32 @@ checkValid cfgEnv intEnv hdr theirTip kis ledgerView = do
 -------------------------------------------------------------------------------}
 
 data UpdatedIntersectionState blk a =
-    -- | The local selection has changed such 'ourFrag' no longer
+    NoLongerIntersects
+    -- ^ The local selection has changed such that 'ourFrag' no longer
     -- intersects 'theirFrag'
     --
-    -- (The intersection could also be lost because of messages they sent, but
-    -- that's handled elsewhere, not involving this data type.)
-    NoLongerIntersects
-  | StillIntersects a !(KnownIntersectionState blk)
+    -- (In general, the intersection could also be lost because of messages
+    -- they sent, but that's handled elsewhere, not involving this data type.)
+  |
+    StillIntersects a !(KnownIntersectionState blk)
 
 data Intersects blk a =
     Intersects
         (KnownIntersectionState blk)
         a
 
-castEarlyExitIntersects
-  :: Monad m
+castEarlyExitIntersects ::
+     Monad m
   => WithEarlyExit m (Intersects blk a)
   -> m (UpdatedIntersectionState blk a)
 castEarlyExitIntersects =
-    fmap f . EarlyExit.withEarlyExit
+    fmap cnv . EarlyExit.withEarlyExit
   where
-    f = \case
+    cnv = \case
         Nothing                 -> NoLongerIntersects
         Just (Intersects kis a) -> StillIntersects a kis
 
--- Recent offsets
+-- | Recent offsets
 --
 -- These offsets are used to find an intersection point between our chain
 -- and the upstream node's. We use the fibonacci sequence to try blocks
@@ -1295,18 +1431,18 @@ mkOffsets (SecurityParam k) maxOffset =
   where
     l = k `min` maxOffset
 
-ourTipFromChain
-    :: HasHeader (Header blk)
-    => AnchoredFragment (Header blk)
-    -> Our (Tip blk)
+ourTipFromChain ::
+     HasHeader (Header blk)
+  => AnchoredFragment (Header blk)
+  -> Our (Tip blk)
 ourTipFromChain = Our . AF.anchorToTip . AF.headAnchor
 
--- If the two fragments `c1` and `c2` intersect, return the intersection
--- point and join the prefix of `c1` before the intersection with the suffix
--- of `c2` after the intersection. The resulting fragment has the same
--- anchor as `c1` and the same head as `c2`.
-cross
-  :: HasHeader blk
+-- | If the two fragments `c1` and `c2` intersect, return the intersection
+-- point and join the prefix of `c1` before the intersection with the suffix of
+-- `c2` after the intersection. The resulting fragment has the same anchor as
+-- `c1` and the same head as `c2`.
+cross ::
+     HasHeader blk
   => AnchoredFragment blk
   -> AnchoredFragment blk
   -> Maybe (Point blk, AnchoredFragment blk)
@@ -1315,12 +1451,12 @@ cross c1 c2 = do
     -- Note that the head of `p1` and `_p2` is the intersection point, and
     -- `_s1` and `s2` are anchored in the intersection point.
     let crossed = case AF.join p1 s2 of
-          Just c  -> c
-          Nothing -> error "invariant violation of AF.intersect"
+            Just c  -> c
+            Nothing -> error "invariant violation of AF.intersect"
     pure (AF.anchorPoint s2, crossed)
 
--- A type-legos auxillary function used in 'readLedgerState'.
-castM :: forall m x. Monad m => m (WithEarlyExit m x) -> WithEarlyExit m x
+-- | A type-legos auxillary function used in 'readLedgerState'.
+castM :: Monad m => m (WithEarlyExit m x) -> WithEarlyExit m x
 castM = join . EarlyExit.lift
 
 attemptRollback ::
@@ -1328,7 +1464,7 @@ attemptRollback ::
      , HasAnnTip blk
      )
   => Point blk
-  -> (AnchoredFragment (Header blk), HeaderStateHistory blk)
+  ->       (AnchoredFragment (Header blk), HeaderStateHistory blk)
   -> Maybe (AnchoredFragment (Header blk), HeaderStateHistory blk)
 attemptRollback rollBackPoint (frag, state) = do
     frag'  <- AF.rollback (castPoint rollBackPoint) frag
@@ -1354,17 +1490,18 @@ attemptRollback rollBackPoint (frag, state) = do
 -- the candidate fragment and /check/ is the cost of checking whether a block
 -- is invalid (typically \( O(\log(invalid)) \) where /invalid/ is the number
 -- of invalid blocks).
-invalidBlockRejector
-    :: forall m blk.
-       ( IOLike m
-       , LedgerSupportsProtocol blk
-       )
-    => Tracer m (TraceChainSyncClientEvent blk)
-    -> NodeToNodeVersion
-    -> STM m (WithFingerprint (HeaderHash blk -> Maybe (InvalidBlockReason blk)))
-       -- ^ Get the invalid block checker
-    -> STM m (AnchoredFragment (Header blk))
-    -> Watcher m
+invalidBlockRejector ::
+  forall m blk.
+     ( IOLike m
+     , LedgerSupportsProtocol blk
+     )
+  => Tracer m (TraceChainSyncClientEvent blk)
+  -> NodeToNodeVersion
+  -> STM m (WithFingerprint (HeaderHash blk -> Maybe (InvalidBlockReason blk)))
+     -- ^ Get the invalid block checker
+  -> STM m (AnchoredFragment (Header blk))
+     -- ^ Get the candidate
+  -> Watcher m
          (WithFingerprint (HeaderHash blk -> Maybe (InvalidBlockReason blk)))
          Fingerprint
 invalidBlockRejector tracer version getIsInvalidBlock getCandidate =
@@ -1377,30 +1514,33 @@ invalidBlockRejector tracer version getIsInvalidBlock getCandidate =
   where
     checkInvalid :: (HeaderHash blk -> Maybe (InvalidBlockReason blk)) -> m ()
     checkInvalid isInvalidBlock = do
-      theirFrag <- atomically getCandidate
-      -- The invalid block is likely to be a more recent block, so check from
-      -- newest to oldest.
-      --
-      -- As of block diffusion pipelining, their tip header might be tentative.
-      -- Since they do not yet have a way to explicitly say whether it is
-      -- tentative, we assume it is and therefore skip their tip here. TODO once
-      -- it's explicit, only skip it if it's annotated as tentative
-      mapM_ (uncurry disconnect) $ firstJust
-        (\hdr -> (hdr,) <$> isInvalidBlock (headerHash hdr))
-        (  (case isPipeliningEnabled version of
-              ReceivingTentativeBlocks    -> drop 1
-              NotReceivingTentativeBlocks -> id)
-         $ AF.toNewestFirst theirFrag
-        )
+        theirFrag <- atomically getCandidate
+        -- The invalid block is likely to be a more recent block, so check from
+        -- newest to oldest.
+        --
+        -- As of block diffusion pipelining, their tip header might be
+        -- tentative. Since they do not yet have a way to explicitly say
+        -- whether it is tentative, we assume it is and therefore skip their
+        -- tip here. TODO once it's explicit, only skip it if it's annotated as
+        -- tentative
+        mapM_ (uncurry disconnect)
+          $ firstJust
+                (\hdr -> (hdr,) <$> isInvalidBlock (headerHash hdr))
+          $ (   case isPipeliningEnabled version of
+                    ReceivingTentativeBlocks    -> drop 1
+                    NotReceivingTentativeBlocks -> id
+            )
+          $ AF.toNewestFirst theirFrag
 
     disconnect :: Header blk -> InvalidBlockReason blk -> m ()
     disconnect invalidHeader reason = do
-      let ex = InvalidBlock
-                 (headerPoint invalidHeader)
-                 (headerHash invalidHeader)
-                 reason
-      traceWith tracer $ TraceException ex
-      throwIO ex
+        let ex =
+                InvalidBlock
+                  (headerPoint invalidHeader)
+                  (headerHash invalidHeader)
+                  reason
+        traceWith tracer $ TraceException ex
+        throwIO ex
 
 {-------------------------------------------------------------------------------
   Explicit state
@@ -1416,8 +1556,11 @@ invalidBlockRejector tracer version getIsInvalidBlock getCandidate =
 -- the state explicit in the types and do the check in 'continueWithState'.
 newtype Stateful m blk s st = Stateful (s -> m (Consensus st blk m))
 
-continueWithState :: forall m blk s st. NoThunks s
-                  => s -> Stateful m blk s st -> m (Consensus st blk m)
+continueWithState ::
+     NoThunks s
+  => s
+  -> Stateful m blk s st
+  -> m (Consensus st blk m)
 continueWithState !s (Stateful f) =
     checkInvariant (show <$> unsafeNoThunks s) $ f s
 
@@ -1425,8 +1568,8 @@ continueWithState !s (Stateful f) =
   Return value
 -------------------------------------------------------------------------------}
 
--- | The Chain sync client only _gracefully_ terminates when the upstream node's
--- chain is not interesting (e.g., forked off too far in the past). By
+-- | The Chain sync client only _gracefully_ terminates when the upstream
+-- node's chain is not interesting (e.g., forked off too far in the past). By
 -- gracefully terminating, the network layer can keep the other mini-protocols
 -- connect to the same upstream node running.
 --
@@ -1437,56 +1580,60 @@ continueWithState !s (Stateful f) =
 -- protocol, and, e.g., the transaction submission protocol, should keep
 -- running.
 data ChainSyncClientResult =
-      -- | The server we're connecting to forked more than @k@ blocks ago.
-      forall blk. BlockSupportsProtocol blk =>
-        ForkTooDeep
-          (Point blk)  -- ^ Intersection
-          (Our   (Tip blk))
-          (Their (Tip blk))
-
-      -- | Our chain changed such that it no longer intersects with the
-      -- candidate's fragment, and asking for a new intersection did not yield
-      -- one.
-    | forall blk. BlockSupportsProtocol blk =>
-        NoMoreIntersection
-          (Our   (Tip blk))
-          (Their (Tip blk))
-
-      -- | We were asked to roll back past the anchor point of the candidate's
-      -- fragment. This means the candidate chain no longer forks off within
-      -- @k@, making it impossible to switch to.
-    | forall blk. BlockSupportsProtocol blk =>
-        RolledBackPastIntersection
-          (Point blk)  -- ^ Point asked to roll back to
-          (Our   (Tip blk))
-          (Their (Tip blk))
-
-      -- | We were asked to terminate via the 'ControlMessageSTM'
-    | AskedToTerminate
+    forall blk. BlockSupportsProtocol blk =>
+    ForkTooDeep
+        (Point blk)  -- ^ Intersection
+        (Our   (Tip blk))
+        (Their (Tip blk))
+    -- ^ The server we're connecting to forked more than @k@ blocks ago.
+  |
+    forall blk. BlockSupportsProtocol blk =>
+    NoMoreIntersection
+        (Our   (Tip blk))
+        (Their (Tip blk))
+    -- ^ Our chain changed such that it no longer intersects with the
+    -- candidate's fragment, and asking for a new intersection did not yield
+    -- one.
+  |
+    forall blk. BlockSupportsProtocol blk =>
+    RolledBackPastIntersection
+        (Point blk)  -- ^ Point asked to roll back to
+        (Our   (Tip blk))
+        (Their (Tip blk))
+    -- ^ We were asked to roll back past the anchor point of the candidate's
+    -- fragment. This means the candidate chain no longer forks off within @k@,
+    -- making it impossible to switch to.
+  |
+    AskedToTerminate
+    -- ^ We were asked to terminate via the 'ControlMessageSTM'
 
 deriving instance Show ChainSyncClientResult
 
 instance Eq ChainSyncClientResult where
-  ForkTooDeep (a :: Point blk) b c == ForkTooDeep (a' :: Point blk') b' c' =
-    case eqT @blk @blk' of
-      Nothing   -> False
-      Just Refl -> (a, b, c) == (a', b', c')
-  ForkTooDeep{} == _ = False
+    (==)
+        (ForkTooDeep (a  :: Point blk)  b  c )
+        (ForkTooDeep (a' :: Point blk') b' c')
+      | Just Refl <- eqT @blk @blk'
+      = (a, b, c) == (a', b', c')
 
-  NoMoreIntersection (a :: Our (Tip blk)) b == NoMoreIntersection (a' :: Our (Tip blk')) b' =
-    case eqT @blk @blk' of
-      Nothing   -> False
-      Just Refl -> (a, b) == (a', b')
-  NoMoreIntersection{} == _ = False
+    (==)
+        (NoMoreIntersection (a  :: Our (Tip blk )) b )
+        (NoMoreIntersection (a' :: Our (Tip blk')) b')
+      | Just Refl <- eqT @blk @blk'
+      = (a, b) == (a', b')
 
-  RolledBackPastIntersection (a :: Point blk) b c == RolledBackPastIntersection (a' :: Point blk') b' c' =
-    case eqT @blk @blk' of
-      Nothing   -> False
-      Just Refl -> (a, b, c) == (a', b', c')
-  RolledBackPastIntersection{} == _ = False
+    (==)
+        (RolledBackPastIntersection (a  :: Point blk ) b  c )
+        (RolledBackPastIntersection (a' :: Point blk') b' c')
+      | Just Refl <- eqT @blk @blk'
+      = (a, b, c) == (a', b', c')
 
-  AskedToTerminate == AskedToTerminate = True
-  AskedToTerminate == _ = False
+    AskedToTerminate == AskedToTerminate = True
+
+    ForkTooDeep{}                == _ = False
+    NoMoreIntersection{}         == _ = False
+    RolledBackPastIntersection{} == _ = False
+    AskedToTerminate             == _ = False
 
 {-------------------------------------------------------------------------------
   Exception
@@ -1497,61 +1644,68 @@ instance Eq ChainSyncClientResult where
 -- known invalid block, we throw an exception to disconnect. This will bring
 -- down all miniprotocols in both directions with that node.
 data ChainSyncClientException =
-      -- | Header validation threw an error.
-      forall blk. (BlockSupportsProtocol blk, ValidateEnvelope blk) =>
-        HeaderError
-          (Point blk)  -- ^ Invalid header
-          (HeaderError blk)
-          (Our   (Tip blk))
-          (Their (Tip blk))
-
-      -- | We send the upstream node a bunch of points from a chain fragment and
-      -- the upstream node responded with an intersection point that is not on
-      -- our chain fragment, and thus not among the points we sent.
-      --
-      -- We store the intersection point the upstream node sent us.
-    | forall blk. BlockSupportsProtocol blk =>
-        InvalidIntersection
-          (Point blk)  -- ^ Intersection
-          (Our   (Tip blk))
-          (Their (Tip blk))
-
-      -- | The upstream node's chain contained a block that we know is invalid.
-    | forall blk. LedgerSupportsProtocol blk =>
-        InvalidBlock
-          (Point blk)
-          -- ^ Block that triggered the validity check.
-          (HeaderHash blk)
-          -- ^ Invalid block. If pipelining was negotiated, this can be
-          -- different from the previous argument.
-          (InvalidBlockReason blk)
-
-    |   InFutureHeaderExceedsClockSkew !InFutureCheck.HeaderArrivalException
+    forall blk. (BlockSupportsProtocol blk, ValidateEnvelope blk) =>
+    HeaderError
+        (Point blk)  -- ^ Invalid header
+        (HeaderError blk)
+        (Our   (Tip blk))
+        (Their (Tip blk))
+    -- ^ Header validation threw an error.
+  |
+    forall blk. BlockSupportsProtocol blk =>
+    InvalidIntersection
+        (Point blk)  -- ^ Intersection
+        (Our   (Tip blk))
+        (Their (Tip blk))
+    -- ^ We send the upstream node a bunch of points from a chain fragment and
+    -- the upstream node responded with an intersection point that is not on
+    -- our chain fragment, and thus not among the points we sent.
+    --
+    -- We store the intersection point the upstream node sent us.
+  |
+    forall blk. LedgerSupportsProtocol blk =>
+    InvalidBlock
+        (Point blk)
+        -- ^ Block that triggered the validity check.
+        (HeaderHash blk)
+        -- ^ Invalid block. If pipelining was negotiated, this can be
+        -- different from the previous argument.
+        (InvalidBlockReason blk)
+    -- ^ The upstream node's chain contained a block that we know is invalid.
+  |
+    InFutureHeaderExceedsClockSkew !InFutureCheck.HeaderArrivalException
+    -- ^ A header arrived from the far future.
 
 deriving instance Show ChainSyncClientException
 
 instance Eq ChainSyncClientException where
-  HeaderError (a :: Point blk) b c d == HeaderError (a' :: Point blk') b' c' d' =
-    case eqT @blk @blk' of
-      Nothing   -> False
-      Just Refl -> (a, b, c, d) == (a', b', c', d')
-  HeaderError{} == _ = False
+    (==)
+        (HeaderError (a  :: Point blk ) b  c  d )
+        (HeaderError (a' :: Point blk') b' c' d')
+      | Just Refl <- eqT @blk @blk'
+      = (a, b, c, d) == (a', b', c', d')
 
-  InvalidIntersection (a :: Point blk) b c == InvalidIntersection (a' :: Point blk') b' c' =
-    case eqT @blk @blk' of
-      Nothing   -> False
-      Just Refl -> (a, b, c) == (a', b', c')
-  InvalidIntersection{} == _ = False
+    (==)
+        (InvalidIntersection (a  :: Point blk ) b  c )
+        (InvalidIntersection (a' :: Point blk') b' c')
+      | Just Refl <- eqT @blk @blk'
+      = (a, b, c) == (a', b', c')
 
-  InvalidBlock (a :: Point blk) b c == InvalidBlock (a' :: Point blk') b' c' =
-    case eqT @blk @blk' of
-      Nothing   -> False
-      Just Refl -> (a, b, c) == (a', b', c')
-  InvalidBlock{} == _ = False
+    (==)
+        (InvalidBlock (a  :: Point blk)  b  c )
+        (InvalidBlock (a' :: Point blk') b' c')
+      | Just Refl <- eqT @blk @blk'
+      = (a, b, c) == (a', b', c')
 
-  InFutureHeaderExceedsClockSkew a == InFutureHeaderExceedsClockSkew a' =
-    a == a'
-  InFutureHeaderExceedsClockSkew{} == _ = False
+    (==)
+        (InFutureHeaderExceedsClockSkew a )
+        (InFutureHeaderExceedsClockSkew a')
+      = a == a'
+
+    HeaderError{}                    == _ = False
+    InvalidIntersection{}            == _ = False
+    InvalidBlock{}                   == _ = False
+    InFutureHeaderExceedsClockSkew{} == _ = False
 
 instance Exception ChainSyncClientException
 
@@ -1560,25 +1714,32 @@ instance Exception ChainSyncClientException
 -------------------------------------------------------------------------------}
 
 -- | Events traced by the Chain Sync Client.
-data TraceChainSyncClientEvent blk
-  = TraceDownloadedHeader (Header blk)
+data TraceChainSyncClientEvent blk =
+    TraceDownloadedHeader (Header blk)
     -- ^ While following a candidate chain, we rolled forward by downloading a
     -- header.
-  | TraceRolledBack (Point blk)
+  |
+    TraceRolledBack (Point blk)
     -- ^ While following a candidate chain, we rolled back to the given point.
-  | TraceFoundIntersection (Point blk) (Our (Tip blk)) (Their (Tip blk))
+  |
+    TraceFoundIntersection (Point blk) (Our (Tip blk)) (Their (Tip blk))
     -- ^ We found an intersection between our chain fragment and the
     -- candidate's chain.
-  | TraceException ChainSyncClientException
+  |
+    TraceException ChainSyncClientException
     -- ^ An exception was thrown by the Chain Sync Client.
-  | TraceTermination ChainSyncClientResult
+  |
+    TraceTermination ChainSyncClientResult
     -- ^ The client has terminated.
 
-deriving instance ( BlockSupportsProtocol blk
-                  , Eq (Header blk)
-                  )
-               => Eq   (TraceChainSyncClientEvent blk)
-deriving instance ( BlockSupportsProtocol blk
-                  , Show (Header blk)
-                  )
-               => Show (TraceChainSyncClientEvent blk)
+deriving instance
+  ( BlockSupportsProtocol blk
+  , Eq (Header blk)
+  )
+  => Eq (TraceChainSyncClientEvent blk)
+
+deriving instance
+  ( BlockSupportsProtocol blk
+  , Show (Header blk)
+  )
+  => Show (TraceChainSyncClientEvent blk)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -432,7 +432,7 @@ chainSyncClient
     => MkPipelineDecision
     -> Tracer m (TraceChainSyncClientEvent blk)
     -> TopLevelConfig blk
-    -> InFutureCheck.HeaderInFutureCheck m blk
+    -> InFutureCheck.SomeHeaderInFutureCheck m blk
     -> ChainDbView m blk
     -> NodeToNodeVersion
     -> ControlMessageSTM m
@@ -440,13 +440,15 @@ chainSyncClient
     -> StrictTVar m (AnchoredFragment (Header blk))
     -> Consensus ChainSyncClientPipelined blk m
 chainSyncClient mkPipelineDecision0 tracer cfg
-                InFutureCheck.HeaderInFutureCheck
-                { -- these fields in order of use
-                  proxyArrival        = Proxy :: Proxy arrival
-                , recordHeaderArrival
-                , judgeHeaderArrival
-                , handleHeaderArrival
-                }
+                (InFutureCheck.SomeHeaderInFutureCheck
+                   InFutureCheck.HeaderInFutureCheck
+                   { -- these fields in order of use
+                     proxyArrival        = Proxy :: Proxy arrival
+                   , recordHeaderArrival
+                   , judgeHeaderArrival
+                   , handleHeaderArrival
+                   }
+                )
                 ChainDbView
                 { getCurrentChain
                 , getHeaderStateHistory

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE LambdaCase                 #-}
 {-# LANGUAGE MultiWayIf                 #-}
 {-# LANGUAGE NamedFieldPuns             #-}
+{-# LANGUAGE Rank2Types                 #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE StandaloneDeriving         #-}
 {-# LANGUAGE TupleSections              #-}
@@ -42,6 +43,7 @@ module Ouroboros.Consensus.MiniProtocol.ChainSync.Client (
   , ChainDbView (..)
   , ConfigEnv (..)
   , DynamicEnv (..)
+  , InternalEnv (..)
   , defaultChainDbView
     -- * Results
   , ChainSyncClientException (..)
@@ -88,6 +90,7 @@ import           Ouroboros.Consensus.Storage.ChainDB (ChainDB,
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
 import           Ouroboros.Consensus.Util
 import           Ouroboros.Consensus.Util.Assert (assertWithMsg)
+import           Ouroboros.Consensus.Util.EarlyExit (WithEarlyExit, exitEarly)
 import qualified Ouroboros.Consensus.Util.EarlyExit as EarlyExit
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.STM (Fingerprint, Watcher (..),
@@ -153,7 +156,8 @@ bracketChainSyncClient
          -> m a
        )
     -> m a
-bracketChainSyncClient tracer ChainDbView { getIsInvalidBlock } varCandidates
+bracketChainSyncClient tracer ChainDbView { getIsInvalidBlock }
+                       varCandidates
                        peer version body =
     bracket newCandidateVar releaseCandidateVar
       $ \varCandidate ->
@@ -285,8 +289,8 @@ bracketChainSyncClient tracer ChainDbView { getIsInvalidBlock } varCandidates
 
 -- | State used when the intersection between the candidate and the current
 -- chain is unknown.
-data UnknownIntersectionState blk = UnknownIntersectionState
-  { ourFrag               :: !(AnchoredFragment (Header blk))
+data UnknownIntersectionState blk = UnknownIntersectionState {
+    ourFrag               :: !(AnchoredFragment (Header blk))
     -- ^ A view of the current chain fragment. Note that this might be
     -- temporarily out of date w.r.t. the actual current chain until we update
     -- it again.
@@ -307,8 +311,8 @@ instance ( LedgerSupportsProtocol blk
 
 -- | State used when the intersection between the candidate and the current
 -- chain is known.
-data KnownIntersectionState blk = KnownIntersectionState
-  { theirFrag               :: !(AnchoredFragment (Header blk))
+data KnownIntersectionState blk = KnownIntersectionState {
+    theirFrag               :: !(AnchoredFragment (Header blk))
     -- ^ The candidate, the synched fragment of their chain.
     --
     -- See the \"Candidate fragment size\" note above.
@@ -438,6 +442,10 @@ assertKnownIntersectionInvariants
 assertKnownIntersectionInvariants cfg kis =
     assertWithMsg (checkKnownIntersectionInvariants cfg kis) kis
 
+{-------------------------------------------------------------------------------
+  The ChainSync client definition
+-------------------------------------------------------------------------------}
+
 -- | Arguments determined by configuration
 --
 -- These are available before the diffusion layer is online.
@@ -461,6 +469,58 @@ data DynamicEnv m blk = DynamicEnv {
     , varCandidate            :: StrictTVar m (AnchoredFragment (Header blk))
     }
 
+-- | General values collectively needed by the top-level entry points
+data InternalEnv m blk arrival judgment = InternalEnv {
+      -- | "Drain the pipe": collect and discard all in-flight responses and
+      -- finally execute the given action.
+      drainThePipe
+        :: forall s n. NoThunks s
+        => Nat n
+        -> Stateful m blk s (ClientPipelinedStIdle 'Z)
+        -> Stateful m blk s (ClientPipelinedStIdle n)
+    ,
+      -- | Disconnect from the upstream node by throwing the given exception.
+      -- The cleanup is handled in 'bracketChainSyncClient'.
+      disconnect
+        :: forall m' a. MonadThrow m'
+        => ChainSyncClientException
+        -> m' a
+    ,
+      headerInFutureCheck
+        :: InFutureCheck.HeaderInFutureCheck m blk arrival judgment
+    ,
+      -- | A combinator necessary whenever relying on a
+      -- 'KnownIntersectionState', since it's always possible that that
+      -- intersection will go stale.
+      --
+      -- Look at the current chain fragment that may have been updated in the
+      -- background. Check whether the candidate fragment still intersects with
+      -- it. If so, update the 'KnownIntersectionState' and trim the candidate
+      -- fragment to the new current chain fragment's anchor point. If not,
+      -- return 'Nothing'.
+      --
+      -- INVARIANT: This a read-only STM transaction.
+      intersectsWithCurrentChain
+        :: KnownIntersectionState blk
+        -> STM m (UpdatedIntersectionState blk ())
+    ,
+      -- | Gracefully terminate the connection with the upstream node with the
+      -- given result.
+      terminate
+        :: ChainSyncClientResult
+        -> m (Consensus (ClientPipelinedStIdle 'Z) blk m)
+    ,
+      -- | Same as 'terminate', but first 'drainThePipe'.
+      terminateAfterDrain
+        :: forall n.
+           Nat n
+        -> ChainSyncClientResult
+        -> m (Consensus (ClientPipelinedStIdle n) blk m)
+    ,
+      -- | Trace any 'ChainSyncClientException' if thrown.
+      traceException :: forall a. m a -> m a
+    }
+
 -- | Chain sync client
 --
 -- This never terminates. In case of a failure, a 'ChainSyncClientException'
@@ -474,48 +534,153 @@ chainSyncClient
     => ConfigEnv m blk
     -> DynamicEnv m blk
     -> Consensus ChainSyncClientPipelined blk m
-chainSyncClient
-    cfgEnv@(ConfigEnv {
-        someHeaderInFutureCheck =
-          InFutureCheck.SomeHeaderInFutureCheck 
-            headerInFutureCheck@(InFutureCheck.HeaderInFutureCheck {
-                InFutureCheck.proxyArrival = Proxy :: Proxy arrival
-              })
-      })
-    dynEnv
-  = ChainSyncClientPipelined $ continueWithState () $ initialise
+chainSyncClient cfgEnv dynEnv = case someHeaderInFutureCheck cfgEnv of
+    InFutureCheck.SomeHeaderInFutureCheck headerInFutureCheck ->
+        ChainSyncClientPipelined
+      $ continueWithState ()
+      $ -- Start ChainSync by looking for an intersection between our current
+        -- chain fragment and their chain.
+        findIntersectionTop
+          cfgEnv
+          dynEnv
+          (mkIntEnv headerInFutureCheck)
+          (ForkTooDeep GenesisPoint)
   where
     ConfigEnv {
-        mkPipelineDecision0
+        cfg
+      , chainDbView
       , tracer
+      } = cfgEnv
+
+    ChainDbView {
+        getCurrentChain
+      } = chainDbView
+
+    mkIntEnv
+      :: InFutureCheck.HeaderInFutureCheck m blk arrival judgment
+      -> InternalEnv                       m blk arrival judgment
+    mkIntEnv hifc = InternalEnv {
+        drainThePipe
+      , disconnect                 = throwIO
+      , headerInFutureCheck        = hifc
+      , intersectsWithCurrentChain
+      , terminate
+      , terminateAfterDrain        = \n result ->
+            continueWithState ()
+          $ drainThePipe n
+          $ Stateful $ const $ terminate result
+      , traceException             = \m -> do
+          m `catch` \(e :: ChainSyncClientException) -> do
+            traceWith tracer $ TraceException e
+            throwIO e
+      }
+
+    drainThePipe
+      :: forall s n. NoThunks s
+      => Nat n
+      -> Stateful m blk s (ClientPipelinedStIdle 'Z)
+      -> Stateful m blk s (ClientPipelinedStIdle n)
+    drainThePipe        =     \n0 m ->
+      let
+        go :: forall n'. Nat n'
+           -> s
+           -> m (Consensus (ClientPipelinedStIdle n') blk m)
+        go n s = case n of
+          Zero    -> continueWithState s m
+          Succ n' -> return $ CollectResponse Nothing $ ClientStNext
+            { recvMsgRollForward  = \_hdr _tip -> go n' s
+            , recvMsgRollBackward = \_pt  _tip -> go n' s
+            }
+      in Stateful $ go n0
+
+    terminate
+      :: ChainSyncClientResult
+      -> m (Consensus (ClientPipelinedStIdle 'Z) blk m)
+    terminate res = do
+      traceWith tracer (TraceTermination res)
+      pure (SendMsgDone res)
+
+    intersectsWithCurrentChain
+      :: KnownIntersectionState blk
+      -> STM m (UpdatedIntersectionState blk ())
+    intersectsWithCurrentChain kis@KnownIntersectionState
+                               { theirFrag
+                               , theirHeaderStateHistory
+                               , ourFrag
+                               } = do
+      ourFrag' <- getCurrentChain
+      if
+        | AF.headPoint ourFrag == AF.headPoint ourFrag' ->
+          -- Our current chain didn't change, and changes to their chain that
+          -- might affect the intersection point are handled elsewhere
+          -- ('rollBackward'), so we have nothing to do.
+          return $ StillIntersects () kis
+
+        | Just (intersection, trimmedCandidateFrag) <- cross ourFrag' theirFrag
+          -- Even though our current chain changed it still intersects with
+          -- candidate fragment, so update the 'ourFrag' field and trim the
+          -- candidate fragment to the same anchor point.
+          --
+          -- Note that this is the only place we need to trim. Headers on
+          -- their chain can only become unnecessary (eligible for trimming)
+          -- in two ways: 1. we adopted them, i.e., our chain changed (handled
+          -- in this function); 2. we will /never/ adopt them, which is
+          -- handled in the "no more intersection case".
+        , let -- We trim the 'HeaderStateHistory' to the same size as our
+              -- fragment so they keep in sync.
+              trimmedHeaderStateHistory' =
+                 HeaderStateHistory.trim
+                   (AF.length trimmedCandidateFrag)
+                   theirHeaderStateHistory ->
+          return $ StillIntersects () $
+            assertKnownIntersectionInvariants (configConsensus cfg) $
+              KnownIntersectionState {
+                  ourFrag                 = ourFrag'
+                , theirFrag               = trimmedCandidateFrag
+                , theirHeaderStateHistory = trimmedHeaderStateHistory'
+                , mostRecentIntersection  = castPoint intersection
+                }
+
+        | otherwise -> return NoLongerIntersects
+
+{-------------------------------------------------------------------------------
+  (Re-)Establishing a common intersection
+-------------------------------------------------------------------------------}
+
+findIntersectionTop
+    :: forall m blk arrival judgment.
+       ( IOLike m
+       , LedgerSupportsProtocol blk
+       )
+    => ConfigEnv m blk
+    -> DynamicEnv m blk
+    -> InternalEnv m blk arrival judgment
+    -> (Our (Tip blk) -> Their (Tip blk) -> ChainSyncClientResult)
+       -- ^ Exception to throw when no intersection is found.
+    -> Stateful m blk () (ClientPipelinedStIdle 'Z)
+findIntersectionTop cfgEnv dynEnv intEnv =
+    \mkResult -> findIntersection mkResult
+  where
+    ConfigEnv {
+        tracer
       , cfg
       , chainDbView
       } = cfgEnv
 
-    InFutureCheck.HeaderInFutureCheck {
-        handleHeaderArrival
-      , judgeHeaderArrival
-      , recordHeaderArrival
-      } = headerInFutureCheck 
-
     ChainDbView {
         getCurrentChain
       , getHeaderStateHistory
-      , getPastLedger
-      , getIsInvalidBlock
       } = chainDbView
 
     DynamicEnv {
-        version
-      , controlMessageSTM
-      , headerMetricsTracer
-      , varCandidate
+        varCandidate
       } = dynEnv
 
-    -- | Start ChainSync by looking for an intersection between our current
-    -- chain fragment and their chain.
-    initialise :: Stateful m blk () (ClientPipelinedStIdle 'Z)
-    initialise = findIntersection (ForkTooDeep GenesisPoint)
+    InternalEnv {
+        disconnect
+      , terminate
+      , traceException
+      } = intEnv
 
     -- | Try to find an intersection by sending points of our current chain to
     -- the server, if any of them intersect with their chain, roll back our
@@ -535,10 +700,10 @@ chainSyncClient
       -- was an intersection within the last @k@ blocks of our current chain.
       -- If not, we could never switch to this candidate chain anyway.
       let maxOffset = fromIntegral (AF.length ourFrag)
+          k         = protocolSecurityParam (configConsensus cfg)
+          offsets   = mkOffsets k maxOffset
           points    = map castPoint
-                    $ AF.selectPoints
-                        (map fromIntegral (offsets maxOffset))
-                        ourFrag
+                    $ AF.selectPoints (map fromIntegral offsets) ourFrag
           uis = UnknownIntersectionState {
               ourFrag               = ourFrag
             , ourHeaderStateHistory = ourHeaderStateHistory
@@ -597,7 +762,8 @@ chainSyncClient
                 intersection
                 (ourTipFromChain ourFrag)
                 theirTip
-        atomically $ writeTVar varCandidate theirFrag
+        atomically $ do
+          writeTVar varCandidate theirFrag
         let kis = assertKnownIntersectionInvariants (configConsensus cfg) $
               KnownIntersectionState
                 { theirFrag               = theirFrag
@@ -605,57 +771,54 @@ chainSyncClient
                 , ourFrag                 = ourFrag
                 , mostRecentIntersection  = intersection
                 }
-        continueWithState kis $ nextStep mkPipelineDecision0 Zero theirTip
+        continueWithState kis $
+          knownIntersectionStateTop cfgEnv dynEnv intEnv theirTip
 
-    -- | Look at the current chain fragment that may have been updated in the
-    -- background. Check whether the candidate fragment still intersects with
-    -- it. If so, update the 'KnownIntersectionState' and trim the candidate
-    -- fragment to the new current chain fragment's anchor point. If not,
-    -- return 'Nothing'.
-    intersectsWithCurrentChain
-      :: KnownIntersectionState blk
-      -> STM m (Maybe (KnownIntersectionState blk))
-    intersectsWithCurrentChain kis@KnownIntersectionState
-                               { theirFrag
-                               , theirHeaderStateHistory
-                               , ourFrag
-                               } = do
-      ourFrag' <- getCurrentChain
-      if
-        | AF.headPoint ourFrag == AF.headPoint ourFrag' ->
-          -- Our current chain didn't change, and changes to their chain that
-          -- might affect the intersection point are handled elsewhere
-          -- ('rollBackward'), so we have nothing to do.
-          return $ Just kis
+{-------------------------------------------------------------------------------
+  Processing 'MsgRollForward' and 'MsgRollBackward'
+-------------------------------------------------------------------------------}
 
-        | Just (intersection, trimmedCandidateFrag) <- cross ourFrag' theirFrag
-          -- Our current chain changed, but it still intersects with candidate
-          -- fragment, so update the 'ourFrag' field and trim the
-          -- candidate fragment to the same anchor point.
-          --
-          -- Note that this is the only place we need to trim. Headers on
-          -- their chain can only become unnecessary (eligible for trimming)
-          -- in two ways: 1. we adopted them, i.e., our chain changed (handled
-          -- in this function); 2. we will /never/ adopt them, which is
-          -- handled in the "no more intersection case".
-        , let -- We trim the 'HeaderStateHistory' to the same size as our
-              -- fragment so they keep in sync.
-              trimmedHeaderStateHistory' =
-                 HeaderStateHistory.trim
-                   (AF.length trimmedCandidateFrag)
-                   theirHeaderStateHistory ->
-          return $ Just $
-            assertKnownIntersectionInvariants (configConsensus cfg) $
-              KnownIntersectionState {
-                  ourFrag                 = ourFrag'
-                , theirFrag               = trimmedCandidateFrag
-                , theirHeaderStateHistory = trimmedHeaderStateHistory'
-                , mostRecentIntersection  = castPoint intersection
-                }
+knownIntersectionStateTop
+    :: forall m blk arrival judgment.
+       ( IOLike m
+       , LedgerSupportsProtocol blk
+       )
+    => ConfigEnv m blk
+    -> DynamicEnv m blk
+    -> InternalEnv m blk arrival judgment
+    -> Their (Tip blk)
+    -> Stateful m blk
+         (KnownIntersectionState blk)
+         (ClientPipelinedStIdle 'Z)
+knownIntersectionStateTop cfgEnv dynEnv intEnv =
+    \theirTip -> nextStep mkPipelineDecision0 Zero theirTip
+      -- The 'MkPiplineDecision' and @'Nat' n@ arguments below could safely be
+      -- merged into the 'KnownIntersectionState' record type, but it's
+      -- unfortunately quite awkward to do so.
+  where
+    ConfigEnv {
+        mkPipelineDecision0
+      , tracer
+      , cfg
+      } = cfgEnv
 
-        | otherwise ->
-          -- No more intersection with the current chain
-          return Nothing
+    DynamicEnv {
+        controlMessageSTM
+      , headerMetricsTracer
+      , varCandidate
+      } = dynEnv
+
+    InternalEnv {
+        drainThePipe
+      , headerInFutureCheck
+      , intersectsWithCurrentChain
+      , terminateAfterDrain
+      , traceException
+      } = intEnv
+
+    InFutureCheck.HeaderInFutureCheck {
+        recordHeaderArrival
+      } = headerInFutureCheck
 
     -- | Request the next message (roll forward or backward), unless our chain
     -- has changed such that it no longer intersects with the candidate, in
@@ -681,7 +844,7 @@ chainSyncClient
         _continue -> do
           mKis' <- atomically $ intersectsWithCurrentChain kis
           case mKis' of
-            Just kis'@KnownIntersectionState { theirFrag } -> do
+            StillIntersects () kis'@KnownIntersectionState { theirFrag } -> do
               -- Our chain (tip) didn't change or if it did, it still intersects
               -- with the candidate fragment, so we can continue requesting the
               -- next block.
@@ -689,31 +852,13 @@ chainSyncClient
               let candTipBlockNo = AF.headBlockNo theirFrag
               return $
                 requestNext kis' mkPipelineDecision n theirTip candTipBlockNo
-            Nothing ->
+            NoLongerIntersects -> do
               -- Our chain (tip) has changed and it no longer intersects with
               -- the candidate fragment, so we have to find a new intersection,
               -- but first drain the pipe.
               continueWithState ()
                 $ drainThePipe n
-                $ findIntersection NoMoreIntersection
-
-    -- | "Drain the pipe": collect and discard all in-flight responses and
-    -- finally execute the given action.
-    drainThePipe :: forall s n. NoThunks s
-                 => Nat n
-                 -> Stateful m blk s (ClientPipelinedStIdle 'Z)
-                 -> Stateful m blk s (ClientPipelinedStIdle n)
-    drainThePipe n0 m = Stateful $ go n0
-      where
-        go :: forall n'. Nat n'
-           -> s
-           -> m (Consensus (ClientPipelinedStIdle n') blk m)
-        go n s = case n of
-          Zero    -> continueWithState s m
-          Succ n' -> return $ CollectResponse Nothing $ ClientStNext
-            { recvMsgRollForward  = \_hdr _tip -> go n' s
-            , recvMsgRollBackward = \_pt  _tip -> go n' s
-            }
+                $ findIntersectionTop cfgEnv dynEnv intEnv NoMoreIntersection
 
     requestNext :: KnownIntersectionState blk
                 -> MkPipelineDecision
@@ -773,156 +918,26 @@ chainSyncClient
                      (ClientPipelinedStIdle n)
     rollForward mkPipelineDecision n hdr theirTip
               = Stateful $ \kis -> traceException $ do
-        arrival <- recordHeaderArrival hdr
-        now     <- getMonotonicTime
-        let hdrPoint = headerPoint hdr
-            slotNo   = blockSlot   hdr
+        arrival     <- recordHeaderArrival hdr
+        arrivalTime <- getMonotonicTime
 
-        do
-          let scrutinee =
-                case isPipeliningEnabled version of
-                  NotReceivingTentativeBlocks -> BlockHash (headerHash hdr)
-                  -- Disconnect if the parent block of `hdr` is known to be invalid.
-                  ReceivingTentativeBlocks    -> headerPrevHash hdr
-          case scrutinee of
-            GenesisHash    -> return ()
-            BlockHash hash -> do
-              -- If the peer is sending headers quickly, the
-              -- @invalidBlockWatcher@ might miss one. So this call is a
-              -- lightweight supplement. Note that neither check /must/ be 100%
-              -- reliable.
-              isInvalidBlock <- atomically $ forgetFingerprint <$> getIsInvalidBlock
-              whenJust (isInvalidBlock hash) $ \reason ->
-                disconnect $ InvalidBlock hdrPoint hash reason
+        let slotNo = blockSlot hdr
 
-        mLedgerView <- EarlyExit.withEarlyExit $ do
-          Intersects kis2 lst        <- checkArrivalTime kis arrival
-          Intersects kis3 ledgerView <- case projectLedgerView slotNo lst of
-              Just ledgerView -> pure $ Intersects kis2 ledgerView
-              Nothing         -> readLedgerState kis2 (projectLedgerView slotNo)
-          pure $ Intersects kis3 ledgerView
+        checkKnownInvalid cfgEnv dynEnv intEnv hdr
 
-        case mLedgerView of
-
-          Nothing -> do
-            -- The above computation exited early, which means our chain (tip)
-            -- has changed and it no longer intersects with the candidate
-            -- fragment, so we have to find a new intersection. But first drain
-            -- the pipe.
+        checkTime cfgEnv intEnv kis arrival slotNo >>= \case
+          NoLongerIntersects -> do
             continueWithState ()
               $ drainThePipe n
-              $ findIntersection NoMoreIntersection
+              $ findIntersectionTop cfgEnv dynEnv intEnv NoMoreIntersection
 
-          Just (Intersects kis' ledgerView) -> do
-            -- Our chain still intersects with the candidate fragment and we
-            -- have obtained a 'LedgerView' that we can use to validate @hdr@.
-            let KnownIntersectionState {
-                    ourFrag
-                  , theirFrag
-                  , theirHeaderStateHistory
-                  , mostRecentIntersection
-                  } = kis'
+          StillIntersects ledgerView kis' -> do
+            kis'' <- checkValid cfgEnv intEnv hdr theirTip kis' ledgerView
 
-            -- Validate header
-            theirHeaderStateHistory' <-
-              case runExcept $ validateHeader cfg ledgerView hdr theirHeaderStateHistory of
-                Right theirHeaderStateHistory' -> return theirHeaderStateHistory'
-                Left  vErr ->
-                  disconnect $
-                    HeaderError hdrPoint vErr (ourTipFromChain ourFrag) theirTip
-
-            let theirFrag' = theirFrag :> hdr
-                -- Advance the most recent intersection if we have the same
-                -- header on our fragment too. This is cheaper than recomputing
-                -- the intersection from scratch.
-                mostRecentIntersection'
-                  | Just ourSuccessor <-
-                      AF.successorBlock (castPoint mostRecentIntersection) ourFrag
-                  , headerHash ourSuccessor == headerHash hdr
-                  = headerPoint hdr
-                  | otherwise
-                  = mostRecentIntersection
-                kis'' = assertKnownIntersectionInvariants (configConsensus cfg) $
-                  KnownIntersectionState {
-                      theirFrag               = theirFrag'
-                    , theirHeaderStateHistory = theirHeaderStateHistory'
-                    , ourFrag                 = ourFrag
-                    , mostRecentIntersection  = mostRecentIntersection'
-                    }
-            atomically $ writeTVar varCandidate theirFrag'
-            atomically $ traceWith headerMetricsTracer (slotNo, now)
+            atomically $ writeTVar varCandidate (theirFrag kis'')
+            atomically $ traceWith headerMetricsTracer (slotNo, arrivalTime)
 
             continueWithState kis'' $ nextStep mkPipelineDecision n theirTip
-
-    -- Used in 'rollForward': determines whether the header is from the future,
-    -- and handle that fact if so. Also return the ledger state used for the
-    -- determination.
-    --
-    -- Relies on 'readLedgerState'.
-    checkArrivalTime :: KnownIntersectionState blk
-                     -> arrival
-                     -> EarlyExit.WithEarlyExit m (Intersects blk (LedgerState blk))
-    checkArrivalTime kis arrival = do
-        Intersects kis' (lst, judgment) <- readLedgerState kis $ \lst ->
-          case runExcept $ judgeHeaderArrival (configLedger cfg) lst arrival of
-            Left PastHorizon{} -> Nothing
-            Right judgment     -> Just (lst, judgment)
-
-        -- For example, throw an exception if the header is from the far
-        -- future.
-        EarlyExit.lift $ handleHeaderArrival judgment >>= \case
-          Just exn -> disconnect (InFutureHeaderExceedsClockSkew exn)
-          Nothing  -> return $ Intersects kis' lst
-
-    -- Used in 'rollForward': block until the the ledger state at the
-    -- intersection with the local selection returns 'Just'.
-    --
-    -- Exits early if the intersection no longer exists.
-    readLedgerState :: KnownIntersectionState blk
-                    -> (LedgerState blk -> Maybe a)
-                    -> EarlyExit.WithEarlyExit m (Intersects blk a)
-    readLedgerState kis prj =
-        join $ EarlyExit.lift $ readLedgerStateHelper kis prj
-
-    readLedgerStateHelper :: KnownIntersectionState blk
-                          -> (LedgerState blk -> Maybe a)
-                          -> m (EarlyExit.WithEarlyExit m (Intersects blk a))
-    readLedgerStateHelper kis prj = atomically $ do
-        -- We must first find the most recent intersection with the current
-        -- chain. Note that this is cheap when the chain and candidate haven't
-        -- changed.
-        intersectsWithCurrentChain kis >>= \case
-          Nothing   -> return EarlyExit.exitEarly
-          Just kis' -> do
-            let KnownIntersectionState { mostRecentIntersection } = kis'
-            lst <-
-              maybe
-                (error $
-                   "intersection not within last k blocks: " <> show mostRecentIntersection)
-                ledgerState
-                <$> getPastLedger mostRecentIntersection
-            case prj lst of
-              Nothing         -> retry
-              Just ledgerView -> return $ return $ Intersects kis' ledgerView
-
-    -- Used in 'rollForward': returns 'Nothing' if the ledger state cannot
-    -- forecast the ledger view that far into the future.
-    projectLedgerView :: SlotNo
-                      -> LedgerState blk
-                      -> Maybe (LedgerView (BlockProtocol blk))
-    projectLedgerView slot lst =
-        let forecast = ledgerViewForecastAt (configLedger cfg) lst
-              -- TODO cache this in the KnownIntersectionState? Or even in the
-              -- LedgerDB?
-        in
-        case runExcept $ forecastFor forecast slot of
-          -- The header is too far ahead of the intersection point with our
-          -- current chain. We have to wait until our chain and the
-          -- intersection have advanced far enough. This will wait on
-          -- changes to the current chain via the call to
-          -- 'intersectsWithCurrentChain' before it.
-          Left OutsideForecastRange{} -> Nothing
-          Right ledgerView            -> Just ledgerView
 
     rollBackward :: MkPipelineDecision
                  -> Nat n
@@ -989,83 +1004,324 @@ chainSyncClient
                     , mostRecentIntersection  = mostRecentIntersection'
                     }
             atomically $ writeTVar varCandidate theirFrag'
-
             continueWithState kis' $ nextStep mkPipelineDecision n theirTip
 
-    -- | Gracefully terminate the connection with the upstream node with the
-    -- given result.
-    terminate :: ChainSyncClientResult -> m (Consensus (ClientPipelinedStIdle 'Z) blk m)
-    terminate res = do
-      traceWith tracer (TraceTermination res)
-      pure (SendMsgDone res)
+{-------------------------------------------------------------------------------
+  Header checks
+-------------------------------------------------------------------------------}
 
-    -- | Same as 'terminate', but first 'drainThePipe'.
-    terminateAfterDrain :: Nat n -> ChainSyncClientResult -> m (Consensus (ClientPipelinedStIdle n) blk m)
-    terminateAfterDrain n result =
-          continueWithState ()
-        $ drainThePipe n
-        $ Stateful $ const $ terminate result
+-- | Check whether 'getIsInvalidBlock' indicates that the peer's most recent
+-- header indicates they are either adversarial or buggy
+--
+-- If the peer is sending headers quickly, the 'invalidBlockRejector' might
+-- miss one. So this call is a lightweight supplement. Note that neither check
+-- /must/ be 100% reliable.
+checkKnownInvalid
+    :: forall m blk arrival judgment.
+       ( IOLike m
+       , LedgerSupportsProtocol blk
+       )
+    => ConfigEnv m blk
+    -> DynamicEnv m blk
+    -> InternalEnv m blk arrival judgment
+    -> Header blk
+    -> m ()
+checkKnownInvalid cfgEnv dynEnv intEnv hdr = case scrutinee of
+    GenesisHash    -> return ()
+    BlockHash hash -> do
+      isInvalidBlock <- atomically $ forgetFingerprint <$> getIsInvalidBlock
+      whenJust (isInvalidBlock hash) $ \reason ->
+        disconnect $ InvalidBlock (headerPoint hdr) hash reason
+  where
+    ConfigEnv {
+        chainDbView
+      } = cfgEnv
 
-    -- | Disconnect from the upstream node by throwing the given exception.
-    -- The cleanup is handled in 'bracketChainSyncClient'.
-    disconnect :: forall m' x'. MonadThrow m'
-               => ChainSyncClientException -> m' x'
-    disconnect = throwIO
+    ChainDbView {
+        getIsInvalidBlock
+      } = chainDbView
 
-    -- | Trace any 'ChainSyncClientException' if thrown.
-    traceException :: m a -> m a
-    traceException m = m `catch` \(e :: ChainSyncClientException) -> do
-      traceWith tracer $ TraceException e
-      throwIO e
+    DynamicEnv {
+        version
+      } = dynEnv
 
-    ourTipFromChain :: AnchoredFragment (Header blk) -> Our (Tip blk)
-    ourTipFromChain = Our . AF.anchorToTip . AF.headAnchor
+    InternalEnv {
+        disconnect
+      } = intEnv
 
-    -- Recent offsets
+    -- when pipelining, the tip of the candidate is forgiven when it's invalid
+    -- block, but not if it extends any invalid blocks
+    scrutinee = case isPipeliningEnabled version of
+      NotReceivingTentativeBlocks -> BlockHash (headerHash hdr)
+      -- Disconnect if the parent block of `hdr` is known to be invalid.
+      ReceivingTentativeBlocks    -> headerPrevHash hdr
+
+-- | Manage the relationships between the header's slot, arrival time, and
+-- intersection with the local selection
+--
+-- The first step is to determine the timestamp of the slot's onset. If the
+-- intersection with local selection is much older than the header, then this
+-- may not be possible. The client will block until that is no longer true.
+-- However, it will stop blocking and 'exitEarly' as soon as
+-- 'NoLongerIntersects' arises.
+--
+-- If the slot is from the far-future, the peer is buggy, so disconnect. If
+-- it's from the near-future, follow the Ouroboros Chronos rule and ignore this
+-- peer until this header is no longer from the future.
+--
+-- Finally, the client will block on the intersection a second time, if
+-- necessary, since it's possible for a ledger state to determine the slot's
+-- onset's timestamp without also determining the slot's 'LedgerView'.
+checkTime
+    :: forall m blk arrival judgment.
+       ( IOLike m
+       , LedgerSupportsProtocol blk
+       )
+    => ConfigEnv m blk
+    -> InternalEnv m blk arrival judgment
+    -> KnownIntersectionState blk
+    -> arrival
+    -> SlotNo
+    -> m (UpdatedIntersectionState blk (LedgerView (BlockProtocol blk)))
+checkTime cfgEnv intEnv = \kis arrival slotNo -> castEarlyExitIntersects $ do
+    Intersects kis2 lst        <- checkArrivalTime kis arrival
+    Intersects kis3 ledgerView <- case projectLedgerView slotNo lst of
+      Just ledgerView -> pure $ Intersects kis2 ledgerView
+      Nothing         -> readLedgerState kis2 (projectLedgerView slotNo)
+    pure $ Intersects kis3 ledgerView
+  where
+    ConfigEnv {
+        cfg
+      , chainDbView
+      } = cfgEnv
+
+    ChainDbView {
+        getPastLedger
+      } = chainDbView
+
+    InternalEnv {
+        disconnect
+      , headerInFutureCheck
+      , intersectsWithCurrentChain
+      } = intEnv
+
+    InFutureCheck.HeaderInFutureCheck {
+        handleHeaderArrival
+      , judgeHeaderArrival
+      } = headerInFutureCheck
+
+    -- Determine whether the header is from the future, and handle that fact if
+    -- so. Also return the ledger state used for the determination.
     --
-    -- These offsets are used to find an intersection point between our chain
-    -- and the upstream node's. We use the fibonacci sequence to try blocks
-    -- closer to our tip, and fewer blocks further down the chain. It is
-    -- important that this sequence constains at least a point @k@ back: if no
-    -- intersection can be found at most @k@ back, then this is not a peer
-    -- that we can sync with (since we will never roll back more than @k).
-    --
-    -- For @k = 2160@, this evaluates to
-    --
-    -- > [0,1,2,3,5,8,13,21,34,55,89,144,233,377,610,987,1597,2160]
-    --
-    -- For @k = 5@ (during testing), this evaluates to
-    --
-    -- > [0,1,2,3,5]
-    --
-    -- In case the fragment contains less than @k@ blocks, we use the length
-    -- of the fragment as @k@. This ensures that the oldest rollback point is
-    -- selected.
-    offsets :: Word64 -> [Word64]
-    offsets maxOffset = [0] ++ takeWhile (< l) [fib n | n <- [2..]] ++ [l]
-      where
-        l = k `min` maxOffset
+    -- Relies on 'readLedgerState'.
+    checkArrivalTime :: KnownIntersectionState blk
+                     -> arrival
+                     -> WithEarlyExit m (Intersects blk (LedgerState blk))
+    checkArrivalTime kis arrival = do
+        Intersects kis' (lst, judgment) <- readLedgerState kis $ \lst ->
+          case runExcept $ judgeHeaderArrival (configLedger cfg) lst arrival of
+            Left PastHorizon{} -> Nothing
+            Right judgment     -> Just (lst, judgment)
 
-    -- If the two fragments `c1` and `c2` intersect, return the intersection
-    -- point and join the prefix of `c1` before the intersection with the suffix
-    -- of `c2` after the intersection. The resulting fragment has the same
-    -- anchor as `c1` and the same head as `c2`.
-    cross ::
-         HasHeader block
-      => AnchoredFragment block
-      -> AnchoredFragment block
-      -> Maybe (Point block, AnchoredFragment block)
-    cross c1 c2 = do
-        (p1, _p2, _s1, s2) <- AF.intersect c1 c2
-        -- Note that the head of `p1` and `_p2` is the intersection point, and
-        -- `_s1` and `s2` are anchored in the intersection point.
-        let crossed = case AF.join p1 s2 of
-              Just c  -> c
-              Nothing -> error "invariant violation of AF.intersect"
-        pure (AF.anchorPoint s2, crossed)
+        -- For example, throw an exception if the header is from the far
+        -- future.
+        EarlyExit.lift $ handleHeaderArrival judgment >>= \case
+          Just exn -> disconnect (InFutureHeaderExceedsClockSkew exn)
+          Nothing  -> return $ Intersects kis' lst
 
-    k :: Word64
-    k = maxRollbacks $ configSecurityParam cfg
+    -- Block until the the ledger state at the intersection with the local
+    -- selection returns 'Just'.
+    --
+    -- Exits early if the intersection no longer exists.
+    readLedgerState :: forall a. ()
+                    => KnownIntersectionState blk
+                    -> (LedgerState blk -> Maybe a)
+                    -> WithEarlyExit m (Intersects blk a)
+    readLedgerState kis prj = castM $ readLedgerStateHelper kis prj
+
+    readLedgerStateHelper :: forall a. ()
+                          => KnownIntersectionState blk
+                          -> (LedgerState blk -> Maybe a)
+                          -> m (WithEarlyExit m (Intersects blk a))
+    readLedgerStateHelper kis prj = atomically $ do
+        -- We must first find the most recent intersection with the current
+        -- chain. Note that this is cheap when the chain and candidate haven't
+        -- changed.
+        intersectsWithCurrentChain kis >>= \case
+          NoLongerIntersects      -> return exitEarly
+          StillIntersects () kis' -> do
+            let KnownIntersectionState { mostRecentIntersection } = kis'
+            lst <-
+              maybe
+                (error $
+                   "intersection not within last k blocks: " <> show mostRecentIntersection)
+                ledgerState
+                <$> getPastLedger mostRecentIntersection
+            case prj lst of
+              Nothing         -> retry
+              Just ledgerView -> return $ return $ Intersects kis' ledgerView
+
+    -- Returns 'Nothing' if the ledger state cannot forecast the ledger view
+    -- that far into the future.
+    projectLedgerView :: SlotNo
+                      -> LedgerState blk
+                      -> Maybe (LedgerView (BlockProtocol blk))
+    projectLedgerView slot lst =
+        let forecast = ledgerViewForecastAt (configLedger cfg) lst
+              -- TODO cache this in the KnownIntersectionState? Or even in the
+              -- LedgerDB?
+        in
+        case runExcept $ forecastFor forecast slot of
+          -- The header is too far ahead of the intersection point with our
+          -- current chain. We have to wait until our chain and the
+          -- intersection have advanced far enough. This will wait on
+          -- changes to the current chain via the call to
+          -- 'intersectsWithCurrentChain' before it.
+          Left OutsideForecastRange{} -> Nothing
+          Right ledgerView            -> Just ledgerView
+
+-- | Update the 'KnownIntersectionState' according to the header, if it's valid
+--
+-- Crucially: disconnects if it isn't.
+checkValid
+    :: forall m blk arrival judgment.
+       ( IOLike m
+       , LedgerSupportsProtocol blk
+       )
+    => ConfigEnv m blk
+    -> InternalEnv m blk arrival judgment
+    -> Header blk
+    -> Their (Tip blk)
+    -> KnownIntersectionState blk
+    -> LedgerView (BlockProtocol blk)
+    -> m (KnownIntersectionState blk)
+checkValid cfgEnv intEnv hdr theirTip kis ledgerView = do
+    let KnownIntersectionState {
+            ourFrag
+          , theirFrag
+          , theirHeaderStateHistory
+          , mostRecentIntersection
+          }      = kis
+        hdrPoint = headerPoint hdr
+
+    -- Validate header
+    theirHeaderStateHistory' <-
+      case runExcept $ validateHeader cfg ledgerView hdr theirHeaderStateHistory of
+        Right theirHeaderStateHistory' -> return theirHeaderStateHistory'
+        Left  vErr ->
+          disconnect $
+            HeaderError hdrPoint vErr (ourTipFromChain ourFrag) theirTip
+
+    let theirFrag' = theirFrag :> hdr
+        -- Advance the most recent intersection if we have the same
+        -- header on our fragment too. This is cheaper than recomputing
+        -- the intersection from scratch.
+        mostRecentIntersection'
+          | Just ourSuccessor <-
+              AF.successorBlock (castPoint mostRecentIntersection) ourFrag
+          , headerHash ourSuccessor == headerHash hdr
+          = headerPoint hdr
+          | otherwise
+          = mostRecentIntersection
+
+    pure $ assertKnownIntersectionInvariants (configConsensus cfg) $
+          KnownIntersectionState {
+              theirFrag               = theirFrag'
+            , theirHeaderStateHistory = theirHeaderStateHistory'
+            , ourFrag                 = ourFrag
+            , mostRecentIntersection  = mostRecentIntersection'
+            }
+  where
+    ConfigEnv {
+        cfg
+      } = cfgEnv
+
+    InternalEnv {
+        disconnect
+      } = intEnv
+
+{-------------------------------------------------------------------------------
+  Utilities used in the *top functions
+-------------------------------------------------------------------------------}
+
+data UpdatedIntersectionState blk a =
+    -- | The local selection has changed such 'ourFrag' no longer
+    -- intersects 'theirFrag'
+    --
+    -- (The intersection could also be lost because of messages they sent, but
+    -- that's handled elsewhere, not involving this data type.)
+    NoLongerIntersects
+  | StillIntersects a !(KnownIntersectionState blk)
+
+data Intersects blk a =
+    Intersects
+        (KnownIntersectionState blk)
+        a
+
+castEarlyExitIntersects
+  :: Monad m
+  => WithEarlyExit m (Intersects blk a)
+  -> m (UpdatedIntersectionState blk a)
+castEarlyExitIntersects =
+    fmap f . EarlyExit.withEarlyExit
+  where
+    f = \case
+        Nothing                 -> NoLongerIntersects
+        Just (Intersects kis a) -> StillIntersects a kis
+
+-- Recent offsets
+--
+-- These offsets are used to find an intersection point between our chain
+-- and the upstream node's. We use the fibonacci sequence to try blocks
+-- closer to our tip, and fewer blocks further down the chain. It is
+-- important that this sequence constains at least a point @k@ back: if no
+-- intersection can be found at most @k@ back, then this is not a peer
+-- that we can sync with (since we will never roll back more than @k).
+--
+-- For @k = 2160@, this evaluates to
+--
+-- > [0,1,2,3,5,8,13,21,34,55,89,144,233,377,610,987,1597,2160]
+--
+-- For @k = 5@ (during testing), this evaluates to
+--
+-- > [0,1,2,3,5]
+--
+-- In case the fragment contains less than @k@ blocks, we use the length
+-- of the fragment as @k@. This ensures that the oldest rollback point is
+-- selected.
+mkOffsets :: SecurityParam -> Word64 -> [Word64]
+mkOffsets (SecurityParam k) maxOffset =
+    [0] ++ takeWhile (< l) [fib n | n <- [2..]] ++ [l]
+  where
+    l = k `min` maxOffset
+
+ourTipFromChain
+    :: HasHeader (Header blk)
+    => AnchoredFragment (Header blk)
+    -> Our (Tip blk)
+ourTipFromChain = Our . AF.anchorToTip . AF.headAnchor
+
+-- If the two fragments `c1` and `c2` intersect, return the intersection
+-- point and join the prefix of `c1` before the intersection with the suffix
+-- of `c2` after the intersection. The resulting fragment has the same
+-- anchor as `c1` and the same head as `c2`.
+cross
+  :: HasHeader blk
+  => AnchoredFragment blk
+  -> AnchoredFragment blk
+  -> Maybe (Point blk, AnchoredFragment blk)
+cross c1 c2 = do
+    (p1, _p2, _s1, s2) <- AF.intersect c1 c2
+    -- Note that the head of `p1` and `_p2` is the intersection point, and
+    -- `_s1` and `s2` are anchored in the intersection point.
+    let crossed = case AF.join p1 s2 of
+          Just c  -> c
+          Nothing -> error "invariant violation of AF.intersect"
+    pure (AF.anchorPoint s2, crossed)
+
+-- A type-legos auxillary function used in 'readLedgerState'.
+castM :: forall m x. Monad m => m (WithEarlyExit m x) -> WithEarlyExit m x
+castM = join . EarlyExit.lift
 
 attemptRollback ::
      ( BlockSupportsProtocol blk
@@ -1078,6 +1334,10 @@ attemptRollback rollBackPoint (frag, state) = do
     frag'  <- AF.rollback (castPoint rollBackPoint) frag
     state' <- HeaderStateHistory.rewind rollBackPoint state
     return (frag', state')
+
+{-------------------------------------------------------------------------------
+   Looking for newly-recognized trap headers on the existing candidate
+-------------------------------------------------------------------------------}
 
 -- | Watch the invalid block checker function for changes (using its
 -- fingerprint). Whenever it changes, i.e., a new invalid block is detected,
@@ -1141,12 +1401,6 @@ invalidBlockRejector tracer version getIsInvalidBlock getCandidate =
                  reason
       traceWith tracer $ TraceException ex
       throwIO ex
-
--- | Auxiliary data type used as an intermediary result in 'rollForward'.
-data Intersects blk a =
-    Intersects
-        (KnownIntersectionState blk)
-        a
 
 {-------------------------------------------------------------------------------
   Explicit state
@@ -1300,48 +1554,6 @@ instance Eq ChainSyncClientException where
   InFutureHeaderExceedsClockSkew{} == _ = False
 
 instance Exception ChainSyncClientException
-
-{-------------------------------------------------------------------------------
-  TODO #221: Implement genesis
-
-  Genesis in paper:
-
-    When we compare a candidate to our own chain, and that candidate forks off
-    more than k in the past, we compute the intersection point between that
-    candidate and our chain, select s slots from both chains, and compare the
-    number of blocks within those s slots. If the candidate has more blocks
-    in those s slots, we prefer the candidate, otherwise we stick with our own
-    chain.
-
-  Genesis as we will implement it:
-
-    * We decide we are in genesis mode if the head of our chain is more than
-      @k@ blocks behind the blockchain time. We will have to approximate this
-      as @k/f@ /slots/ behind the blockchain time time.
-    * In this situation, we must make sure we have a sufficient number of
-      upstream nodes "and collect chains from all of them"
-    * We still never consider chains that would require /us/ to rollback more
-      than k blocks.
-    * In order to compare two candidates, we compute the intersection point of
-      X of those two candidates and compare the density at point X.
-
-
-
-
-  Scribbled notes during meeting with Duncan:
-
-   geensis mode: compare clock to our chain
-   do we have enough peers?
-   still only interested in chains that don't fork more than k from our own chain
-
-     downloading headers from a /single/ node, download at least s headers
-     inform /other/ peers: "here is a point on our chain"
-     if all agree ("intersection imporved") -- all peers agree
-     avoid downloading tons of headers
-     /if/ there is a difference, get s headers from the peer who disagrees,
-       pick the denser one, and ignore the other
-       PROBLEM: what if the denser node has invalid block bodies??
--------------------------------------------------------------------------------}
 
 {-------------------------------------------------------------------------------
   Trace events

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client/InFutureCheck.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client/InFutureCheck.hs
@@ -15,7 +15,7 @@ module Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck (
   ) where
 
 import           Control.Exception (Exception)
-import           Control.Monad (guard, unless)
+import           Control.Monad (guard, unless, when)
 import           Control.Monad.Class.MonadTimer.SI (MonadDelay, threadDelay)
 import           Control.Monad.Except (Except, liftEither)
 import           Data.Proxy (Proxy (Proxy))
@@ -137,8 +137,8 @@ realHeaderInFutureCheck skew systemTime =
             now <- systemTimeCurrent systemTime
             let ageNow         = now `diffRelTime` onset
                 syntheticDelay = negate ageNow
-            threadDelay $ nominalDelay syntheticDelay   -- TODO leap seconds?
-               -- recall that threadDelay ignores negative arguments
+            when (0 < syntheticDelay) $ do   -- note https://github.com/input-output-hk/io-sim/issues/129
+                threadDelay $ nominalDelay syntheticDelay   -- TODO leap seconds?
 
         pure $ do
             guard tooEarly   -- no exception if within skew

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -399,15 +399,22 @@ runChainSync skew securityParam (ClientUpdates clientUpdates)
                -> Consensus ChainSyncClientPipelined
                     TestBlock
                     m
-        client = chainSyncClient
-                   (pipelineDecisionLowHighMark 10 20)
-                   chainSyncTracer
-                   nodeCfg
-                   headerInFutureCheck
-                   chainDbView
-                   (maxBound :: NodeToNodeVersion)
-                   (return Continue)
-                   nullTracer
+        client varCandidate =
+            chainSyncClient
+              ConfigEnv {
+                  chainDbView
+                , cfg                     = nodeCfg
+                , tracer                  = chainSyncTracer
+                , someHeaderInFutureCheck = headerInFutureCheck
+                , mkPipelineDecision0     =
+                    pipelineDecisionLowHighMark 10 20
+                }
+              DynamicEnv {
+                  version             = maxBound :: NodeToNodeVersion
+                , controlMessageSTM   = return Continue
+                , headerMetricsTracer = nullTracer
+                , varCandidate
+                }
 
     -- Set up the server
     varChainProducerState <- uncheckedNewTVarM $ initChainProducerState Genesis

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -389,7 +389,7 @@ runChainSync skew securityParam (ClientUpdates clientUpdates)
               pure $ WithFingerprint isInvalidBlock fp
           }
 
-        headerInFutureCheck :: InFutureCheck.HeaderInFutureCheck m TestBlock
+        headerInFutureCheck :: InFutureCheck.SomeHeaderInFutureCheck m TestBlock
         headerInFutureCheck =
             InFutureCheck.realHeaderInFutureCheck skew clientSystemTime
             -- Note that this tests passes in the exact difference between the


### PR DESCRIPTION
While working on PR 808, I feel like the ChainSync client module needs some refactoring.

- It takes way too many arguments, so I've introduced data types that bundle those.
- It has way too many declarations in its `where`-clause, and with the new argument bundles, it's easier than ever before to float those out to their own top-level definitions.
- Moreover, some lines of logic in the message handlers can also be floated out as their own separate logic. This makes the definitions of the higher-level steps easier to read---eg, each one fits on a single "page" now.
- Finally: the whole module's styling is not internally consistent.