### PR TITLE
Ensure chain schemas have at least k+1 blocks after intersections

### DIFF
--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/GenChains.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/GenChains.hs
@@ -81,6 +81,7 @@ genAlternativeChainSchema (testRecipeH, arHonest) =
         A.NoSuchAdversarialBlock -> pure Nothing
         A.NoSuchCompetitor       -> error $ "impossible! " <> show e
         A.NoSuchIntersection     -> error $ "impossible! " <> show e
+        A.KcpIs1                 -> error $ "impossible! " <> show e
 
       Right (A.SomeCheckedAdversarialRecipe _ testRecipeA'') -> do
         let Count prefixCount = arPrefix

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/GenChains.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/GenChains.hs
@@ -66,7 +66,7 @@ genAlternativeChainSchema (testRecipeH, arHonest) =
     let H.HonestRecipe kcp scg delta _len = testRecipeH
 
     (seedPrefix :: QCGen) <- QC.arbitrary
-    let arPrefix = genPrefixBlockCount seedPrefix arHonest
+    let arPrefix = genPrefixBlockCount kcp seedPrefix arHonest
 
     let testRecipeA = A.AdversarialRecipe {
       A.arPrefix,

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/GenChains.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/GenChains.hs
@@ -86,7 +86,7 @@ genAlternativeChainSchema (testRecipeH, arHonest) =
       Right (A.SomeCheckedAdversarialRecipe _ testRecipeA'') -> do
         let Count prefixCount = arPrefix
         (seed :: QCGen) <- QC.arbitrary
-        let H.ChainSchema _ v = A.uniformAdversarialChain (Just alternativeAsc) testRecipeA'' seed
+        A.GrownChainSchema _ v <- pure $ A.uniformAdversarialChain (Just alternativeAsc) testRecipeA'' seed
         pure $ Just (prefixCount, Vector.toList (getVector v))
 
 -- | Random generator for a block tree. The block tree contains one trunk (the

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -71,43 +71,43 @@ prop_rollback wantRollback = do
   where
     schedulerConfig = noTimeoutsSchedulerConfig defaultPointScheduleConfig
 
-    -- A schedule that advertises all the points of the trunk up until the kth
-    -- block after the intersection, then switches to the first alternative
-    -- chain of the given block tree.
-    --
-    -- PRECONDITION: Block tree with at least one alternative chain.
-    rollbackSchedule :: Int -> BlockTree TestBlock -> PointSchedule
-    rollbackSchedule k blockTree =
-      let branch = head $ btBranches blockTree
-          trunk = btTrunk blockTree
-          prefixLen = AF.length $ btbPrefix branch
-          trunkPrefix = AF.takeOldest (k + prefixLen) trunk
-          branchSuffix = btbSuffix branch
-          states = banalStates trunkPrefix ++ banalStates branchSuffix
-          peers = peersOnlyHonest states
-          pointSchedule = balanced defaultPointScheduleConfig peers
-       in fromJust pointSchedule
+-- A schedule that advertises all the points of the trunk up until the kth
+-- block after the intersection, then switches to the first alternative
+-- chain of the given block tree.
+--
+-- PRECONDITION: Block tree with at least one alternative chain.
+rollbackSchedule :: Int -> BlockTree TestBlock -> PointSchedule
+rollbackSchedule k blockTree =
+  let branch = head $ btBranches blockTree
+      trunk = btTrunk blockTree
+      prefixLen = AF.length $ btbPrefix branch
+      trunkPrefix = AF.takeOldest (k + prefixLen) trunk
+      branchSuffix = btbSuffix branch
+      states = banalStates trunkPrefix ++ banalStates branchSuffix
+      peers = peersOnlyHonest states
+      pointSchedule = balanced defaultPointScheduleConfig peers
+   in fromJust pointSchedule
 
-    -- | Whether the honest chain has more than 'k' blocks after the
-    -- intersection with the alternative chain.
-    --
-    -- PRECONDITION: Block tree with exactly one alternative chain, otherwise
-    -- this property does not make sense. With no alternative chain, this will
-    -- even crash.
-    honestChainIsLongEnough :: SecurityParam -> BlockTree TestBlock -> Bool
-    honestChainIsLongEnough (SecurityParam k) blockTree =
-      let BlockTreeBranch{btbTrunkSuffix} = head $ btBranches blockTree
-          lengthTrunkSuffix = AF.length btbTrunkSuffix
-       in lengthTrunkSuffix > fromIntegral k
+-- | Whether the honest chain has more than 'k' blocks after the
+-- intersection with the alternative chain.
+--
+-- PRECONDITION: Block tree with exactly one alternative chain, otherwise
+-- this property does not make sense. With no alternative chain, this will
+-- even crash.
+honestChainIsLongEnough :: SecurityParam -> BlockTree TestBlock -> Bool
+honestChainIsLongEnough (SecurityParam k) blockTree =
+  let BlockTreeBranch{btbTrunkSuffix} = head $ btBranches blockTree
+      lengthTrunkSuffix = AF.length btbTrunkSuffix
+   in lengthTrunkSuffix > fromIntegral k
 
-    -- | Whether the alternative chain has more than 'k' blocks after the
-    -- intersection with the honest chain.
-    --
-    -- PRECONDITION: Block tree with exactly one alternative chain, otherwise
-    -- this property does not make sense. With no alternative chain, this will
-    -- even crash.
-    alternativeChainIsLongEnough :: SecurityParam -> BlockTree TestBlock -> Bool
-    alternativeChainIsLongEnough (SecurityParam k) blockTree =
-      let BlockTreeBranch{btbSuffix} = head $ btBranches blockTree
-          lengthSuffix = AF.length btbSuffix
-       in lengthSuffix > fromIntegral k
+-- | Whether the alternative chain has more than 'k' blocks after the
+-- intersection with the honest chain.
+--
+-- PRECONDITION: Block tree with exactly one alternative chain, otherwise
+-- this property does not make sense. With no alternative chain, this will
+-- even crash.
+alternativeChainIsLongEnough :: SecurityParam -> BlockTree TestBlock -> Bool
+alternativeChainIsLongEnough (SecurityParam k) blockTree =
+  let BlockTreeBranch{btbSuffix} = head $ btBranches blockTree
+      lengthSuffix = AF.length btbSuffix
+   in lengthSuffix > fromIntegral k

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -86,19 +86,20 @@ prop_cannotRollback = do
   where
     schedulerConfig = noTimeoutsSchedulerConfig defaultPointScheduleConfig
 
--- A schedule that advertises all the points of the trunk up until the kth
+-- | A schedule that advertises all the points of the trunk up until the nth
 -- block after the intersection, then switches to the first alternative
 -- chain of the given block tree.
 --
 -- PRECONDITION: Block tree with at least one alternative chain.
 rollbackSchedule :: Int -> BlockTree TestBlock -> PointSchedule
-rollbackSchedule k blockTree =
+rollbackSchedule n blockTree =
   let branch = head $ btBranches blockTree
-      trunk = btTrunk blockTree
-      prefixLen = AF.length $ btbPrefix branch
-      trunkPrefix = AF.takeOldest (k + prefixLen) trunk
-      branchSuffix = btbSuffix branch
-      states = banalStates trunkPrefix ++ banalStates branchSuffix
+      trunkSuffix = AF.takeOldest n (btbTrunkSuffix branch)
+      states = concat
+        [ banalStates (btbPrefix branch)
+        , banalStates trunkSuffix
+        , banalStates (btbSuffix branch)
+        ]
       peers = peersOnlyHonest states
       pointSchedule = balanced defaultPointScheduleConfig peers
    in fromJust pointSchedule

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -47,12 +47,17 @@ prop_rollback :: Bool -> QC.Gen QC.Property
 prop_rollback wantRollback = do
   genesisTest <- genChains 1
 
-  let schedule = rollbackSchedule (gtBlockTree genesisTest)
+  let SecurityParam k = gtSecurityParam genesisTest
+      schedule =
+        if wantRollback then rollbackSchedule (fromIntegral k) (gtBlockTree genesisTest)
+        else rollbackSchedule (fromIntegral (k + 1)) (gtBlockTree genesisTest)
 
   -- | We consider the test case interesting if we want a rollback and we can
   -- actually get one, or if we want no rollback and we cannot actually get one.
   pure $
-    wantRollback == canRollbackFromTrunkTip (gtSecurityParam genesisTest) (gtBlockTree genesisTest)
+    alternativeChainIsLongEnough (gtSecurityParam genesisTest) (gtBlockTree genesisTest)
+      &&
+    (wantRollback || honestChainIsLongEnough (gtSecurityParam genesisTest) (gtBlockTree genesisTest))
     ==>
       runSimOrThrow $ runTest schedulerConfig genesisTest schedule $ \StateView{svSelectedChain} ->
         let headOnAlternativeChain = case AF.headHash svSelectedChain of
@@ -66,33 +71,43 @@ prop_rollback wantRollback = do
   where
     schedulerConfig = noTimeoutsSchedulerConfig defaultPointScheduleConfig
 
-    -- A schedule that advertises all the points of the trunk, then switches to
-    -- the first alternative chain of the given block tree.
+    -- A schedule that advertises all the points of the trunk up until the kth
+    -- block after the intersection, then switches to the first alternative
+    -- chain of the given block tree.
     --
     -- PRECONDITION: Block tree with at least one alternative chain.
-    rollbackSchedule :: BlockTree TestBlock -> PointSchedule
-    rollbackSchedule blockTree =
-      let trunk = btTrunk blockTree
-          branch = btbSuffix $ head $ btBranches blockTree
-          states = banalStates trunk ++ banalStates branch
+    rollbackSchedule :: Int -> BlockTree TestBlock -> PointSchedule
+    rollbackSchedule k blockTree =
+      let branch = head $ btBranches blockTree
+          trunk = btTrunk blockTree
+          prefixLen = AF.length $ btbPrefix branch
+          trunkPrefix = AF.takeOldest (k + prefixLen) trunk
+          branchSuffix = btbSuffix branch
+          states = banalStates trunkPrefix ++ banalStates branchSuffix
           peers = peersOnlyHonest states
           pointSchedule = balanced defaultPointScheduleConfig peers
        in fromJust pointSchedule
 
-    -- | Whether it is possible to roll back from the trunk after having served
-    -- it fully, that is whether there is an alternative chain that forks of the
-    -- trunk no more than 'k' blocks from the tip and that is longer than the
-    -- trunk.
+    -- | Whether the honest chain has more than 'k' blocks after the
+    -- intersection with the alternative chain.
     --
     -- PRECONDITION: Block tree with exactly one alternative chain, otherwise
     -- this property does not make sense. With no alternative chain, this will
     -- even crash.
-    --
-    -- REVIEW: Why does 'existsSelectableAdversary' get to be a classifier and
-    -- not this? (or a generalised version of this)
-    canRollbackFromTrunkTip :: SecurityParam -> BlockTree TestBlock -> Bool
-    canRollbackFromTrunkTip (SecurityParam k) blockTree =
-      let BlockTreeBranch{btbSuffix, btbTrunkSuffix} = head $ btBranches blockTree
-          lengthSuffix = AF.length btbSuffix
+    honestChainIsLongEnough :: SecurityParam -> BlockTree TestBlock -> Bool
+    honestChainIsLongEnough (SecurityParam k) blockTree =
+      let BlockTreeBranch{btbTrunkSuffix} = head $ btBranches blockTree
           lengthTrunkSuffix = AF.length btbTrunkSuffix
-       in lengthTrunkSuffix <= fromIntegral k && lengthSuffix > lengthTrunkSuffix
+       in lengthTrunkSuffix > fromIntegral k
+
+    -- | Whether the alternative chain has more than 'k' blocks after the
+    -- intersection with the honest chain.
+    --
+    -- PRECONDITION: Block tree with exactly one alternative chain, otherwise
+    -- this property does not make sense. With no alternative chain, this will
+    -- even crash.
+    alternativeChainIsLongEnough :: SecurityParam -> BlockTree TestBlock -> Bool
+    alternativeChainIsLongEnough (SecurityParam k) blockTree =
+      let BlockTreeBranch{btbSuffix} = head $ btBranches blockTree
+          lengthSuffix = AF.length btbSuffix
+       in lengthSuffix > fromIntegral k

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Adversarial.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Adversarial.hs
@@ -355,6 +355,12 @@ data NoSuchAdversarialChainSchema =
   |
     -- | @not (0 <= 'arPrefix' <= C)@ where @C@ is the number of active slots in 'arHonest'
     NoSuchIntersection
+  |
+    -- | @k=1@
+    --
+    -- This may technically be viable, but our current specification for
+    -- 'uniformAdversarialChain' requires @k>1@.
+    KcpIs1
   deriving (Eq, Show)
 
 -----
@@ -377,6 +383,8 @@ checkAdversarialRecipe ::
          (SomeCheckedAdversarialRecipe base hon)
 checkAdversarialRecipe recipe = do
     when (0 == k) $ Exn.throwError NoSuchAdversarialBlock
+
+    when (1 == k) $ Exn.throwError KcpIs1
 
     -- validate 'arPrefix'
     firstAdvSlot <- case compare arPrefix 0 of

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Adversarial.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Adversarial.hs
@@ -253,8 +253,10 @@ checkAdversarialChain recipe adv = do
                                          --
                                          -- TODO hpc shows this never executes
     checkDensity :: Exn.Except (AdversarialViolation hon adv) ()
-    checkDensity =
-        when (C.Count s <= C.windowSize winA) $ do
+    checkDensity = do
+        let honestSuffixSize = C.getCount (C.windowLast winH) - C.getCount (C.windowStart winA) + 1
+
+        when (C.Count s <= C.windowSize winA && s <= honestSuffixSize) $ do
             let -- first stability window after the intersection in the honest
                 -- schema
                 hScgWin = C.UnsafeContains (C.Count $ C.getCount $ C.windowStart winA) (C.Count s)

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Adversarial.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Adversarial.hs
@@ -14,7 +14,7 @@ module Test.Ouroboros.Consensus.ChainGenerator.Adversarial (
     -- * Generating
     AdversarialRecipe (AdversarialRecipe, arHonest, arParams, arPrefix)
   , CheckedAdversarialRecipe (UnsafeCheckedAdversarialRecipe, carHonest, carParams, carWin)
-  , NoSuchAdversarialChainSchema (NoSuchAdversarialBlock, NoSuchCompetitor, NoSuchIntersection)
+  , NoSuchAdversarialChainSchema (NoSuchAdversarialBlock, NoSuchCompetitor, NoSuchIntersection, KcpIs1)
   , SomeCheckedAdversarialRecipe (SomeCheckedAdversarialRecipe)
   , checkAdversarialRecipe
   , uniformAdversarialChain

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Counting.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Counting.hs
@@ -52,6 +52,7 @@ module Test.Ouroboros.Consensus.ChainGenerator.Counting (
   , createV
   , getMVector
   , getVector
+  , growMV
   , lengthMV
   , lengthV
   , modifyMV
@@ -360,6 +361,9 @@ modifyMV (MVector mv) f (Count i)   = MV.modify mv f i
 
 readV :: MV.Unbox a => Vector base elem a -> Index base elem -> a
 readV (Vector v) (Count i) = v V.! i
+
+growMV :: MV.Unbox a => MVector base elem s a -> Size base elem -> ST s (MVector base elem s a)
+growMV (MVector mv) (Count n) = fmap MVector $ MV.grow mv n
 
 -----
 

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Counting.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Counting.hs
@@ -61,6 +61,7 @@ module Test.Ouroboros.Consensus.ChainGenerator.Counting (
   , replicateMV
   , sliceMV
   , sliceV
+  , unsafeFreezeMV
   , unsafeThawV
   , writeMV
     -- * variables
@@ -323,6 +324,9 @@ sliceV win (Vector v) =
 
 unsafeThawV :: MV.Unbox a => Vector base elem a -> ST s (MVector base elem s a)
 unsafeThawV (Vector v) = MVector <$> V.unsafeThaw v
+
+unsafeFreezeMV :: MV.Unbox a => MVector base elem s a -> ST s (Vector base elem a)
+unsafeFreezeMV (MVector v) = Vector <$> V.unsafeFreeze v
 
 createV :: MV.Unbox a => (forall s. ST s (MVector base elem s a)) -> Vector base elem a
 createV m = Vector $ V.create (getMVector <$> m)

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Honest.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Honest.hs
@@ -106,10 +106,10 @@ genHonestRecipe :: QC.Gen HonestRecipe
 genHonestRecipe = sized1 $ \sz -> do
     (Kcp k, Scg s, Delta d) <- genKSD
     -- Ensure that there are k + 1 slots in the chain:
-    -- 2s has 2k blocks, but if the windows overlap as in 2s-k, then
-    -- only k blocks might be present.
-    -- Therefore we enlarge the schema by one slot to get the size 2s-k+1
-    l <- (+ (2*s - k + 1)) <$> QC.choose (0, 5 * sz)
+    -- 2s slots has at least 2k blocks. But that is ensuring k-1 more blocks
+    -- than we actually need. Thus it's safe to remove the k-1 last slots.
+    -- Therefore we set for a length of at least 2s - (k - 1).
+    l <- (+ (2*s - (k - 1))) <$> QC.choose (0, 5 * sz)
     pure $ HonestRecipe (Kcp k) (Scg s) (Delta d) (Len l)
 
 -- | Checks whether the given 'HonestRecipe' determines a valid input to

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Honest.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Honest.hs
@@ -104,10 +104,13 @@ data NoSuchHonestChainSchema =
 
 genHonestRecipe :: QC.Gen HonestRecipe
 genHonestRecipe = sized1 $ \sz -> do
-  (kcp, Scg s, delta) <- genKSD
-  -- s <= l, most of the time
-  l <- QC.frequency [(9, (+ s) <$> QC.choose (0, 5 * sz)), (1, QC.choose (1, s))]
-  pure $ HonestRecipe kcp (Scg s) delta (Len l)
+    (Kcp k, Scg s, Delta d) <- genKSD
+    -- Ensure that there are k + 1 slots in the chain:
+    -- 2s has 2k blocks, but if the windows overlap as in 2s-k, then
+    -- only k blocks might be present.
+    -- Therefore we enlarge the schema by one slot to get the size 2s-k+1
+    l <- (+ (2*s - k + 1)) <$> QC.choose (0, 5 * sz)
+    pure $ HonestRecipe (Kcp k) (Scg s) (Delta d) (Len l)
 
 -- | Checks whether the given 'HonestRecipe' determines a valid input to
 -- 'uniformTheHonestChain'

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Params.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Params.hs
@@ -98,6 +98,8 @@ genAsc = ascFromBits <$> QC.choose (1 :: Word8, maxBound - 1)
 
 genKSD :: QC.Gen (Kcp, Scg, Delta)
 genKSD = sized1 $ \sz -> do
+    -- k > 1 so we can ensure an alternative schema loses the density comparison
+    -- without having to deactivate the first active slot
     k <- (+ 2) <$> QC.choose (0, 2 * sz)
     s <- (+ k) <$> QC.choose (0, 3 * sz)   -- ensures @k / s <= 1@
     d <- QC.choose (0, max 0 $ min (div sz 4) (s-1)) -- ensures @d < s@

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Params.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Params.hs
@@ -98,7 +98,7 @@ genAsc = ascFromBits <$> QC.choose (1 :: Word8, maxBound - 1)
 
 genKSD :: QC.Gen (Kcp, Scg, Delta)
 genKSD = sized1 $ \sz -> do
-    d <- QC.choose (0, div sz 4)
     k <- (+ 2) <$> QC.choose (0, 2 * sz)
     s <- (+ k) <$> QC.choose (0, 3 * sz)   -- ensures @k / s <= 1@
+    d <- QC.choose (0, max 0 $ min (div sz 4) (s-1)) -- ensures @d < s@
     pure (Kcp k, Scg s, Delta d)

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/Adversarial.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/Adversarial.hs
@@ -128,6 +128,7 @@ instance QC.Arbitrary SomeTestAdversarial where
                 A.NoSuchAdversarialBlock -> pure Nothing
                 A.NoSuchCompetitor       -> error $ "impossible! " <> show e
                 A.NoSuchIntersection     -> error $ "impossible! " <> show e
+                A.KcpIs1                 -> error $ "impossible! " <> show e
 
             Right testRecipeA' -> do
                 pure $ Just $ SomeTestAdversarial Proxy Proxy $ TestAdversarial {
@@ -365,6 +366,7 @@ instance QC.Arbitrary SomeTestAdversarialMutation where
                     A.NoSuchAdversarialBlock -> Nothing
                     A.NoSuchCompetitor       -> error $ "impossible! " <> show e
                     A.NoSuchIntersection     -> error $ "impossible! " <> show e
+                    A.KcpIs1                 -> error $ "impossible! " <> show e
 
                 Right recipeA' -> case Exn.runExcept $ A.checkAdversarialRecipe $ mutateAdversarial recipeA mut of
                     Left{} -> Nothing

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/Adversarial.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/Adversarial.hs
@@ -25,15 +25,14 @@ import qualified Test.Ouroboros.Consensus.ChainGenerator.BitVector as BV
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Counting as C
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Honest as H
 import           Test.Ouroboros.Consensus.ChainGenerator.Params (Asc,
-                     Delta (Delta), Kcp (Kcp), Len (Len), Scg (Scg), genAsc,
-                     genKSD)
+                     Delta (Delta), Kcp (Kcp), Len (Len), Scg (Scg), genAsc)
 import qualified Test.Ouroboros.Consensus.ChainGenerator.RaceIterator as RI
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Slot as S
 import           Test.Ouroboros.Consensus.ChainGenerator.Slot (E (SlotE))
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Some as Some
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Tests.Honest as H
 import qualified Test.QuickCheck as QC hiding (elements)
-import           Test.QuickCheck.Extras (sized1, unsafeMapSuchThatJust)
+import           Test.QuickCheck.Extras (unsafeMapSuchThatJust)
 import           Test.QuickCheck.Random (QCGen)
 import qualified Test.Tasty as TT
 import qualified Test.Tasty.QuickCheck as TT
@@ -337,14 +336,7 @@ instance QC.Arbitrary SomeTestAdversarialMutation where
     arbitrary = do
         mut <- QC.elements [minBound .. maxBound :: AdversarialMutation]
         unsafeMapSuchThatJust $ do
-            (kcp, scg, delta, len) <- sized1 $ \sz -> do
-                (kcp, Scg s, delta) <- genKSD
-
-                l <- (+ s) <$> QC.choose (0, 5 * sz)
-
-                pure (kcp, Scg s, delta, Len l)
-
-            let recipeH = H.HonestRecipe kcp scg delta len
+            recipeH@(H.HonestRecipe kcp scg delta len) <- H.genHonestRecipe
 
             someTestRecipeH' <- case Exn.runExcept $ H.checkHonestRecipe recipeH of
                 Left e  -> error $ "impossible! " <> show (recipeH, e)

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/Adversarial.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/Adversarial.hs
@@ -176,12 +176,12 @@ prop_kPlus1BlocksAfterIntersection someTestAdversarial testSeedA = runIdentity $
       $ QC.counterexample ("arPrefix = " <> show (A.arPrefix testRecipeA))
       $ QC.counterexample ("stabWin  = " <> show stabWin)
       $ QC.counterexample ("stabWin' = " <> show (C.joinWin winA stabWin))
-      $ QC.counterexample ("The honest chain has k+1 blocks after the intersection")
+      $ QC.counterexample ("The honest chain should have k+1 blocks after the intersection")
           (BV.countActivesInV S.notInverted vH
             `QC.ge` C.toSize (C.Count (k + 1) + A.arPrefix testRecipeA)
           )
         QC..&&.
-        QC.counterexample ("The alternative chain has k+1 blocks after the intersection")
+        QC.counterexample ("The alternative chain should have k+1 blocks after the intersection")
           (BV.countActivesInV S.notInverted vA `QC.ge` C.Count (k + 1))
 
 

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/Adversarial.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/Adversarial.hs
@@ -44,9 +44,9 @@ tests :: [TT.TestTree]
 tests = [
     TT.testProperty "k+1 blocks after the intersection" prop_kPlus1BlocksAfterIntersection
   ,
-    TT.testProperty "prop_adversarialChain" prop_adversarialChain
+    TT.testProperty "Adversarial chains lose density and race comparisons" prop_adversarialChain
   ,
-    TT.localOption (TT.QuickCheckMaxSize 14) $ TT.testProperty "prop_adversarialChainMutation" prop_adversarialChainMutation
+    TT.localOption (TT.QuickCheckMaxSize 14) $ TT.testProperty "Adversarial chains win if checked with relaxed parameters" prop_adversarialChainMutation
   ]
 
 -----

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/Adversarial.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/Adversarial.hs
@@ -109,9 +109,9 @@ instance QC.Arbitrary SomeTestAdversarial where
 
         testSeedPrefix <- QC.arbitrary @QCGen
 
-        let arPrefix = genPrefixBlockCount testSeedPrefix arHonest
+        let arPrefix = genPrefixBlockCount kcp testSeedPrefix arHonest
 
-        let H.HonestRecipe kcp scg delta _len = testRecipeH
+            H.HonestRecipe kcp scg delta _len = testRecipeH
 
             testRecipeA = A.AdversarialRecipe {
                 A.arPrefix
@@ -350,7 +350,7 @@ instance QC.Arbitrary SomeTestAdversarialMutation where
 
             testSeedPrefix <- QC.arbitrary @QCGen
 
-            let arPrefix = genPrefixBlockCount testSeedPrefix arHonest
+            let arPrefix = genPrefixBlockCount kcp testSeedPrefix arHonest
 
             let recipeA = A.AdversarialRecipe {
                     A.arPrefix


### PR DESCRIPTION
This is an alternative approach to #477, that we hope require less interactions with the rest of the generation. The PR includes some refactoring commits from there.

The honest schemas get k+1 slots by choosing a minimum slot count for them (2*s-k+1).

The alternative schemas are grown with additional slots if they need more active slots.

Design notes from a call with @nfrisby:

* Initialize the honest schema to be length max Len (2 * Scg - k + 1).
* Refine the choice of the intersection X to ensure there are at least Kcp+1 honest elections after X.
* Generate the alternative chain as usual.
* Add a new post-processing step:
* Let missingBlocks = max 0 $ k+1 - the number of alternative elections. If it's 0, stop: no post-processing is needed.
* Identify the youngest stable slot. Call the slots after it unstable.
* Append as many inactive slots as necessary to include the youngest stable slot in the schema.
* Let missingSlots = max 0 $ missingBlocks - the number of inactive unstable slots.
* Append missingSlots inactive slots to the end of the alternative schema. POSTCONDITION: there are at least missingBlocks inactive unstable slots.
* Toggle missingBlocks randomly-chosen inactive unstable slots.