### PR TITLE
Re-enable completeness warnings in GHC>=9.6

### DIFF
--- a/ouroboros-consensus-cardano/changelog.d/20231212_174729_fraser.murray_warning_cpp_conditional.md
+++ b/ouroboros-consensus-cardano/changelog.d/20231212_174729_fraser.murray_warning_cpp_conditional.md
@@ -1,0 +1,22 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->
+### Non-Breaking
+
+- Re-enable completeness warnings in Ouroboros.Consensus.Cardano.Node only on GHC>=9.6
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Node.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Node.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                      #-}
 {-# LANGUAGE DataKinds                #-}
 {-# LANGUAGE FlexibleContexts         #-}
 {-# LANGUAGE FlexibleInstances        #-}
@@ -12,11 +13,16 @@
 {-# LANGUAGE TypeApplications         #-}
 {-# LANGUAGE TypeFamilies             #-}
 {-# LANGUAGE TypeOperators            #-}
-{-# OPTIONS_GHC -Wno-orphans
-                -Wno-incomplete-patterns
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+-- Disable completeness checks on GHC versions pre-9.6, where this can be
+-- exceptionally slow:
+#if __GLASGOW_HASKELL__ <= 906
+{-# OPTIONS_GHC -Wno-incomplete-patterns
                 -Wno-incomplete-uni-patterns
                 -Wno-incomplete-record-updates
                 -Wno-overlapping-patterns #-}
+#endif
 
 -- TODO: this is required for ghc-8.10.7, because using NamedFieldPuns and
 -- PatternSynonyms with record syntax results in warnings related to shadowing.


### PR DESCRIPTION
Partially fixes #592 

- `Re-enable completeness warnings in Ouroboros.Consensus.Cardano.Node only on GHC>=9.6`

# Description

This change adds back the disabled warnings provided by the completeness checker which were turned off due to the impact they had on compile times (https://github.com/input-output-hk/ouroboros-network/commit/3a6cd9760c32dd53ebf567d6a83feab633cebfe4). In future, once we no longer support GHC 8.10.x, we should remove the flag entirely and close the associated ticket.