### PR TITLE
Updates to alternative LedgerDB API

### DIFF
--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V1.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V1.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE ConstraintKinds     #-}
 {-# LANGUAGE DeriveGeneric       #-}
 {-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE NumericUnderscores  #-}
 {-# LANGUAGE RankNTypes          #-}
@@ -88,6 +89,8 @@ module Ouroboros.Consensus.Storage.LedgerDB.V1 (
   , LedgerDBArgs (..)
   , QueryBatchSize (..)
   , defaultArgs
+    -- ** Constraints
+  , LedgerDbSerialiseConstraints
     -- * Exposed internals for testing purposes
   , TestInternals (..)
   , openDBInternal
@@ -100,11 +103,11 @@ import           Control.Monad.Class.MonadTime.SI
 import           Control.Tracer
 import           Data.Foldable
 import           Data.Functor.Contravariant
+import qualified Data.Map.Strict as Map
 import           Data.Set (Set)
 import qualified Data.Set as Set
 import           Data.Word
 import           GHC.Generics
-import           NoThunks.Class
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.HeaderStateHistory hiding (current)
@@ -115,7 +118,6 @@ import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Storage.ImmutableDB (ImmutableDB)
 import           Ouroboros.Consensus.Storage.ImmutableDB.Impl.Stream
 import           Ouroboros.Consensus.Storage.LedgerDB.API
-import qualified Ouroboros.Consensus.Storage.LedgerDB.API as API
 import           Ouroboros.Consensus.Storage.LedgerDB.BackingStore
 import           Ouroboros.Consensus.Storage.LedgerDB.DbChangelog hiding
                      (ExceededRollback, ResolveBlock)
@@ -190,31 +192,6 @@ defaultShouldFlush :: FlushFrequency -> (Word64 -> Bool)
 defaultShouldFlush requestedFlushFrequency = case requestedFlushFrequency of
       RequestedFlushFrequency value -> (>= value)
       DefaultFlushFrequency         -> (>= 100)
-
--- | The /maximum/ number of keys to read in a backing store range query.
---
--- When performing a ledger state query that involves on-disk parts of the
--- ledger state, we might have to read ranges of key-value pair data (e.g.,
--- UTxO) from disk using backing store range queries. Instead of reading all
--- data in one go, we read it in batches. 'QueryBatchSize' determines the size
--- of these batches.
---
--- INVARIANT: Should be at least 1.
---
--- It is fine if the result of a range read contains less than this number of
--- keys, but it should never return more.
-data QueryBatchSize =
-    -- | A default value, which is determined by a specific 'DiskPolicy'. See
-    -- 'defaultDiskPolicy' as an example.
-    DefaultQueryBatchSize
-    -- | A requested value: the number of keys to read from disk in each batch.
-  | RequestedQueryBatchSize Word64
-  deriving (Show, Eq, Generic)
-
-defaultQueryBatchSize :: QueryBatchSize -> Word64
-defaultQueryBatchSize requestedQueryBatchSize = case requestedQueryBatchSize of
-    RequestedQueryBatchSize value -> value
-    DefaultQueryBatchSize         -> 100_000
 
 {-------------------------------------------------------------------------------
   Opening a LedgerDB
@@ -306,17 +283,22 @@ openDBInternal args@LedgerDBArgs { lgrHasFS = SomeHasFS fs } bsTracer replayTrac
     (varDB, prevApplied) <-
       (,) <$> newTVarIO dbPrunedToImmDBTip <*> newTVarIO Set.empty
     flushLock <- mkLedgerDBLock
+    forkers <- newTVarIO Map.empty
+    nextForkerKey <- newTVarIO (ForkerKey 0)
     let env = LedgerDBEnv {
                  ldbChangelog      = varDB
                , ldbBackingStore   = lgrBackingStore
                , ldbLock           = flushLock
                , ldbPrevApplied    = prevApplied
+               , ldbForkers        = forkers
+               , ldbNextForkerKey  = nextForkerKey
+
                , ldbDiskPolicy     = lgrDiskPolicy
                , ldbTracer         = lgrTracer
                , ldbCfg            = lgrTopLevelConfig
                , ldbHasFS          = lgrHasFS
                , ldbShouldFlush    = defaultShouldFlush lgrFlushFrequency
-               , ldbQueryBatchSize = defaultQueryBatchSize lgrQueryBatchSize
+               , ldbQueryBatchSize = lgrQueryBatchSize
                , ldbResolveBlock   = getBlock
                , ldbSecParam       = configSecurityParam lgrTopLevelConfig
                , ldbBsTracer       = lgrBsTracer
@@ -361,42 +343,45 @@ mkLedgerDB ::
   => LedgerDBHandle m l blk
   -> LedgerDB m l blk
 mkLedgerDB h = LedgerDB {
-      getVolatileTip         = getEnvSTM  h getVolatileTip'
-    , getImmutableTip        = getEnvSTM  h getImmutableTip'
-    , getPastLedgerState     = getEnvSTM1 h getPastLedgerState'
-    , getHeaderStateHistory  = getEnvSTM  h getHeaderStateHistory'
-    , getForkerAtFromTip     = getEnv1 h getForkHandleAtFromTip'
-    , getForker              = getEnv2 h getForkHandle'
-    , getPrevApplied         = getEnvSTM  h getPrevApplied'
-    , addPrevApplied         = getEnvSTM1 h addPrevApplied'
-    , garbageCollect         = getEnvSTM1 h garbageCollect'
-    , getResolveBlock        = getEnvSTM h getResolveBlock'
-    , tryTakeSnapshot        = getEnv2 h tryTakeSnapshot'
-    , tryFlush               = getEnv h tryFlush'
+      getVolatileTip         = getEnvSTM  h implGetVolatileTip
+    , getImmutableTip        = getEnvSTM  h implGetImmutableTip
+    , getPastLedgerState     = getEnvSTM1 h implGetPastLedgerState
+    , getHeaderStateHistory  = getEnvSTM  h implGetHeaderStateHistory
+    , getForkerAtTip         = newForkerAtTip h
+    , getForkerAtPoint       = newForkerAtPoint h
+    , getForkerAtFromTip     = newForkerAtFromTip h
+    , getPrevApplied         = getEnvSTM  h implGetPrevApplied
+    , addPrevApplied         = getEnvSTM1 h implAddPrevApplied
+    , garbageCollect         = getEnvSTM1 h implGarbageCollect
+    , getResolveBlock        = getEnvSTM  h implGetResolveBlock
+    , getTopLevelConfig      = getEnvSTM  h implGetTopLevelConfig
+    , tryTakeSnapshot        = getEnv2    h implTryTakeSnapshot
+    , tryFlush               = getEnv     h implTryFlush
+    , closeDB                = implCloseDB h
     }
 
-getVolatileTip' ::
+implGetVolatileTip ::
      (MonadSTM m, GetTip l)
   => LedgerDBEnv m l blk
   -> STM m (l EmptyMK)
-getVolatileTip' = fmap (current . anchorlessChangelog) . readTVar . ldbChangelog
+implGetVolatileTip = fmap (current . anchorlessChangelog) . readTVar . ldbChangelog
 
-getImmutableTip' ::
+implGetImmutableTip ::
      MonadSTM m
   => LedgerDBEnv m l blk
   -> STM m (l EmptyMK)
-getImmutableTip' = fmap (anchor . anchorlessChangelog) . readTVar . ldbChangelog
+implGetImmutableTip = fmap (anchor . anchorlessChangelog) . readTVar . ldbChangelog
 
-getPastLedgerState' ::
+implGetPastLedgerState ::
      ( MonadSTM m , HasHeader blk, IsLedger l, StandardHash l
      , HasLedgerTables l, HeaderHash l ~ HeaderHash blk )
   => LedgerDBEnv m l blk -> Point blk -> STM m (Maybe (l EmptyMK))
-getPastLedgerState' env point = getPastLedgerAt point . anchorlessChangelog <$> readTVar (ldbChangelog env)
+implGetPastLedgerState env point = getPastLedgerAt point . anchorlessChangelog <$> readTVar (ldbChangelog env)
 
-getHeaderStateHistory' ::
+implGetHeaderStateHistory ::
      (MonadSTM m, l ~ ExtLedgerState blk)
   => LedgerDBEnv m l blk -> STM m (HeaderStateHistory blk)
-getHeaderStateHistory' env = toHeaderStateHistory . adcStates . anchorlessChangelog <$> readTVar (ldbChangelog env)
+implGetHeaderStateHistory env = toHeaderStateHistory . adcStates . anchorlessChangelog <$> readTVar (ldbChangelog env)
   where
     toHeaderStateHistory ::
          AnchoredSeq (WithOrigin SlotNo) (ExtLedgerState blk EmptyMK) (ExtLedgerState blk EmptyMK)
@@ -405,113 +390,35 @@ getHeaderStateHistory' env = toHeaderStateHistory . adcStates . anchorlessChange
           HeaderStateHistory
         . AS.bimap headerState headerState
 
--- | Given a point (or @Left ()@ for the tip), acquire both a value handle and a
--- db changelog at the requested point. Holds a read lock while doing so.
-getForkHandle' ::
-     forall m l blk a b. (
-       HeaderHash l ~ HeaderHash blk
-     , IOLike m
-     , IsLedger l
-     , StandardHash l
-     , HasLedgerTables l
-     , LedgerSupportsProtocol blk
-     )
-  => LedgerDBEnv m l blk
-  -> StaticEither b () (Point blk)
-  -> STM m a
-     -- ^ STM operation that we want to run in the same atomic block as the
-     -- acquisition of the LedgerDB
-  -> m ( a
-        , StaticEither b
-          (Forker m l blk)
-          (Either (Point blk) (Forker m l blk))
-        )
-getForkHandle' env pt stmAct =
-    withReadLock lock $ do
-    (a, ldb') <- atomically $ do
-      (,) <$> stmAct <*> (anchorlessChangelog <$> readTVar dbvar)
-    (a,) <$> case pt of
-      StaticLeft () -> StaticLeft <$> acquire ldb'
-      StaticRight actualPoint -> StaticRight <$>
-        case rollback actualPoint ldb' of
-          Nothing    -> pure $ Left $ castPoint $ getTip $ anchor ldb'
-          Just ldb'' -> Right <$> acquire ldb''
- where
-    dbvar = ldbChangelog env
-    lock = ldbLock env
-    bs = ldbBackingStore env
+implGetPrevApplied :: MonadSTM m => LedgerDBEnv m l blk -> STM m (Set (RealPoint blk))
+implGetPrevApplied env = readTVar (ldbPrevApplied env)
 
-    acquire ::
-         AnchorlessDbChangelog l
-      -> m (Forker m l blk)
-    acquire l = do
-      vh <- bsValueHandle bs
-      if bsvhAtSlot vh == adcLastFlushedSlot l
-        then newForker env vh l
-        else error ("Critical error: Value handles are created at "
-                    <> show (bsvhAtSlot vh)
-                    <> " while the db changelog is at "
-                    <> show (adcLastFlushedSlot l)
-                    <> ". There is either a race condition or a logic bug"
-                    )
-
--- | Like 'getForkhandle', buts at the tip.
-getForkHandleAtFromTip' ::
-     forall m l blk. (IOLike m, GetTip l, HasLedgerTables l, LedgerSupportsProtocol blk, NoThunks (l EmptyMK))
-  => LedgerDBEnv m l blk
-  -> Word64
-  -> m (Either ExceededRollback (Forker m l blk))
-getForkHandleAtFromTip' env n =
-    withReadLock (ldbLock env) $ do
-      clog <- atomically $ anchorlessChangelog <$> readTVar (ldbChangelog env)
-      case rollbackN n clog of
-        Nothing ->
-          return $ Left $ ExceededRollback {
-              API.rollbackMaximum   = maxRollback clog
-            , API.rollbackRequested = n
-            }
-        Just clog' -> Right <$> acquire clog'
-  where
-    acquire ::
-         AnchorlessDbChangelog l
-      -> m (Forker m l blk)
-    acquire l = do
-      vh <- bsValueHandle (ldbBackingStore env)
-      if bsvhAtSlot vh == adcLastFlushedSlot l
-        then newForker env vh l
-        else error ("Critical error: Value handles are created at "
-                    <> show (bsvhAtSlot vh)
-                    <> " while the db changelog is at "
-                    <> show (adcLastFlushedSlot l)
-                    <> ". There is either a race condition or a logic bug"
-                    )
-
-getPrevApplied' :: MonadSTM m => LedgerDBEnv m l blk -> STM m (Set (RealPoint blk))
-getPrevApplied' env = readTVar (ldbPrevApplied env)
-
-addPrevApplied' ::
+implAddPrevApplied ::
      forall m l blk. (MonadSTM m, StandardHash blk)
   => LedgerDBEnv m l blk -> [RealPoint blk] -> STM m ()
-addPrevApplied' env hs0 = modifyTVar (ldbPrevApplied env) (addPoints hs0)
+implAddPrevApplied env hs0 = modifyTVar (ldbPrevApplied env) (addPoints hs0)
   where
     addPoints :: [RealPoint blk] -> Set (RealPoint blk) -> Set (RealPoint blk)
     addPoints hs set = foldl' (flip Set.insert) set hs
 
 -- | Remove all points with a slot older than the given slot from the set of
 -- previously applied points.
-garbageCollect' :: MonadSTM m => LedgerDBEnv m l blk -> SlotNo -> STM m ()
-garbageCollect' env slotNo = modifyTVar (ldbPrevApplied env) $
+implGarbageCollect :: MonadSTM m => LedgerDBEnv m l blk -> SlotNo -> STM m ()
+implGarbageCollect env slotNo = modifyTVar (ldbPrevApplied env) $
     Set.dropWhileAntitone ((< slotNo) . realPointSlot)
 
-getResolveBlock' :: MonadSTM m => LedgerDBEnv m l blk -> STM m (ResolveBlock m blk)
-getResolveBlock' = pure . ldbResolveBlock
+implGetResolveBlock :: MonadSTM m => LedgerDBEnv m l blk -> STM m (ResolveBlock m blk)
+implGetResolveBlock = pure . ldbResolveBlock
 
-tryTakeSnapshot' ::
+implGetTopLevelConfig :: MonadSTM m => LedgerDBEnv m l blk -> STM m (TopLevelConfig blk)
+implGetTopLevelConfig = pure . ldbCfg
+
+implTryTakeSnapshot ::
      ( l ~ ExtLedgerState blk
      , IOLike m, LedgerDbSerialiseConstraints blk, LedgerSupportsProtocol blk
      )
   => LedgerDBEnv m l blk -> Maybe (Time, Time) -> Word64 -> m SnapCounters
-tryTakeSnapshot' env mTime nrBlocks =
+implTryTakeSnapshot env mTime nrBlocks =
     if onDiskShouldTakeSnapshot (ldbDiskPolicy env) (uncurry (flip diffTime) <$> mTime) nrBlocks then do
       void $ takeSnapshot
                 (ldbChangelog env)
@@ -528,14 +435,13 @@ tryTakeSnapshot' env mTime nrBlocks =
     else
       pure $ SnapCounters (fst <$> mTime) nrBlocks
 
---
 -- If the DbChangelog in the LedgerDB can flush (based on the DiskPolicy
 -- with which this LedgerDB was opened), flush differences to the backing
 -- store. Note this acquires a write lock on the backing store.
-tryFlush' ::
+implTryFlush ::
      (IOLike m, HasLedgerTables l, GetTip l)
   => LedgerDBEnv m l blk -> m ()
-tryFlush' env = do
+implTryFlush env = do
     ldb <- readTVarIO $ ldbChangelog env
     when (ldbShouldFlush env $ DbCh.flushableLength $ anchorlessChangelog ldb)
         (withWriteLock
@@ -543,3 +449,16 @@ tryFlush' env = do
           (flushLedgerDB (ldbChangelog env) (ldbBackingStore env))
         )
 
+implCloseDB :: MonadSTM m => LedgerDBHandle m l blk -> m ()
+implCloseDB (LDBHandle varState) = do
+    mbOpenEnv <- atomically $ readTVar varState >>= \case
+      -- Idempotent
+      LedgerDBClosed   -> return Nothing
+      LedgerDBOpen env -> do
+        writeTVar varState LedgerDBClosed
+        return $ Just env
+
+    -- Only when the LedgerDB was open
+    whenJust mbOpenEnv $ \env -> do
+      closeAllForkers env
+      bsClose (ldbBackingStore env)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V1/Snapshots.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V1/Snapshots.hs
@@ -132,13 +132,17 @@
 
 -}
 module Ouroboros.Consensus.Storage.LedgerDB.V1.Snapshots (
-    deleteSnapshot
+    decodeSnapshotBackwardsCompatible
+  , deleteSnapshot
   , diskSnapshotIsTemporary
+  , encodeSnapshot
   , listSnapshots
   , readSnapshot
+  , snapshotToStatePath
   , snapshotToTablesPath
   , takeSnapshot
   , trimSnapshots
+  , writeSnapshot
   ) where
 
 import           Codec.CBOR.Decoding


### PR DESCRIPTION
# Description

Follow-up to #510

This PR includes changes to the alternative LedgerDB API that are required for integration, which is happening in #815. These changes include:


* LedgerDB API changes:
   * The LedgerDB can now be closed
  * The LedgerDB API now exposes `getToplevelConfig`
  * Forker acquisition is refactored because we now have three variants instead of two, and we can't reuse `StaticEither`
  * Remove the STM function argument from forker acquisition
  * Forker acquisition now requires passing in a resource registry
  * Moved `QueryBatchSize` to the API level, because it's not implementation specific
  * Forkers now have a `forkerRangeReadTablesDefault` function that uses a `QueryBatchSize` that is configured for the whole LedgerDB.
  * `AnnLedgerError` now holds a `Forker`. 
   * Added a few helper functions
* V1 implementation:
  * Export more definitions from the `Snapshots` module
  * Refactored resource acquisition for backing store handles and db changelogs
  * Forkers are no longer implemented as separate handles, but stored directly in the `LedgerDBEnv`. This ensures better concurrency behaviour with respect to closing the LedgerDB and closing forkers. Note: forkers are now implemented similar to ChainDB followers.
  * Expose `LedgerDbSerialiseConstraints` 
  * Small renamings/refactorings